### PR TITLE
Fixed CCFileUtils bug ( issue #1179 ).

### DIFF
--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -150,11 +150,7 @@ NSString *ccRemoveHDSuffixFromFile( NSString *path )
 	if( ! [relPath isAbsolutePath] )
 	{
 		NSString *file = [relPath lastPathComponent];
-		NSString *imageDirectory = [relPath stringByDeletingLastPathComponent];
-		
-		fullpath = [[NSBundle mainBundle] pathForResource:file
-												   ofType:nil
-											  inDirectory:imageDirectory];
+		fullpath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:file];
 	}
 	
 	if (fullpath == nil)


### PR DESCRIPTION
Hello Riq!

When non-hd version of image isn't present it's impossible to load -hd version, even if it exists.
It looks odd, to have -hd and not have non-hd resource, but it happend to me today ;)

More info & ticket is here: http://code.google.com/p/cocos2d-iphone/issues/detail?id=1179
