### PR TITLE
Autowrap implementation for CCLabelBMFont

### DIFF
--- a/cocos2d/CCLabelBMFont.h
+++ b/cocos2d/CCLabelBMFont.h
@@ -69,10 +69,8 @@ typedef struct _BMFontPadding {
 	int bottom;
 } ccBMFontPadding;
 
-enum {
-	// how many characters are supported
-	kCCBMFontMaxChars = 2048, //256,
-};
+#define kCCBMFontMaxChars 65536
+#define kCCBMFontMaxLines 256
 
 /** CCBMFontConfiguration has parsed configuration of the the .fnt file
  @since v0.8
@@ -136,7 +134,7 @@ enum {
 @interface CCLabelBMFont : CCSpriteBatchNode <CCLabelProtocol, CCRGBAProtocol>
 {
 	// string to render
-	NSString		*string_;
+	NSMutableString     *string_;
 	
 	CCBMFontConfiguration	*configuration_;
 
@@ -144,6 +142,9 @@ enum {
 	GLubyte		opacity_;
 	ccColor3B	color_;
 	BOOL opacityModifyRGB_;
+    
+    int lineWidth_;
+    CCTextAlignment alignment_;
 }
 
 /** Purges the cached data.
@@ -160,6 +161,8 @@ enum {
 
 /** creates a BMFont label with an initial string and the FNT file */
 +(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile;
++(id) labelWithString:(NSString*)string width:(int)width alignment:(CCTextAlignment)alignment fntFile:(NSString*)fntFile;
+
 
 /** creates a BMFont label with an initial string and the FNT file
  @deprecated Will be removed in 1.0.1. Use "labelWithString" instead.
@@ -167,7 +170,7 @@ enum {
 +(id) bitmapFontAtlasWithString:(NSString*)string fntFile:(NSString*)fntFile DEPRECATED_ATTRIBUTE;
 
 /** init a BMFont label with an initial string and the FNT file */
--(id) initWithString:(NSString*)string fntFile:(NSString*)fntFile;
+-(id) initWithString:(NSString*)string width:(int)width alignment:(CCTextAlignment)alignment fntFile:(NSString*)fntFile;
 
 /** updates the font chars based on the string to render */
 -(void) createFontChars;

--- a/tests/LabelTest.m
+++ b/tests/LabelTest.m
@@ -13,6 +13,7 @@ static int sceneIdx=-1;
 static NSString *transitions[] = {
 	
 	@"LabelAtlasTest",
+	@"BitmapFontMultiLine",    
 	@"LabelAtlasColorTest",
 	@"Atlas3",
 	@"Atlas4",
@@ -20,7 +21,6 @@ static NSString *transitions[] = {
 	@"Atlas6",
 	@"AtlasBitmapColor",
 	@"AtlasFastBitmap",
-	@"BitmapFontMultiLine",
 	@"LabelsEmpty",
 	@"LabelBMFontHD",
 	@"LabelAtlasHD",
@@ -40,6 +40,8 @@ enum {
 	kTagBitmapAtlas1 = 1,
 	kTagBitmapAtlas2 = 2,
 	kTagBitmapAtlas3 = 3,
+    kTagBitmapAtlas4 = 4,
+    kTagBitmapAtlas5 = 5,
 };
 
 enum {
@@ -731,7 +733,10 @@ Class restartAction()
 		
 		
 		// Center
-		CCLabelBMFont *label2 = [CCLabelBMFont labelWithString:@"Multi line\nCenter" fntFile:@"bitmapFontTest3.fnt"];
+		CCLabelBMFont *label2 = [CCLabelBMFont labelWithString:@"Multi line autowrap center align lorem ipsum foobar withonelongwordthatcannotbewrapped"
+                                                         width:250
+                                                     alignment:CCTextAlignmentCenter
+                                                       fntFile:@"bitmapFontTest3.fnt"];
 		label2.anchorPoint = ccp(0.5f, 0.5f);
 		[self addChild:label2 z:0 tag:kTagBitmapAtlas2];
 
@@ -746,12 +751,33 @@ Class restartAction()
 
 		s = [label3 contentSize];
 		NSLog(@"content size: %.2fx%.2f", s.width, s.height);
+        
+        CCLabelBMFont *label4 = [CCLabelBMFont labelWithString:@"Multi line autowrap left align lorem ipsum foobar with\u00adone\u00adlong\u00adword\u00adthat\u00adhas\u00adsoft\u00adhyphen"
+                                                         width:250
+                                                     alignment:CCTextAlignmentLeft
+                                                       fntFile:@"bitmapFontTest3.fnt"];
+		label4.anchorPoint = ccp(0,1);
+		[self addChild:label4 z:0 tag:kTagBitmapAtlas4];
+        
+		s = [label4 contentSize];
+		NSLog(@"content size: %.2fx%.2f", s.width, s.height);        
 
-		
+        CCLabelBMFont *label5 = [CCLabelBMFont labelWithString:@"Multi line autowrap right align with-one-long-word-with-dashes"
+                                                         width:250
+                                                     alignment:CCTextAlignmentRight
+                                                       fntFile:@"bitmapFontTest3.fnt"];
+		label5.anchorPoint = ccp(1,0);
+		[self addChild:label5 z:0 tag:kTagBitmapAtlas5];
+        
+		s = [label5 contentSize];
+		NSLog(@"content size: %.2fx%.2f", s.width, s.height); 		
+        
 		s = [[CCDirector sharedDirector] winSize];	
 		label1.position = ccp( 0,0);
 		label2.position = ccp( s.width/2, s.height/2);
 		label3.position = ccp( s.width, s.height);
+        label4.position = ccp( 0, s.height);
+		label5.position = ccp( s.width, 0);        
 	}
 	
 	return self;


### PR DESCRIPTION
Here is the implementation of autowrap for CCLabelBMFont. I haven't done massive amounts of testing on this implementation but most of the common bugs are fixed. Text cases are in LabelTest, it runs on iPad Simulator at least. Most likely iPhone will be a bit messed up because the font was large and some numbers are hard coded in the test case, the implementation still works. It should also work on Mac.

The implementation goes through the characters one by one and inserts/replaces the line changing characters where needed and then creates sprites as before. Added benefit for counting the characters beforehand is that now CCTextAlignment can be used for CCLabelBMFont as well. Only one new function needs to be added to the API:

+(id) labelWithString:(NSString *)string width:(int)width alignment:(CCTextAlignment)alignment fntFile:(NSString *)fntFile

Please check this out and see if it can be used. In case you want me to develop it further that's fine too.
