### PR TITLE
CCSpriteFrame shouldn't retain texture if it's possible.

### DIFF
--- a/cocos2d/CCSpriteFrame.h
+++ b/cocos2d/CCSpriteFrame.h
@@ -45,6 +45,8 @@
 	CGPoint			offsetInPixels_;
 	CGSize			originalSizeInPixels_;
 	CCTexture2D		*texture_;
+	BOOL			usesRetainedTexture_;
+	NSString		*textureKey_;
 }
 /** rect of the frame in points. If it is updated, then rectInPixels will be updated too. */
 @property (nonatomic,readwrite) CGRect rect;
@@ -61,8 +63,26 @@
 /** original size of the trimmed image in pixels */
 @property (nonatomic,readwrite) CGSize originalSizeInPixels;
 
-/** texture of the frame */
+/** texture of the frame.
+ * returns retained texture if usesRetainedTexture == YES 
+ * returns CCTextureCache::addImage result if usesRetainedTexture == NO
+ * will change usesRetainedTexture to YES if new texture will be set via setter.
+ */
 @property (nonatomic, retain, readwrite) CCTexture2D *texture;
+
+/** textureKey of the frame.
+ * returns textureKey if usesRetainedTexture == NO 
+ * returns CCTextureCache::keyForTexture if usesRetainedTexture == YES
+ * will change usesRetainedTexture to NO, if will be set via setter, if such 
+ * new textureKey is present in textureCache
+ */
+@property (nonatomic, copy, readwrite) NSString *textureKey;
+
+/** Shows the mode of the frame.
+ * if YES - retains the texture
+ * if NO - uses textureKey to get texture from textureCache
+ */
+@property (nonatomic, readonly) BOOL usesRetainedTexture;
 
 /** Create a CCSpriteFrame with a texture, rect in points.
  It is assumed that the frame was not trimmed.

--- a/cocos2d/CCSpriteFrame.m
+++ b/cocos2d/CCSpriteFrame.m
@@ -29,8 +29,56 @@
 #import "ccMacros.h"
 
 @implementation CCSpriteFrame
-@synthesize rotated = rotated_, offsetInPixels = offsetInPixels_, texture = texture_;
+@synthesize rotated = rotated_, offsetInPixels = offsetInPixels_;
 @synthesize originalSizeInPixels=originalSizeInPixels_;
+@synthesize usesRetainedTexture = usesRetainedTexture_;
+
+@dynamic texture;
+- (CCTexture2D *) texture
+{
+	if (self.usesRetainedTexture)
+		return texture_;
+	
+	return [[CCTextureCache sharedTextureCache] addImage: textureKey_];
+}
+
+- (void) setTexture:(CCTexture2D *) newTexture
+{
+	if (newTexture != texture_)
+	{
+		[texture_ release];
+		texture_ = [newTexture retain];
+		
+		if (texture_)
+		{
+			usesRetainedTexture_ = YES;
+			[textureKey_ release];
+			textureKey_ = nil;
+		}
+	}
+}
+
+@dynamic textureKey;
+- (NSString *) textureKey
+{
+	if (!self.usesRetainedTexture)
+		return textureKey_;
+	
+	return [[CCTextureCache sharedTextureCache] keyForTexture: texture_];
+}
+
+- (void) setTextureKey:(NSString *) newTextureKey
+{
+	if (newTextureKey)
+	{
+		[textureKey_ release];
+		textureKey_ = [newTextureKey copy];
+		
+		usesRetainedTexture_ = NO;
+		[texture_ release];
+		texture_ = nil;
+	}
+}
 
 +(id) frameWithTexture:(CCTexture2D*)texture rect:(CGRect)rect
 {
@@ -51,7 +99,13 @@
 -(id) initWithTexture:(CCTexture2D*)texture rectInPixels:(CGRect)rect rotated:(BOOL)rotated offset:(CGPoint)offset originalSize:(CGSize)originalSize
 {
 	if( (self=[super init]) ) {
-		self.texture = texture;
+		
+		NSString *key = [[CCTextureCache sharedTextureCache] keyForTexture: texture];
+		if (key)
+			self.textureKey = key;
+		else
+			self.texture = texture;		
+		
 		rectInPixels_ = rect;
 		rect_ = CC_RECT_PIXELS_TO_POINTS( rect );
 		rotated_ = rotated;
@@ -75,6 +129,7 @@
 {
 	CCLOGINFO( @"cocos2d: deallocing %@",self);
 	[texture_ release];
+	[textureKey_ release];
 	[super dealloc];
 }
 

--- a/cocos2d/CCTextureCache.h
+++ b/cocos2d/CCTextureCache.h
@@ -84,6 +84,12 @@
  */
 -(CCTexture2D *) textureForKey:(NSString *)key;
 
+/** Returns first found key for already created texture if it exists in textureCache. 
+ * Returns nil if the texture == nil or not present in textureCache.
+ * @since XXX 
+ */
+-(NSString *) keyForTexture: (CCTexture2D *) tex;
+
 /** Purges the dictionary of loaded textures.
  * Call this method if you receive the "Memory Warning"
  * In the short term: it will free some resources preventing your app from being killed

--- a/cocos2d/CCTextureCache.m
+++ b/cocos2d/CCTextureCache.m
@@ -402,6 +402,24 @@ static CCTextureCache *sharedTextureCache;
     return [textures_ objectForKey:key];    
 }
 
+- (NSString *) keyForTexture: (CCTexture2D *) tex
+{
+    if( ! tex )
+        return nil;
+        
+    [dictLock_ lock];
+        
+    NSArray *keys = [textures_ allKeysForObject:tex];
+    
+    [dictLock_ unlock];
+    
+    if ([keys count])
+    {
+        return [keys objectAtIndex:0];
+    }
+    return nil;
+}
+
 @end
 
 


### PR DESCRIPTION
Original topic was here: http://www.cocos2d-iphone.org/forum/topic/13732

Right now in cocos2d CCSpriteFrame retains texture with which it is created. 
This leads to some kind of leaking texture - it will not be dealloced until CCSpriteFrame's retaining it will not be purged from CCSpriteFrameCache.

But i think it's possible and usefull to keep CCSpriteFrame's in CCSpriteFrameCache without retaining the texture. My solution isn't absolute lazy-texture-alloc, but it's tiny and helps me to avoid memory warning crashes without purging CCSpriteFrameCache.

After removing nodes from scene i just call [[CCTextureCache sharedTextureCahce] removeAllUnusedTextures] and use the same call in memoryWarning notification instead of purgeCachedData. It helps me avoid memory crashes and keeps SpriteFrames in cache.

Also i should mention, that purgeCachedData isn't a panacea, cause it will even force app to crash after memory warning if nodes using texture from foo.png aren't dealloced and user tries to load foo.png after purging cached data. This will lead to duplication of foo.png texture in memory and app will crash. Instead of this, i use removeAllUnusedTextures, cause it doesn't loose pointers to retained textures.
