### PR TITLE
Sprite cache naming

### DIFF
--- a/cocos2d/CCSpriteFrameCache.h
+++ b/cocos2d/CCSpriteFrameCache.h
@@ -55,10 +55,15 @@
  */
 +(void)purgeSharedSpriteFrameCache;
 
+/** Generates the key that will be used to index in to the cache dictionary
+ can be used to build the key from outside frame cache
+ */
++(NSString*) makeCacheKeyFromName: (NSString*)name basekey:(NSString*)key;
 
 /** Adds multiple Sprite Frames with a dictionary. The texture will be associated with the created sprite frames.
+ The name is used in the cache key so that sprite names don't have to be unique across all sprite sheets.
  */
--(void) addSpriteFramesWithDictionary:(NSDictionary*)dictionary texture:(CCTexture2D*)texture;
+-(void) addSpriteFramesWithDictionary:(NSDictionary*)dictionary texture:(CCTexture2D*)texture name:(NSString*)name;
 
 /** Adds multiple Sprite Frames from a plist file.
  * A texture will be loaded automatically. The texture name will composed by replacing the .plist suffix with .png
@@ -66,9 +71,19 @@
  */
 -(void) addSpriteFramesWithFile:(NSString*)plist;
 
+/** Adds multiple Sprite Frames from a plist file.
+ Adds a name to the sprite frame name hashes.
+ */
+-(void) addSpriteFramesWithFile:(NSString*)plist name:(NSString*)name;
+
 /** Adds multiple Sprite Frames from a plist file. The texture will be associated with the created sprite frames.
  */
 -(void) addSpriteFramesWithFile:(NSString*)plist texture:(CCTexture2D*)texture;
+
+/** Adds multiple Sprite Frames from a plist file. The texture will be associated with the created sprite frames.
+ Adds a name to the sprite frame name hashes.
+ */
+-(void) addSpriteFramesWithFile:(NSString*)plist texture:(CCTexture2D*)texture name:(NSString*)name;
 
 /** Adds multiple Sprite Frames from a plist file. The texture will be associated with the created sprite frames.
  @since v0.99.5

--- a/cocos2d/CCSpriteFrameCache.m
+++ b/cocos2d/CCSpriteFrameCache.m
@@ -91,7 +91,7 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
 
 #pragma mark CCSpriteFrameCache - loading sprite frames
 
--(void) addSpriteFramesWithDictionary:(NSDictionary*)dictionary texture:(CCTexture2D*)texture
+-(void) addSpriteFramesWithDictionary:(NSDictionary*)dictionary texture:(CCTexture2D*)texture name:(NSString*)name
 {
 	/*
 	 Supported Zwoptex Formats:
@@ -181,6 +181,7 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
 														  offset:spriteOffset 
 													originalSize:spriteSourceSize];
 		}
+        frameDictKey = [CCSpriteFrameCache makeCacheKeyFromName: name basekey:frameDictKey];
 
         // make sure we aren't clobbering an entry
         if( [spriteFrames_ objectForKey:frameDictKey] != nil )
@@ -195,12 +196,25 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
 	}
 }
 
--(void) addSpriteFramesWithFile:(NSString*)plist texture:(CCTexture2D*)texture
++(NSString*) makeCacheKeyFromName: (NSString*)name basekey:(NSString*)key
+{
+    if(name == nil)
+        return key;
+    
+    return [NSString stringWithFormat:@"%@:%@",name, key, nil];
+}
+
+-(void) addSpriteFramesWithFile:(NSString*)plist texture:(CCTexture2D*)texture name:(NSString*)name
 {
 	NSString *path = [CCFileUtils fullPathFromRelativePath:plist];
 	NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:path];
+    
+	return [self addSpriteFramesWithDictionary:dict texture:texture name:name];
+}
 
-	return [self addSpriteFramesWithDictionary:dict texture:texture];
+-(void) addSpriteFramesWithFile:(NSString*)plist texture:(CCTexture2D*)texture
+{
+    [self addSpriteFramesWithFile:plist texture:texture name:nil];
 }
 
 -(void) addSpriteFramesWithFile:(NSString*)plist textureFile:(NSString*)textureFileName
@@ -214,7 +228,7 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
 		CCLOG(@"cocos2d: CCSpriteFrameCache: couldn't load texture file. File not found: %@", textureFileName);
 }
 
--(void) addSpriteFramesWithFile:(NSString*)plist
+-(void) addSpriteFramesWithFile:(NSString*)plist name:(NSString*)name
 {
     NSString *path = [CCFileUtils fullPathFromRelativePath:plist];
     NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:path];
@@ -242,10 +256,15 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
     CCTexture2D *texture = [[CCTextureCache sharedTextureCache] addImage:texturePath];
 	
 	if( texture )
-		[self addSpriteFramesWithDictionary:dict texture:texture];
+		[self addSpriteFramesWithDictionary:dict texture:texture name:name];
 	
 	else
 		CCLOG(@"cocos2d: CCSpriteFrameCache: Couldn't load texture");
+}
+
+-(void) addSpriteFramesWithFile:(NSString*)plist
+{
+    [self addSpriteFramesWithFile:plist name:nil];
 }
 
 -(void) addSpriteFrame:(CCSpriteFrame*)frame name:(NSString*)frameName

--- a/cocos2d/CCSpriteFrameCache.m
+++ b/cocos2d/CCSpriteFrameCache.m
@@ -171,7 +171,7 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
 				if( [spriteFramesAliases_ objectForKey:alias] )
 					CCLOG(@"cocos2d: WARNING: an alias with name %@ already exists",alias);
 				
-				[spriteFramesAliases_ setObject:frameDictKey forKey:alias];
+				[spriteFramesAliases_ setObject:[CCSpriteFrameCache makeCacheKeyFromName: name basekey:frameDictKey] forKey:alias];
 			}
 			
 			// create frame

--- a/cocos2d/CCSpriteFrameCache.m
+++ b/cocos2d/CCSpriteFrameCache.m
@@ -182,6 +182,13 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
 													originalSize:spriteSourceSize];
 		}
 
+        // make sure we aren't clobbering an entry
+        if( [spriteFrames_ objectForKey:frameDictKey] != nil )
+        {
+            CCLOG(@"cocos2d: WARNING: Clobbering an existing spriteFrame (%@) in the spriteFrameCache", frameDictKey);
+        }
+
+        
 		// add sprite frame
 		[spriteFrames_ setObject:spriteFrame forKey:frameDictKey];
 		[spriteFrame release];


### PR DESCRIPTION
This modification enables the use of non-unique sprite names across multiple spritesheets without name collisions in the sprite frame cache. It's a little end-user heavy, since they have to remember and keep track of whatever tag they give to a particular set of sprite frames. But it's adequate and it solved a problem I was having (I'm using a lot of processed sprites, and this modification was easier than making sure every sprite was guaranteed a unique name). 

I considered implicitly adding the name of the spritesheet/png/plist to the cache key, but decided against it in order to facilitate proper backwards compatibility. 

All tests in SpriteTest run as they did in the master branch, however, the alias test doesn't function in the master branch so I was unable to confirm compatibility, though I'm pretty sure I have it covered. 

Other change is that I added a warning to the logs when a sprite frame cache entry was clobbered. This log mimics the one set up for testing against duplicate aliases. 

Overall this change is probably not as robust as it probably should be for a release, but I think it's a solid foundation to build upon. 
