### PR TITLE
CCTextureCache releases the returned texture in 'addImage' rather than autoreleasing.

### DIFF
--- a/cocos2d/CCTextureCache.m
+++ b/cocos2d/CCTextureCache.m
@@ -280,7 +280,7 @@ static CCTextureCache *sharedTextureCache;
 			else
 				CCLOG(@"cocos2d: Couldn't add image:%@ in CCTextureCache", path);
 			
-			[tex release];
+			[tex autorelease];
 		}
 		
 		else {
@@ -297,7 +297,7 @@ static CCTextureCache *sharedTextureCache;
 			else
 				CCLOG(@"cocos2d: Couldn't add image:%@ in CCTextureCache", path);
 			
-			[tex release];			
+			[tex autorelease];			
 		}
 
 		// Only in Mac

--- a/cocos2d/CCTextureCache.m
+++ b/cocos2d/CCTextureCache.m
@@ -317,7 +317,7 @@ static CCTextureCache *sharedTextureCache;
 			else
 				CCLOG(@"cocos2d: Couldn't add image:%@ in CCTextureCache", path);
 			
-			[tex release];			
+			[tex autorelease];			
 		}
 #endif // __MAC_OS_X_VERSION_MAX_ALLOWED
 


### PR DESCRIPTION
CCTextureCache's 'addImage' method currently releases the generated texture before returning it.

In a single-threaded application, this is no problem as the TextureCache itself keeps the retain count at 1. However, in a multithreaded environment, the TextureCache may be freed before the caller of addImage (or addImageAsync) receives the returned texture.

This fork simply autoreleases the texture prior to returning it.
