### PR TITLE
[CocosDenshion] restrict the range of effectsVolume & backgroundMusicVolume

### DIFF
--- a/CocosDenshion/CocosDenshion/SimpleAudioEngine.m
+++ b/CocosDenshion/CocosDenshion/SimpleAudioEngine.m
@@ -194,6 +194,9 @@ static CDBufferManager *bufferManager = nil;
 
 -(void) setBackgroundMusicVolume:(float) volume
 {
+	volume = volume < 0 ? 0.0f : volume;
+    volume = volume > 1 ? 1.0f : volume;
+	
 	am.backgroundMusic.volume = volume;
 }	
 
@@ -205,6 +208,9 @@ static CDBufferManager *bufferManager = nil;
 
 -(void) setEffectsVolume:(float) volume
 {
+	volume = volume < 0 ? 0.0f : volume;
+    volume = volume > 1 ? 1.0f : volume;
+	
 	am.soundEngine.masterGain = volume;
 }	
 


### PR DESCRIPTION
If i set the property
[[SimpleAudioEngine sharedEngine].effectsVolume = -0.1f
or
[[SimpleAudioEngine sharedEngine].effectsVolume = 100.0f

then
[[SimpleAudioEngine sharedEngine] playEffect: @"dp1.caf"];

It output noise, no matter the effect is in caf format or wav format.

I think it's caused by the range of effectsVolume 0.0~1.0f. So I modify SimpleAudioEngine.m to make it safer.
