### PR TITLE
assert on ccArrayDoubleCapacity

### DIFF
--- a/cocos2d/Support/ccCArray.h
+++ b/cocos2d/Support/ccCArray.h
@@ -87,7 +87,10 @@ static inline void ccArrayFree(ccArray *arr)
 static inline void ccArrayDoubleCapacity(ccArray *arr)
 {
 	arr->max *= 2;
-	arr->arr = (id*) realloc( arr->arr, arr->max * sizeof(id) );
+    id *newArr = (id *)realloc( arr->arr, arr->max * sizeof(id) );
+    // will fail when there's not enough memory
+    assert(newArr != NULL);
+	arr->arr = newArr;
 }
 
 /** Increases array capacity such that max >= num + extra. */


### PR DESCRIPTION
it checks that the realloc did actually worked (otherwise, arr->arr is set to a NULL pointer)
