### PR TITLE
New particle system type, relative positioning

### DIFF
--- a/cocos2d/CCParticleSystem.h
+++ b/cocos2d/CCParticleSystem.h
@@ -65,6 +65,8 @@ enum {
 typedef enum {
 	/** If the emitter is repositioned, the living particles won't be repositioned */
 	kCCPositionTypeFree,
+	/** If the emitter is repositioned, the living particles are positioned according to their node's position */
+	kCCPositionTypeRelative,
 	/** If the emitter is repositioned, the living particles will be repositioned too */
 	kCCPositionTypeGrouped,
 }tCCPositionType;

--- a/cocos2d/CCParticleSystem.m
+++ b/cocos2d/CCParticleSystem.m
@@ -384,6 +384,9 @@
 		CGPoint p = [self convertToWorldSpace:CGPointZero];
 		particle->startPos = ccp( p.x * CC_CONTENT_SCALE_FACTOR(), p.y * CC_CONTENT_SCALE_FACTOR() );
 	}
+	else if( positionType_ == kCCPositionTypeRelative ) {
+		particle->startPos = ccp( self.position.x * CC_CONTENT_SCALE_FACTOR(), self.position.y * CC_CONTENT_SCALE_FACTOR() );
+	}
 	
 	// direction
 	float a = CC_DEGREES_TO_RADIANS( angle + angleVar * CCRANDOM_MINUS1_1() );	
@@ -484,6 +487,11 @@
 		currentPosition.x *= CC_CONTENT_SCALE_FACTOR();
 		currentPosition.y *= CC_CONTENT_SCALE_FACTOR();
 	}
+	else if( positionType_ == kCCPositionTypeRelative ) {
+		currentPosition = self.position;
+		currentPosition.x *= CC_CONTENT_SCALE_FACTOR();
+		currentPosition.y *= CC_CONTENT_SCALE_FACTOR();
+	}
 	
 	while( particleIdx < particleCount )
 	{
@@ -548,7 +556,7 @@
 			
 			CGPoint	newPos;
 			
-			if( positionType_ == kCCPositionTypeFree ) {
+			if( positionType_ == kCCPositionTypeFree || positionType_ == kCCPositionTypeRelative ) {
 				CGPoint diff = ccpSub( currentPosition, p->startPos );
 				newPos = ccpSub(p->pos, diff);
 				


### PR DESCRIPTION
http://www.cocos2d-iphone.org/forum/topic/10622

I use this quite often..  I use this for 'trails' of particles...

You can't use kCCPositionTypeFree for 'trails' or particles if the particle system is attached to a node that moves..  kCCPositionTypeFree always converts it's position to world coordinates..   My game is a side scroller which scrolls a layer..  My particle system is always added as a node on that layer, so in order to get particle trails to work properly I always have to use this type of system.
