### PR TITLE
fixed unscheduling of updates

### DIFF
--- a/cocos2d/CCScheduler.h
+++ b/cocos2d/CCScheduler.h
@@ -110,6 +110,8 @@ struct _hashUpdateEntry;
 	// Optimization
 	TICK_IMP			impMethod;
 	SEL					updateSelector;
+    
+    BOOL updateHashLocked; // If true unschedule will not remove anything from a hash. Elements will only be marked for deletion.
 }
 
 /** Modifies the time of all scheduled callbacks.

--- a/cocos2d/CCScheduler.m
+++ b/cocos2d/CCScheduler.m
@@ -43,8 +43,8 @@ typedef struct _listEntry
 	TICK_IMP impMethod;
 	id		target;				// not retained (retained by hashUpdateEntry)
 	int		priority;
-	BOOL	paused;
-	
+	BOOL	paused;	
+    BOOL    markedForDeletion; // selector will no longer be called and entry will be removed at end of the next tick
 } tListEntry;
 
 typedef struct _hashUpdateEntry
@@ -198,6 +198,7 @@ static CCScheduler *sharedScheduler;
 		currentTarget = nil;
 		currentTargetSalvaged = NO;
 		hashForSelectors = nil;
+        updateHashLocked = NO;
 	}
 
 	return self;
@@ -340,7 +341,7 @@ static CCScheduler *sharedScheduler;
 	listElement->paused = paused;
 	listElement->impMethod = (TICK_IMP) [target methodForSelector:updateSelector];
 	listElement->next = listElement->prev = NULL;
-	
+    listElement->markedForDeletion = NO;
 	
 	// empty list ?
 	if( ! *list ) {
@@ -386,6 +387,7 @@ static CCScheduler *sharedScheduler;
 	
 	listElement->target = target;
 	listElement->paused = paused;
+    listElement->markedForDeletion = NO;
 	listElement->impMethod = (TICK_IMP) [target methodForSelector:updateSelector];
 	
 	DL_APPEND(*list, listElement);
@@ -401,11 +403,18 @@ static CCScheduler *sharedScheduler;
 
 -(void) scheduleUpdateForTarget:(id)target priority:(int)priority paused:(BOOL)paused
 {
-#if COCOS2D_DEBUG >= 1
 	tHashUpdateEntry * hashElement = NULL;
 	HASH_FIND_INT(hashForUpdates, &target, hashElement);
-	NSAssert( hashElement == NULL, @"CCScheduler: You can't re-schedule an 'update' selector'. Unschedule it first");
+    if(hashElement)
+    {
+#if COCOS2D_DEBUG >= 1        
+        NSAssert( hashElement->entry->markedForDeletion, @"CCScheduler: You can't re-schedule an 'update' selector'. Unschedule it first");
 #endif	
+        // TODO : check if priority has changed!
+        
+        hashElement->entry->markedForDeletion = NO;
+        return;
+    }
 		
 	// most of the updates are going to be 0, that's way there
 	// is an special list for updates with priority 0
@@ -419,6 +428,23 @@ static CCScheduler *sharedScheduler;
 		[self priorityIn:&updatesPos target:target priority:priority paused:paused];
 }
 
+- (void) removeUpdateFromHash:(tListEntry*)entry
+{
+    tHashUpdateEntry * element = NULL;
+    
+    HASH_FIND_INT(hashForUpdates, &entry->target, element);
+    if( element ) {
+        // list entry
+        DL_DELETE( *element->list, element->entry );
+        free( element->entry );
+        
+        // hash entry
+        [element->target release];
+        HASH_DEL( hashForUpdates, element);
+        free(element);
+    }
+}
+
 -(void) unscheduleUpdateForTarget:(id)target
 {
 	if( target == nil )
@@ -426,16 +452,20 @@ static CCScheduler *sharedScheduler;
 	
 	tHashUpdateEntry * element = NULL;
 	HASH_FIND_INT(hashForUpdates, &target, element);
-	if( element ) {
-	
-		// list entry
-		DL_DELETE( *element->list, element->entry );
-		free( element->entry );
-	
-		// hash entry
-		[element->target release];
-		HASH_DEL( hashForUpdates, element);
-		free(element);
+	if( element ) {    
+        if(updateHashLocked)
+            element->entry->markedForDeletion = YES;
+        else
+            [self removeUpdateFromHash:element->entry];
+        
+//		// list entry
+//		DL_DELETE( *element->list, element->entry );
+//		free( element->entry );
+//	
+//		// hash entry
+//		[element->target release];
+//		HASH_DEL( hashForUpdates, element);
+//		free(element);
 	}
 }
 
@@ -533,6 +563,8 @@ static CCScheduler *sharedScheduler;
 
 -(void) tick: (ccTime) dt
 {
+    updateHashLocked = YES;
+    
 	if( timeScale_ != 1.0f )
 		dt *= timeScale_;
 	
@@ -541,19 +573,21 @@ static CCScheduler *sharedScheduler;
 
 	// updates with priority < 0
 	DL_FOREACH_SAFE( updatesNeg, entry, tmp ) {
-		if( ! entry->paused )
+		if( ! entry->paused && !entry->markedForDeletion )
 			entry->impMethod( entry->target, updateSelector, dt );
 	}
 
 	// updates with priority == 0
 	DL_FOREACH_SAFE( updates0, entry, tmp ) {
-		if( ! entry->paused )
+		if( ! entry->paused && !entry->markedForDeletion )
+        {
 			entry->impMethod( entry->target, updateSelector, dt );
+        }
 	}
 	
 	// updates with priority > 0
 	DL_FOREACH_SAFE( updatesPos, entry, tmp ) {
-		if( ! entry->paused )
+		if( ! entry->paused  && !entry->markedForDeletion )
 			entry->impMethod( entry->target, updateSelector, dt );
 	}
 	
@@ -592,8 +626,33 @@ static CCScheduler *sharedScheduler;
 			[self removeHashElement:currentTarget];		
 	}
 	
+    // delete all updates that are morked for deletion
+    // updates with priority < 0
+	DL_FOREACH_SAFE( updatesNeg, entry, tmp ) {
+		if(entry->markedForDeletion )
+        {
+            [self removeUpdateFromHash:entry];
+        }
+	}
+    
+	// updates with priority == 0
+	DL_FOREACH_SAFE( updates0, entry, tmp ) {
+		if(entry->markedForDeletion )
+        {
+            [self removeUpdateFromHash:entry];
+        }
+	}
+	
+	// updates with priority > 0
+	DL_FOREACH_SAFE( updatesPos, entry, tmp ) {
+		if(entry->markedForDeletion )
+        {
+            [self removeUpdateFromHash:entry];
+        }
+	}
+
+    updateHashLocked = NO;
 	currentTarget = nil;
 }
-
 @end
 


### PR DESCRIPTION
Hi Riq,

this should fix problems with unscheduling updates.

If we are in the tick method of the CCScheduler we do not delete updates from the hash immediately, but mark them for deletion. If they are marked, they will no longer be called in the current tick and they will also be deleted at the end of the tick.

If we are not in the tick function, updates are deleted immediately.

Thomas
