### PR TITLE
Added isRetina method for CCTexture2D. Code from Patrick Wolowicz

### DIFF
--- a/cocos2d/CCTexture2D.h
+++ b/cocos2d/CCTexture2D.h
@@ -121,6 +121,7 @@ typedef enum {
 	GLfloat						maxS_,
 								maxT_;
 	BOOL						hasPremultipliedAlpha_;
+	BOOL						isRetina;
 }
 /** Intializes with a texture2d with data */
 - (id) initWithData:(const void*)data pixelFormat:(CCTexture2DPixelFormat)pixelFormat pixelsWide:(NSUInteger)width pixelsHigh:(NSUInteger)height contentSize:(CGSize)size;
@@ -136,6 +137,8 @@ typedef enum {
 /** hight in pixels */
 @property(nonatomic,readonly) NSUInteger pixelsHigh;
 
+
+@property(readwrite) BOOL isRetina;
 /** texture name */
 @property(nonatomic,readonly) GLuint name;
 

--- a/cocos2d/CCTexture2D.m
+++ b/cocos2d/CCTexture2D.m
@@ -108,6 +108,7 @@ static CCTexture2DPixelFormat defaultAlphaPixelFormat_ = kCCTexture2DPixelFormat
 
 @synthesize contentSizeInPixels = size_, pixelFormat = format_, pixelsWide = width_, pixelsHigh = height_, name = name_, maxS = maxS_, maxT = maxT_;
 @synthesize hasPremultipliedAlpha = hasPremultipliedAlpha_;
+@synthesize isRetina;
 
 - (id) initWithData:(const void*)data pixelFormat:(CCTexture2DPixelFormat)pixelFormat pixelsWide:(NSUInteger)width pixelsHigh:(NSUInteger)height contentSize:(CGSize)size
 {

--- a/cocos2d/CCTextureCache.m
+++ b/cocos2d/CCTextureCache.m
@@ -308,7 +308,6 @@ static CCTextureCache *sharedTextureCache;
 #elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
 		else {
 			NSString *fullpath = [CCFileUtils fullPathFromRelativePath: path ];
-			BOOL isRetina = [CCFileUtils isRetina: path];
 
 			NSData *data = [[NSData alloc] initWithContentsOfFile:fullpath];
 			NSBitmapImageRep *image = [[NSBitmapImageRep alloc] initWithData:data];

--- a/cocos2d/CCTextureCache.m
+++ b/cocos2d/CCTextureCache.m
@@ -268,10 +268,12 @@ static CCTextureCache *sharedTextureCache;
 			// convert jpg to png before loading the texture
 			
 			NSString *fullpath = [CCFileUtils fullPathFromRelativePath: path ];
+			BOOL isRetina = [CCFileUtils isRetina: path];
 						
 			UIImage *jpg = [[UIImage alloc] initWithContentsOfFile:fullpath];
 			UIImage *png = [[UIImage alloc] initWithData:UIImagePNGRepresentation(jpg)];
 			tex = [ [CCTexture2D alloc] initWithImage: png ];
+			tex.isRetina = isRetina;
 			[png release];
 			[jpg release];
 			
@@ -287,9 +289,11 @@ static CCTextureCache *sharedTextureCache;
 			
 			// prevents overloading the autorelease pool
 			NSString *fullpath = [CCFileUtils fullPathFromRelativePath: path ];
-
+			BOOL isRetina = [CCFileUtils isRetina: path];
+			
 			UIImage *image = [ [UIImage alloc] initWithContentsOfFile: fullpath ];
 			tex = [ [CCTexture2D alloc] initWithImage: image ];
+			tex.isRetina = isRetina;
 			[image release];
 			
 			if( tex )
@@ -304,6 +308,7 @@ static CCTextureCache *sharedTextureCache;
 #elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
 		else {
 			NSString *fullpath = [CCFileUtils fullPathFromRelativePath: path ];
+			BOOL isRetina = [CCFileUtils isRetina: path];
 
 			NSData *data = [[NSData alloc] initWithContentsOfFile:fullpath];
 			NSBitmapImageRep *image = [[NSBitmapImageRep alloc] initWithData:data];
@@ -424,6 +429,8 @@ static CCTextureCache *sharedTextureCache;
 	
 	// Split up directory and filename
 	NSString *fullpath = [CCFileUtils fullPathFromRelativePath:path];
+	BOOL isRetina = [CCFileUtils isRetina: path];
+	tex.isRetina = isRetina;
 	
 	NSData *nsdata = [[NSData alloc] initWithContentsOfFile:fullpath];
 	tex = [[CCTexture2D alloc] initWithPVRTCData:[nsdata bytes] level:0 bpp:bpp hasAlpha:alpha length:w];
@@ -453,6 +460,8 @@ static CCTextureCache *sharedTextureCache;
 	
 	// Split up directory and filename
 	NSString *fullpath = [CCFileUtils fullPathFromRelativePath:path];
+	BOOL isRetina = [CCFileUtils isRetina: path];
+	tex.isRetina = isRetina;
 	
 	tex = [[CCTexture2D alloc] initWithPVRFile: fullpath];
 	if( tex )

--- a/cocos2d/Support/CCFileUtils.h
+++ b/cocos2d/Support/CCFileUtils.h
@@ -41,6 +41,9 @@
  
  */
 +(NSString*) fullPathFromRelativePath:(NSString*) relPath;
+
+
++(BOOL) isRetina:(NSString*) relPath;
 @end
 
 /** loads a file into memory.

--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -140,6 +140,29 @@ NSString *ccRemoveHDSuffixFromFile( NSString *path )
 	return path;
 }
 
++(BOOL) isRetina:(NSString*) relPath
+{
+	NSAssert(relPath != nil, @"CCFileUtils: Invalid path");
+	
+	NSString *fullpath = nil;
+	
+	// only if it is not an absolute path
+	if( ! [relPath isAbsolutePath] )
+	{
+		NSString *file = [relPath lastPathComponent];
+		NSString *imageDirectory = [relPath stringByDeletingLastPathComponent];
+		
+		fullpath = [[NSBundle mainBundle] pathForResource:file
+												   ofType:nil
+											  inDirectory:imageDirectory];
+	}
+	
+	if (fullpath == nil)
+		fullpath = relPath;
+	
+	return !(fullpath == [self getDoubleResolutionImage:fullpath]) ;
+}
+
 +(NSString*) fullPathFromRelativePath:(NSString*) relPath
 {
 	NSAssert(relPath != nil, @"CCFileUtils: Invalid path");


### PR DESCRIPTION
Tiny change that will allow CCTexture2D to know, was it loaded for retina mode (from foo-hd.png) or not (from foo.png) when user asked it to load from foo.png

Can be usefull to decrease resources, if universal resources can be used for iPad/iPhone/iPhone retina.
Example: https://github.com/psineur/CCMenuAdvanced/commit/5a6815e9c80c3fc30d1877d643ce239386858c28

This is about issue #1118 , but without automatic upscaling, just give user a chance to do it manually, by knowing is texture loaded from hd resource or not.
Original Patrick's code taken from here: http://www.cocos2d-iphone.org/forum/topic/13935
