### PR TITLE
Updated FontLabel class

### DIFF
--- a/external/FontLabel/FontLabel.m
+++ b/external/FontLabel/FontLabel.m
@@ -168,12 +168,21 @@
 	
 	if (numberOfLines == 1) {
 		// if numberOfLines == 1 we need to use the version that converts spaces
-		CGSize size = [self.text sizeWithZFont:self.zFont];
+		CGSize size;
+		if (self.zAttributedText == nil) {
+			size = [self.text sizeWithZFont:self.zFont];
+		} else {
+			size = [self.zAttributedText size];
+		}
 		bounds.size.width = MIN(bounds.size.width, size.width);
 		bounds.size.height = MIN(bounds.size.height, size.height);
 	} else {
 		if (numberOfLines > 0) bounds.size.height = MIN(bounds.size.height, self.zFont.leading * numberOfLines);
-		bounds.size = [self.text sizeWithZFont:self.zFont constrainedToSize:bounds.size lineBreakMode:self.lineBreakMode];
+		if (self.zAttributedText == nil) {
+			bounds.size = [self.text sizeWithZFont:self.zFont constrainedToSize:bounds.size lineBreakMode:self.lineBreakMode];
+		} else {
+			bounds.size = [self.zAttributedText sizeConstrainedToSize:bounds.size lineBreakMode:self.lineBreakMode];
+		}
 	}
 	return bounds;
 }

--- a/external/FontLabel/FontLabelStringDrawing.m
+++ b/external/FontLabel/FontLabelStringDrawing.m
@@ -455,7 +455,8 @@ static CGSize drawOrSizeTextConstrainedToSize(BOOL performDraw, NSString *string
 	
 	READ_GLYPHS();
 	
-	NSCharacterSet *alphaCharset = [NSCharacterSet alphanumericCharacterSet];
+	NSMutableCharacterSet *alphaCharset = [NSMutableCharacterSet alphanumericCharacterSet];
+    [alphaCharset addCharactersInString:@"'\u2019\u02BC"]; // apostrophes
 	
 	// scan left-to-right looking for newlines or until we hit the width constraint
 	// When we hit a wrapping point, calculate truncation as follows:
@@ -518,6 +519,27 @@ static CGSize drawOrSizeTextConstrainedToSize(BOOL performDraw, NSString *string
 					lineAscender = MAX(lineAscender, currentFont.ascender);
 				}
 				unichar c = characters[idx];
+				// Mark a wrap point before spaces and after any stretch of non-alpha characters
+				BOOL markWrap = NO;
+				if (c == (unichar)' ') {
+					markWrap = YES;
+				} else if ([alphaCharset characterIsMember:c]) {
+					if (!inAlpha) {
+						markWrap = YES;
+						inAlpha = YES;
+					}
+				} else {
+					inAlpha = NO;
+				}
+				if (markWrap) {
+					lastWrapCache = (__typeof__(lastWrapCache)){
+						.index = idx,
+						.glyphIndex = glyphIdx,
+						.currentRunIdx = currentRunIdx,
+						.lineSize = lineSize
+					};
+				}
+				// process the line
 				if (c == (unichar)'\n' || c == 0x0085) { // U+0085 is the NEXT_LINE unicode character
 					finishLine = YES;
 					skipCount = 1;
@@ -682,26 +704,6 @@ static CGSize drawOrSizeTextConstrainedToSize(BOOL performDraw, NSString *string
 				glyphIdx += skipCount;
 				lineCount++;
 			} else {
-				// Mark a wrap point before spaces and after any stretch of non-alpha characters
-				BOOL markWrap = NO;
-				if (characters[idx] == (unichar)' ') {
-					markWrap = YES;
-				} else if ([alphaCharset characterIsMember:characters[idx]]) {
-					if (!inAlpha) {
-						markWrap = YES;
-						inAlpha = YES;
-					}
-				} else {
-					inAlpha = NO;
-				}
-				if (markWrap) {
-					lastWrapCache = (__typeof__(lastWrapCache)){
-						.index = idx,
-						.glyphIndex = glyphIdx,
-						.currentRunIdx = currentRunIdx,
-						.lineSize = lineSize
-					};
-				}
 				lineSize.width += advances[glyphIdx];
 				glyphIdx++;
 				idx++;

--- a/external/FontLabel/FontManager.m
+++ b/external/FontLabel/FontManager.m
@@ -21,7 +21,6 @@
 
 #import "FontManager.h"
 #import "ZFont.h"
-#import "CCConfiguration.h"
 
 static FontManager *sharedFontManager = nil;
 

--- a/external/FontLabel/ZAttributedString.m
+++ b/external/FontLabel/ZAttributedString.m
@@ -67,7 +67,7 @@
 }
 
 - (id)mutableCopyWithZone:(NSZone *)zone {
-	return [(ZMutableAttributedString*)[ZMutableAttributedString allocWithZone:zone] initWithAttributedString:self];
+	return [(ZMutableAttributedString *)[ZMutableAttributedString allocWithZone:zone] initWithAttributedString:self];
 }
 
 - (NSUInteger)length {
@@ -291,7 +291,7 @@
 			NSUInteger endRunIndex = runIndex+1;
 			runIndex--;
 			// search backwards
-			while (true) {
+			while (runIndex >= 0) {
 				if (run.index <= rangeLimit.location) {
 					break;
 				}
@@ -349,7 +349,7 @@
 
 @implementation ZMutableAttributedString
 - (id)copyWithZone:(NSZone *)zone {
-	return [(ZMutableAttributedString*)[ZAttributedString allocWithZone:zone] initWithAttributedString:self];
+	return [(ZAttributedString *)[ZAttributedString allocWithZone:zone] initWithAttributedString:self];
 }
 
 - (void)addAttribute:(NSString *)name value:(id)value range:(NSRange)range {
@@ -459,7 +459,7 @@
 	if (((ZAttributeRun *)[_attributes lastObject]).index < NSMaxRange(range)) {
 		NSRange subrange = NSMakeRange(first, [_attributes count] - first);
 		if (NSMaxRange(range) < [_buffer length]) {
-			ZAttributeRun *newRun = [[ZAttributeRun alloc] initWithIndex:NSMaxRange(range) attributes:(NSDictionary*)[[_attributes lastObject] attributes]];
+			ZAttributeRun *newRun = [[ZAttributeRun alloc] initWithIndex:NSMaxRange(range) attributes:[[_attributes lastObject] attributes]];
 			[_attributes addObject:newRun];
 			[newRun release];
 		}
@@ -483,7 +483,7 @@
 		if ([[_attributes objectAtIndex:firstAfter] index] > NSMaxRange(range)) {
 			// the first after is too far after, insert another run!
 			ZAttributeRun *newRun = [[ZAttributeRun alloc] initWithIndex:NSMaxRange(range)
-															  attributes:(NSDictionary*)[[_attributes objectAtIndex:firstAfter-1] attributes]];
+															  attributes:[[_attributes objectAtIndex:firstAfter-1] attributes]];
 			[_attributes insertObject:newRun atIndex:firstAfter];
 			[newRun release];
 		}
@@ -536,6 +536,7 @@
 }
 
 - (id)initWithIndex:(NSUInteger)idx attributes:(NSDictionary *)attrs {
+	NSParameterAssert(idx >= 0);
 	if ((self = [super init])) {
 		_index = idx;
 		if (attrs == nil) {

--- a/external/FontLabel/ZFont.m
+++ b/external/FontLabel/ZFont.m
@@ -52,7 +52,6 @@
 
 - (id)init {
 	NSAssert(NO, @"-init is not valid for ZFont");
-	[self release];
 	return nil;
 }
 


### PR DESCRIPTION
We ran into a problem with FontLabel where text was not properly wrapping (it would wrap on the apostrophe character, and sometimes hyphen etc.) I saw someone had forked and fixed the issue, and he informed me that he is the original author (kballard), and now maintaining it under a different fork. 
