### PR TITLE
Implement CCRGBAProtocol for CCProgressTimer

### DIFF
--- a/cocos2d/CCProgressTimer.h
+++ b/cocos2d/CCProgressTimer.h
@@ -50,7 +50,7 @@ typedef enum {
  The progress can be Radial, Horizontal or vertical.
  @since v0.99.1
  */
-@interface CCProgressTimer : CCNode
+@interface CCProgressTimer : CCNode<CCRGBAProtocol>
 {
 	CCProgressTimerType	type_;
 	float				percentage_;

--- a/cocos2d/CCProgressTimer.m
+++ b/cocos2d/CCProgressTimer.m
@@ -119,6 +119,31 @@ const char kProgressTextureCoords = 0x1e;
 		type_ = newType;
 	}
 }
+
+#pragma mark CCRGBAProtocol implementation
+
+-(void)setColor:(ccColor3B)color
+{
+	[sprite_ setColor:color];
+	[self updateColor];
+}
+
+-(ccColor3B)color
+{
+	return sprite_.color;
+}
+
+-(GLubyte)opacity
+{
+	return sprite_.opacity;
+}
+
+-(void)setOpacity:(GLubyte)opacity
+{
+	[sprite_ setOpacity:opacity];
+	[self updateColor];
+}
+
 @end
 
 @implementation CCProgressTimer(Internal)
@@ -150,9 +175,9 @@ const char kProgressTextureCoords = 0x1e;
 	
 	ccColor4B color = { c3b.r, c3b.g, c3b.b, op };
 	if([sprite_.texture hasPremultipliedAlpha]){
-		color.r *= op/255;
-		color.g *= op/255;
-		color.b *= op/255;
+		color.r *= op/255.f;
+		color.g *= op/255.f;
+		color.b *= op/255.f;
 	}
 	
 	if(vertexData_){


### PR DESCRIPTION
Before this change, it was impossible to apply an action
like CCFadeIn or CCFadeOut to the 'sprite' property of
CCProgressTimer, because CCProgressTimer overrides the 'draw'
method.

With this change applied, we can now write

```
CCProgressTimer *ptimer = ...;
ptimer.opacity = 0;
[ptimer runAction:[CCFadeIn actionWithDuration:1.0]];
```

and it's going to work.

Signed-off-by: Alexei Sholik alcosholik@gmail.com
