### PR TITLE
Suppress warnings in CCTexturePVR

### DIFF
--- a/cocos2d/CCTexturePVR.m
+++ b/cocos2d/CCTexturePVR.m
@@ -303,7 +303,7 @@ typedef struct _PVRTexHeader
 			glTexImage2D(GL_TEXTURE_2D, i, internalFormat, width, height, 0, format, type, data);
 
 		if( i > 0 && (width != height || ccNextPOT(width) != width ) )
-			CCLOG(@"cocos2d: TexturePVR. WARNING. Mipmap level %lu is not squared. Texture won't render correctly. width=%lu != height=%lu", i, width, height);
+			CCLOG(@"cocos2d: TexturePVR. WARNING. Mipmap level %u is not squared. Texture won't render correctly. width=%u != height=%u", i, width, height);
 		
 		err = glGetError();
 		if (err != GL_NO_ERROR)


### PR DESCRIPTION
Hi, I fixed for clang warnings with between '%lu' and NSUInteger arguments.

warning: conversion specifies type 'unsigned long' but the argument has type 'NSUInteger' (aka 'unsigned int') [-Wformat]
