### PR TITLE
fixed wrong assert in CCRenderTexture

### DIFF
--- a/cocos2d/CCRenderTexture.h
+++ b/cocos2d/CCRenderTexture.h
@@ -56,6 +56,10 @@ enum
 	GLint				oldFBO_;
 	CCTexture2D*		texture_;
 	CCSprite*			sprite_;
+	
+	GLenum				pixelFormat_;
+	GLfloat				clearColor_[4];
+
 }
 
 /** The CCSprite being used.
@@ -65,11 +69,19 @@ enum
 */
 @property (nonatomic,readwrite, assign) CCSprite* sprite;
 
-/** creates a RenderTexture object with width and height in Points */
-+(id)renderTextureWithWidth:(int)width height:(int)height;
-/** initializes a RenderTexture object with width and height in Points */
--(id)initWithWidth:(int)width height:(int)height;
+/** creates a RenderTexture object with width and height in Points and a pixel format, only RGB and RGBA formats are valid */
++(id)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexture2DPixelFormat) format;
+
+/** creates a RenderTexture object with width and height in Points, pixel format is RGBA8888 */
++(id)renderTextureWithWidth:(int)w height:(int)h;
+
+
+/** initializes a RenderTexture object with width and height in Points and a pixel format, only RGB and RGBA formats are valid */
+-(id)initWithWidth:(int)w height:(int)h pixelFormat:(CCTexture2DPixelFormat) format;
 -(void)begin;
+
+/** starts rendering to the texture while clearing the texture first. This is more efficient then calling -clear first and then -begin */
+-(void)beginWithClear:(float)r g:(float)g b:(float)b a:(float)a;
 -(void)end;
 
 /** clears the texture with a color */
@@ -81,8 +93,8 @@ enum
 -(BOOL)saveBuffer:(NSString*)name;
 /** saves the texture into a file. The format can be JPG or PNG */
 -(BOOL)saveBuffer:(NSString*)name format:(int)format;
-/* get buffer as UIImage */
--(UIImage *)getUIImageFromBuffer;
+/* get buffer as UIImage, can only save a render buffer which has a RGBA8888 pixel format */
+-(NSData*)getUIImageAsDataFromBuffer:(int) format;
 #endif
 
 @end

--- a/cocos2d/CCRenderTexture.h
+++ b/cocos2d/CCRenderTexture.h
@@ -36,7 +36,8 @@
 enum  
 {
 	kCCImageFormatJPG = 0,
-	kCCImageFormatPNG = 1
+	kCCImageFormatPNG = 1,
+	kCCImageFormatRawData =2
 };
 
 

--- a/cocos2d/CCRenderTexture.m
+++ b/cocos2d/CCRenderTexture.m
@@ -237,7 +237,6 @@
 	
 	GLubyte *buffer	= malloc(sizeof(GLubyte)*myDataLength);
 	GLubyte *pixels	= malloc(sizeof(GLubyte)*myDataLength);
-	//GLubyte *buffer = (GLubyte *) malloc(myDataLength);
 	
 	if( ! (buffer && pixels) ) {
 		CCLOG(@"cocos2d: CCRenderTexture#getUIImageFromBuffer: not enough memory");

--- a/cocos2d/CCRenderTexture.m
+++ b/cocos2d/CCRenderTexture.m
@@ -39,7 +39,7 @@
 
 @synthesize sprite=sprite_;
 
-// issue # 
+// issue #994 
 +(id)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexture2DPixelFormat) format
 {
 	return [[[self alloc] initWithWidth:w height:h pixelFormat:format] autorelease];
@@ -100,12 +100,11 @@
 		[self addChild:sprite_];
 
 		// issue #937
-		
 		[sprite_ setBlendFunc:(ccBlendFunc){GL_ONE, GL_ONE_MINUS_SRC_ALPHA}];
 		
-		// issue #878 save opengl state
-		[self saveGLstate];
+			
 		
+				
 
 		ccglBindFramebuffer(CC_GL_FRAMEBUFFER, oldFBO_);
 	}
@@ -122,7 +121,9 @@
 
 -(void)begin
 {
-	
+	// issue #878 save opengl state
+	[self saveGLstate];
+
 	CC_DISABLE_DEFAULT_GL_STATES();
 	// Save the current matrix
 	glPushMatrix();
@@ -147,6 +148,9 @@
 
 -(void)beginWithClear:(float)r g:(float)g b:(float)b a:(float)a
 {
+	// issue #878 save opengl state
+	[self saveGLstate];
+	
 	CC_DISABLE_DEFAULT_GL_STATES();
 	// Save the current matrix
 	glPushMatrix();
@@ -228,7 +232,7 @@
 -(NSData*)getUIImageAsDataFromBuffer:(int) format
 {
 	
-	NSAssert(format != kCCTexture2DPixelFormat_RGBA8888,@"only RGBA8888 can be saved as image");
+	NSAssert(format == kCCTexture2DPixelFormat_RGBA8888,@"only RGBA8888 can be saved as image");
 	
 	CGSize s = [texture_ contentSizeInPixels];
 	int tx = s.width;

--- a/cocos2d/Platforms/iOS/EAGLView.m
+++ b/cocos2d/Platforms/iOS/EAGLView.m
@@ -244,12 +244,12 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 			if (depthFormat_)
 			{
 				GLenum attachments[] = {GL_COLOR_ATTACHMENT0_OES, GL_DEPTH_ATTACHMENT_OES};
-				glDiscardFramebufferEXT(GL_FRAMEBUFFER_OES, 2, attachments);
+				glDiscardFramebufferEXT(GL_READ_FRAMEBUFFER_APPLE, 2, attachments);
 			}
 			else
 			{
 				GLenum attachments[] = {GL_COLOR_ATTACHMENT0_OES};
-				glDiscardFramebufferEXT(GL_FRAMEBUFFER_OES, 1, attachments);
+				glDiscardFramebufferEXT(GL_READ_FRAMEBUFFER_APPLE, 1, attachments);
 			}
 			
 			glBindRenderbufferOES(GL_RENDERBUFFER_OES, [renderer_ colorRenderBuffer]);


### PR DESCRIPTION
Wrong assert addressed as well as saving the clear color every time the rendering begins, instead of a one time save during initialization. 
