### PR TITLE
Reorder sprite

### DIFF
--- a/cocos2d/CCDirector.h
+++ b/cocos2d/CCDirector.h
@@ -134,6 +134,8 @@ and when to execute the Scenes.
 
 	/* the cocos2d running thread */
 	NSThread	*runningThread_;
+	
+	int mutatedChildren_;
 
 	// profiler
 #if CC_ENABLE_PROFILERS
@@ -300,5 +302,9 @@ and when to execute the Scenes.
 
 // Profiler
 -(void) showProfilers;
+
+//used for sorting children array
+-(int) getMutatedIndex;
+-(void) resetMutatedChildren;
 
 @end

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -542,6 +542,16 @@ static CCDirector *_sharedDirector = nil;
 }
 #endif
 
+-(int) getMutatedIndex
+{
+	return ++mutatedChildren_;	
+}
+
+- (void) resetMutatedChildren
+{
+	mutatedChildren_=0;	
+}
+
 - (void) showProfilers {
 #if CC_ENABLE_PROFILERS
 	accumDtForProfiler_ += dt;

--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -154,6 +154,9 @@ enum {
 
 	// Is running
 	BOOL isRunning_;
+	
+	//used to preserve sequence while sorting children with the same zOrder
+	int mutatedIndex_;
 
 	// To reduce memory, place BOOLs that are not properties here:
 	BOOL isTransformDirty_:1;
@@ -236,6 +239,9 @@ enum {
 @property(nonatomic,readwrite,assign) NSInteger tag;
 /** A custom user data pointer */
 @property(nonatomic,readwrite,assign) void *userData;
+
+/** used internally for zOrder sorting, don't change this manually */
+@property(nonatomic,readwrite) int mutatedIndex;
 
 // initializators
 /** allocates and initializes a node.

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -69,6 +69,7 @@
 @synthesize vertexZ = vertexZ_;
 @synthesize isRunning=isRunning_;
 @synthesize userData=userData_;
+@synthesize mutatedIndex=mutatedIndex_;
 
 #pragma mark CCNode - Transform related properties
 
@@ -268,6 +269,8 @@
 
 		//initialize parent to nil
 		parent_ = nil;
+		
+		mutatedIndex_=0;
 	}
 	
 	return self;
@@ -365,6 +368,9 @@
 	child.tag = aTag;
 	
 	[child setParent: self];
+	
+	//CCDirector.sharedDirector->getMutatedIndex
+	[child setMutatedIndex:[[CCDirector sharedDirector] getMutatedIndex]];
 	
 	if( isRunning_ ) {
 		[child onEnter];
@@ -476,6 +482,7 @@
 	NSAssert( child != nil, @"Child must be non-nil");
 	
 	isReorderChildDirty_=YES;
+	[child setMutatedIndex:[[CCDirector sharedDirector] getMutatedIndex]];
 	[child _setZOrder:z];
 }
 
@@ -493,7 +500,7 @@
 			tempItem = x[i];
 			j = i-1;
 			
-			while(j>=0 && ((CCNode*) tempItem).zOrder<((CCNode*)x[j]).zOrder)
+			while(j>=0 && ( ((CCNode*) tempItem).zOrder<((CCNode*)x[j]).zOrder || ( ((CCNode*) tempItem).mutatedIndex < ((CCNode*)x[j]).mutatedIndex ) ) ) 
 			{
 				x[j+1] = x[j];
 				j = j-1;
@@ -502,6 +509,7 @@
 		}
 		
 		//don't need to check children recursively, that's done in visit of each child
+		
 		isReorderChildDirty_=NO;
 	}
 }
@@ -555,6 +563,8 @@
 
 	} else
 		[self draw];
+	
+	mutatedIndex_=0;
 	
 	if ( grid_ && grid_.active)
 		[grid_ afterDraw:self];

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -729,7 +729,7 @@ static SEL selSortMethod = NULL;
 			tempItem = x[i];
 			j = i-1;
 			
-			while(j>=0 && ((CCSprite*) tempItem).zOrder<((CCSprite*)x[j]).zOrder)
+			while(j>=0 && ( ((CCSprite*) tempItem).zOrder<((CCSprite*)x[j]).zOrder || ( ((CCNode*) tempItem).mutatedIndex < ((CCNode*)x[j]).mutatedIndex ) ) )
 			{
 				x[j+1] = x[j];
 				j = j-1;

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -156,6 +156,8 @@ CGFloat	__ccContentScaleFactor = 1;
 	/* calculate "global" dt */
 	[self calculateDeltaTime];
 	
+	[self resetMutatedChildren];
+	
 	/* tick before glClear: issue #533 */
 	if( ! isPaused_ ) {
 		[[CCScheduler sharedScheduler] tick: dt];	

--- a/tests/PerformanceTests/PerformanceNodeChildrenTest/PerformanceNodeChildrenTest.h
+++ b/tests/PerformanceTests/PerformanceNodeChildrenTest/PerformanceNodeChildrenTest.h
@@ -66,5 +66,23 @@ enum {
 {}
 @end
 
+@interface ReorderSpriteSheet : AddRemoveSpriteSheet
+{}
+@end
 
+@interface ReorderSpriteSheetInOrder : AddRemoveSpriteSheet
+{}
+@end
+
+@interface ReorderSpriteSheetInReverseOrder : AddRemoveSpriteSheet
+{}
+@end
+
+@interface AddSpriteSheetInOrder : AddRemoveSpriteSheet
+{}
+@end
+
+@interface AddSpriteSheetInReverseOrder : AddRemoveSpriteSheet
+{}
+@end
 

--- a/tests/PerformanceTests/PerformanceNodeChildrenTest/PerformanceNodeChildrenTest.m
+++ b/tests/PerformanceTests/PerformanceNodeChildrenTest/PerformanceNodeChildrenTest.m
@@ -24,6 +24,11 @@ static NSString *transitions[] = {
 		@"IterateSpriteSheetCArray",
 		@"AddSpriteSheet",
 		@"RemoveSpriteSheet",
+		@"ReorderSpriteSheet",
+		@"ReorderSpriteSheetInOrder",
+		@"ReorderSpriteSheetInReverseOrder",
+		@"AddSpriteSheetInOrder",	
+		@"AddSpriteSheetInReverseOrder",
 };
 
 Class nextAction()
@@ -419,6 +424,7 @@ Class restartAction()
 		{
 			[batchNode addChild:sprites[i] z:zs[i] tag:kTagBase+i];
 		}
+		[batchNode sortAllChildren];
 		CCProfilingEndTimingBlock(_profilingTimer);
 		
 		// remove them
@@ -487,6 +493,274 @@ Class restartAction()
 -(NSString*) profilerName
 {
 	return @"remove sprites";
+}
+@end
+
+@implementation ReorderSpriteSheet
+-(void) update:(ccTime)dt
+{
+	srandom(0);
+	
+	// 15 percent
+	int totalToAdd = currentQuantityOfNodes * 0.15f;
+	
+	if( totalToAdd > 0 ) {
+		
+		CCSprite *sprites[ totalToAdd ];
+		
+		// Don't include the sprite creation time as part of the profiling
+		for(int i=0;i<totalToAdd;i++) {
+			sprites[i] = [CCSprite spriteWithTexture:[batchNode texture] rect:CGRectMake(0,0,32,32)];
+		}
+		
+		// add them with random Z (very important!)
+		for( int i=0; i < totalToAdd;i++ )
+		{
+			[batchNode addChild:sprites[i] z:CCRANDOM_MINUS1_1() * 50 tag:kTagBase+i];
+		}
+		
+		[batchNode sortAllChildren];
+	
+		// reorder them
+		CCProfilingBeginTimingBlock(_profilingTimer);
+		for( int i=0;i <  totalToAdd;i++)
+		{
+			[batchNode reorderChild:[[batchNode children] objectAtIndex:i] z:CCRANDOM_MINUS1_1() * 50];
+		}
+		[batchNode sortAllChildren];
+		CCProfilingEndTimingBlock(_profilingTimer);
+		
+		// remove them
+		for( int i=0;i <  totalToAdd;i++)
+		{
+			[batchNode removeChildByTag:kTagBase+i cleanup:YES];
+		}
+	}
+}
+
+-(NSString*) title
+{
+	return @"E - Reorder from spritesheet";
+}
+-(NSString*) subtitle
+{
+	return @"Reorder %10 of total sprites placed randomly. See console";
+}
+-(NSString*) profilerName
+{
+	return @"reorder sprites";
+}
+@end
+
+@implementation ReorderSpriteSheetInOrder
+-(void) update:(ccTime)dt
+{
+	srandom(0);
+	
+	// 15 percent
+	int totalToAdd = currentQuantityOfNodes * 0.15f;
+	
+	if( totalToAdd > 0 ) {
+		
+		CCSprite *sprites[ totalToAdd ];
+		
+		// Don't include the sprite creation time as part of the profiling
+		for(int i=0;i<totalToAdd;i++) {
+			sprites[i] = [CCSprite spriteWithTexture:[batchNode texture] rect:CGRectMake(0,0,32,32)];
+		}
+		
+		
+		for( int i=0; i < totalToAdd;i++ )
+		{
+			[batchNode addChild:sprites[i] z:i tag:kTagBase+i];
+		}
+		
+		[batchNode sortAllChildren];
+		
+		// reorder them
+		CCProfilingBeginTimingBlock(_profilingTimer);
+		for( int i=0;i <  totalToAdd;i++)
+		{
+			CCSprite* temp =[[batchNode children] objectAtIndex:i];
+			[batchNode reorderChild:temp z:i+1];
+		}
+		[batchNode sortAllChildren];
+		CCProfilingEndTimingBlock(_profilingTimer);
+		
+		// remove them
+		for( int i=0;i <  totalToAdd;i++)
+		{
+			[batchNode removeChildByTag:kTagBase+i cleanup:YES];
+		}
+	}
+}
+
+-(NSString*) title
+{
+	return @"F - Reorder from spritesheet";
+}
+-(NSString*) subtitle
+{
+	return @"Reorder %10 of total sprites placed in order. See console";
+}
+-(NSString*) profilerName
+{
+	return @"reorder sprites in order";
+}
+@end
+
+@implementation ReorderSpriteSheetInReverseOrder
+-(void) update:(ccTime)dt
+{
+	srandom(0);
+	
+	// 15 percent
+	int totalToAdd = currentQuantityOfNodes * 0.15f;
+	
+	if( totalToAdd > 0 ) {
+		
+		CCSprite *sprites[ totalToAdd ];
+		
+		// Don't include the sprite creation time as part of the profiling
+		for(int i=0;i<totalToAdd;i++) {
+			sprites[i] = [CCSprite spriteWithTexture:[batchNode texture] rect:CGRectMake(0,0,32,32)];
+		}
+		
+
+
+		for( int i=0; i < totalToAdd;i++ )
+		{
+			[batchNode addChild:sprites[i] z:i tag:kTagBase+i];
+		}
+		[batchNode sortAllChildren];
+
+		
+		// reorder them, worst case scenario
+		CCProfilingBeginTimingBlock(_profilingTimer);
+		for( int i=0;i <  totalToAdd;i++)
+		{
+			CCSprite* temp =[[batchNode children] objectAtIndex:i];
+			[batchNode reorderChild:temp z:totalToAdd-i];
+		}
+		[batchNode sortAllChildren];
+		CCProfilingEndTimingBlock(_profilingTimer);
+		
+		// remove them
+		for( int i=0;i <  totalToAdd;i++)
+		{
+			[batchNode removeChildByTag:kTagBase+i cleanup:YES];
+		}
+	}
+}
+
+-(NSString*) title
+{
+	return @"G - Reorder from spritesheet";
+}
+-(NSString*) subtitle
+{
+	return @"Reorder %10 of total sprites placed in reverse order. See console";
+}
+-(NSString*) profilerName
+{
+	return @"reorder sprites in reverse order";
+}
+@end
+
+@implementation AddSpriteSheetInOrder
+-(void) update:(ccTime)dt
+{
+	srandom(0);
+	
+	// 15 percent
+	int totalToAdd = currentQuantityOfNodes * 0.15f;
+	
+	if( totalToAdd > 0 ) {
+		
+		CCSprite *sprites[ totalToAdd ];
+		
+		// Don't include the sprite creation time as part of the profiling
+		for(int i=0;i<totalToAdd;i++) {
+			sprites[i] = [CCSprite spriteWithTexture:[batchNode texture] rect:CGRectMake(0,0,32,32)];
+		}
+		
+		//best case scenario
+		CCProfilingBeginTimingBlock(_profilingTimer);
+		for( int i=0; i < totalToAdd;i++ )
+		{
+			[batchNode addChild:sprites[i] z:i tag:kTagBase+i];
+		}
+		[batchNode sortAllChildren];
+		CCProfilingEndTimingBlock(_profilingTimer);
+		
+		// remove them
+		for( int i=0;i <  totalToAdd;i++)
+		{
+			[batchNode removeChildByTag:kTagBase+i cleanup:YES];
+		}
+	}
+}
+
+-(NSString*) title
+{
+	return @"H - Add to spritesheet";
+}
+-(NSString*) subtitle
+{
+	return @"Add %10 of total sprites placed in order. See console";
+}
+-(NSString*) profilerName
+{
+	return @"add sprites in order";
+}
+@end
+
+@implementation AddSpriteSheetInReverseOrder
+-(void) update:(ccTime)dt
+{
+	srandom(0);
+	
+	// 15 percent
+	int totalToAdd = currentQuantityOfNodes * 0.15f;
+	
+	if( totalToAdd > 0 ) {
+		
+		CCSprite *sprites[ totalToAdd ];
+		
+		// Don't include the sprite creation time as part of the profiling
+		for(int i=0;i<totalToAdd;i++) {
+			sprites[i] = [CCSprite spriteWithTexture:[batchNode texture] rect:CGRectMake(0,0,32,32)];
+		}
+		
+		
+		//worst case scenario
+		CCProfilingBeginTimingBlock(_profilingTimer);
+		for( int i=0; i < totalToAdd;i++ )
+		{
+			[batchNode addChild:sprites[i] z:totalToAdd-i tag:kTagBase+i];
+		}
+		[batchNode sortAllChildren];
+		CCProfilingEndTimingBlock(_profilingTimer);		
+		
+		// remove them
+		for( int i=0;i <  totalToAdd;i++)
+		{
+			[batchNode removeChildByTag:kTagBase+i cleanup:YES];
+		}
+	}
+}
+
+-(NSString*) title
+{
+	return @"I - Add to spritesheet";
+}
+-(NSString*) subtitle
+{
+	return @"Add %10 of total sprites placed in reverse order. See console";
+}
+-(NSString*) profilerName
+{
+	return @"add sprites in reverse order";
 }
 @end
 

--- a/tests/SpriteTest.h
+++ b/tests/SpriteTest.h
@@ -77,6 +77,17 @@
 }
 @end
 
+@interface SpriteBatchNodeReorderSameIndex : SpriteDemo
+{
+	CCSpriteBatchNode *batchNode;
+	CCSprite *sprite1;
+	CCSprite *sprite2;
+	CCSprite *sprite3;	
+	CCSprite *sprite4;	
+	CCSprite *sprite5;		
+}
+@end
+
 @interface SpriteBatchNodeReorderIssue767 : SpriteDemo
 {}
 @end

--- a/tests/SpriteTest.m
+++ b/tests/SpriteTest.m
@@ -32,6 +32,7 @@ static NSString *transitions[] = {
 	@"SpriteBatchNodeReorderIssue744",
 	@"SpriteBatchNodeReorderIssue766",
 	@"SpriteBatchNodeReorderIssue767",
+	@"SpriteBatchNodeReorderSameIndex",
 	@"SpriteZVertex",
 	@"SpriteBatchNodeZVertex",
 	@"Sprite6",
@@ -736,6 +737,70 @@ Class restartAction()
 }
 @end
 
+@implementation SpriteBatchNodeReorderSameIndex
+
+- (void) reorderSprite:(ccTime)dt
+{
+	[self unschedule:_cmd];
+	
+	[batchNode reorderChild:sprite4 z:4];
+	[batchNode reorderChild:sprite5 z:4];
+	[batchNode reorderChild:sprite1 z:4];
+	
+	[batchNode sortAllChildren];
+	CCSprite* child;
+	CCARRAY_FOREACH(batchNode.descendants,child) NSLog(@"tag %i",child.tag);
+	
+}
+
+// on "init" you need to initialize your instance
+-(id) init
+{
+	// always call "super" init
+	// Apple recommends to re-assign "self" with the "super" return value
+	if( (self=[super init] )) {
+		
+		batchNode = [CCSpriteBatchNode batchNodeWithFile:@"piece.png" capacity:15];
+		[self addChild:batchNode z:1 tag:0];
+				
+		sprite1 = [CCSprite spriteWithBatchNode:batchNode rect:CGRectMake(128,0,64,64)];
+		sprite1.position = CGPointMake(100,160);
+		[batchNode addChild:sprite1 z:3 tag:1];
+		
+		sprite2= [CCSprite spriteWithBatchNode:batchNode rect:CGRectMake(128,0,64,64)];
+		sprite2.position = CGPointMake(164,160);
+		[batchNode addChild:sprite2 z:4 tag:2];
+		
+		sprite3 = [CCSprite spriteWithBatchNode:batchNode rect:CGRectMake(128,0,64,64)];
+		sprite3.position = CGPointMake(228,160);
+		[batchNode addChild:sprite3 z:4 tag:3];
+		
+		sprite4 = [CCSprite spriteWithBatchNode:batchNode rect:CGRectMake(128,0,64,64)];
+		sprite4.position = CGPointMake(292,160);
+		[batchNode addChild:sprite4 z:5 tag:4];
+		
+		sprite5 = [CCSprite spriteWithBatchNode:batchNode rect:CGRectMake(128,0,64,64)];
+		sprite5.position = CGPointMake(356,160);
+		[batchNode addChild:sprite5 z:6 tag:5];
+		
+		
+		[self schedule:@selector(reorderSprite:) interval:2];
+	}
+	return self;
+}
+
+-(NSString *) title
+{
+	return @"SpriteBatchNodeReorder same index";
+}
+
+-(NSString *) subtitle
+{
+	return @"tag order in console should be 2,3,4,5,1";
+}
+
+@end
+
 @implementation SpriteBatchNodeReorderIssue766
 -(CCSprite *)makeSpriteZ:(int)aZ
 {
@@ -786,7 +851,7 @@ Class restartAction()
 
 -(NSString *) title
 {
-	return @"SpriteBatchNode: reorder issue #766";
+	return @"SpriteBatchNodeReorder";
 }
 
 -(NSString *) subtitle
@@ -795,6 +860,7 @@ Class restartAction()
 }
 
 @end
+
 
 
 @implementation SpriteBatchNodeReorderIssue767


### PR DESCRIPTION
This version performs better than the last version, I've reduced the number of traverses th
rough the descendants array to one. Now in one step every item gets its right atlasIndex an
d it gets reorderd at the same time.

To solve the order problem I described in my last comment, I had to introduce a global variable (using the director) that keeps track of the order of calling -addChild and -reorderChild.

As far as I know all spriteTests perform normally.

See the commit for a performance comparison. 

Compared to the last version a few things have changed

CCDirector
added getMutableIndex, resetMutableIndex methods
added mutableIndex_ property

SpriteTest
Added a test to check if the index in the children array is correct when when reordering multiple children to a already existing zOrder.

PerformanceNodeChildrenTest
Added several tests to include best and worst case scenarios for reordering and adding.
This will make the comparison between different algorithms more clearer.

CCDirectorIOS
modified the mainLoop, have to reset mutableIndex every frame

CCNode
modified visit, sets mutableIndex on 0
added int mutatedIndex

CCBatchNode
removed sortDescendants
modified visit, sets mutableIndex on 0
