### PR TITLE
CCTexture2D changes

### DIFF
--- a/cocos2d/CCTexture2D.h
+++ b/cocos2d/CCTexture2D.h
@@ -62,10 +62,6 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 #import <Availability.h>
 
-#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-#import <UIKit/UIKit.h>			// for UIImage
-#endif
-
 #import <Foundation/Foundation.h> //	for NSObject
 
 #import "Platforms/CCGL.h" // OpenGL stuff
@@ -177,12 +173,16 @@ Extensions to make it easy to create a CCTexture2D object from an image file.
 Note that RGBA type textures will have their alpha premultiplied - use the blending mode (GL_ONE, GL_ONE_MINUS_SRC_ALPHA).
 */
 @interface CCTexture2D (Image)
-/** Initializes a texture from a UIImage object */
+/**
+ @deprecated: Will be removed soon.
+ */
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-- (id) initWithImage:(UIImage *)uiImage;
-#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
-- (id) initWithImage:(CGImageRef)cgImage;
+- (id) initWithImage:(UIImage*)image;
 #endif
+/** Initializes a texture from a CGImageRef object
+ */
+- (id) initWithCGImage:(CGImageRef)image;
+
 @end
 
 /**
@@ -293,8 +293,8 @@ typedef struct _ccTexParams {
 @end
 
 @interface CCTexture2D (PixelFormat)
-/** sets the default pixel format for UIImages that contains alpha channel.
- If the UIImage contains alpha channel, then the options are:
+/** sets the default pixel format for CGImages that contains alpha channel.
+ If the CGImage contains alpha channel, then the options are:
 	- generate 32-bit textures: kCCTexture2DPixelFormat_RGBA8888 (default one)
 	- generate 16-bit textures: kCCTexture2DPixelFormat_RGBA4444
 	- generate 16-bit textures: kCCTexture2DPixelFormat_RGB5A1

--- a/cocos2d/CCTexture2D.m
+++ b/cocos2d/CCTexture2D.m
@@ -196,11 +196,15 @@ static CCTexture2DPixelFormat defaultAlphaPixelFormat_ = kCCTexture2DPixelFormat
 #pragma mark CCTexture2D - Image
 
 @implementation CCTexture2D (Image)
+
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-- (id) initWithImage:(UIImage *)uiImage
-#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
-- (id) initWithImage:(CGImageRef)CGImage
+- (id) initWithImage:(UIImage*)image
+{
+    return [self initWithCGImage:image.CGImage];
+}
 #endif
+
+- (id) initWithCGImage:(CGImageRef)CGImage
 {
 	NSUInteger				POTWide, POTHigh;
 	CGContextRef			context = nil;
@@ -214,12 +218,8 @@ static CCTexture2DPixelFormat defaultAlphaPixelFormat_ = kCCTexture2DPixelFormat
 	CGSize					imageSize;
 	CCTexture2DPixelFormat	pixelFormat;
 	
-#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-	CGImageRef	CGImage = uiImage.CGImage;
-#endif
-	
 	if(CGImage == NULL) {
-		CCLOG(@"cocos2d: CCTexture2D. Can't create Texture. UIImage is nil");
+		CCLOG(@"cocos2d: CCTexture2D. Can't create Texture. CGImageRef is nil");
 		[self release];
 		return nil;
 	}
@@ -684,11 +684,13 @@ static BOOL PVRHaveAlphaPremultiplied_ = NO;
 								width + point.x,	point.y,	0.0f,
 								point.x,			height  + point.y,	0.0f,
 								width + point.x,	height  + point.y,	0.0f };
-	
+
+	glDisableClientState(GL_COLOR_ARRAY);
 	glBindTexture(GL_TEXTURE_2D, name_);
 	glVertexPointer(3, GL_FLOAT, 0, vertices);
 	glTexCoordPointer(2, GL_FLOAT, 0, coordinates);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	glEnableClientState(GL_COLOR_ARRAY);
 }
 
 
@@ -702,11 +704,13 @@ static BOOL PVRHaveAlphaPremultiplied_ = NO;
 							rect.origin.x + rect.size.width,		rect.origin.y,							/*0.0f,*/
 							rect.origin.x,							rect.origin.y + rect.size.height,		/*0.0f,*/
 							rect.origin.x + rect.size.width,		rect.origin.y + rect.size.height,		/*0.0f*/ };
-	
+    
+	glDisableClientState(GL_COLOR_ARRAY);	
 	glBindTexture(GL_TEXTURE_2D, name_);
 	glVertexPointer(2, GL_FLOAT, 0, vertices);
 	glTexCoordPointer(2, GL_FLOAT, 0, coordinates);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	glEnableClientState(GL_COLOR_ARRAY);    
 }
 
 @end

--- a/cocos2d/CCTextureCache.m
+++ b/cocos2d/CCTextureCache.m
@@ -62,6 +62,7 @@ static NSOpenGLContext *auxGLcontext = nil;
 @synthesize selector = selector_;
 @synthesize target = target_;
 @synthesize data = data_;
+
 - (void) dealloc
 {
 	CCLOGINFO(@"cocos2d: deallocing %@", self);
@@ -272,7 +273,7 @@ static CCTextureCache *sharedTextureCache;
 						
 			UIImage *jpg = [[UIImage alloc] initWithContentsOfFile:fullpath];
 			UIImage *png = [[UIImage alloc] initWithData:UIImagePNGRepresentation(jpg)];
-			tex = [ [CCTexture2D alloc] initWithImage: png ];
+			tex = [ [CCTexture2D alloc] initWithCGImage: [png CGImage] ];
 			[png release];
 			[jpg release];
 			
@@ -284,37 +285,25 @@ static CCTextureCache *sharedTextureCache;
 			// autorelease prevents possible crash in multithreaded environments
 			[tex autorelease];
 		}
-		
+#endif		
 		else {
 			
 			// prevents overloading the autorelease pool
 			NSString *fullpath = [CCFileUtils fullPathFromRelativePath: path ];
-
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 			UIImage *image = [ [UIImage alloc] initWithContentsOfFile: fullpath ];
-			tex = [ [CCTexture2D alloc] initWithImage: image ];
-			[image release];
-			
-			if( tex )
-				[textures_ setObject: tex forKey:path];
-			else
-				CCLOG(@"cocos2d: Couldn't add image:%@ in CCTextureCache", path);
-			
-			// autorelease prevents possible crash in multithreaded environments
-			[tex autorelease];			
-		}
-
-		// Only in Mac
 #elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
-		else {
-			NSString *fullpath = [CCFileUtils fullPathFromRelativePath: path ];
-
-			NSData *data = [[NSData alloc] initWithContentsOfFile:fullpath];
+ 			NSData *data = [[NSData alloc] initWithContentsOfFile:fullpath];
 			NSBitmapImageRep *image = [[NSBitmapImageRep alloc] initWithData:data];
-			tex = [ [CCTexture2D alloc] initWithImage:[image CGImage]];
-			
-			[data release];
-			[image release];
+#endif
+            
+			tex = [ [CCTexture2D alloc] initWithCGImage: [image CGImage] ];
 
+#ifdef __MAC_OS_X_VERSION_MAX_ALLOWED
+			[data release];          
+#endif
+			[image release];
+			
 			if( tex )
 				[textures_ setObject: tex forKey:path];
 			else
@@ -323,8 +312,6 @@ static CCTextureCache *sharedTextureCache;
 			// autorelease prevents possible crash in multithreaded environments
 			[tex autorelease];			
 		}
-#endif // __MAC_OS_X_VERSION_MAX_ALLOWED
-
 	}
 	
 	[dictLock_ unlock];
@@ -344,15 +331,7 @@ static CCTextureCache *sharedTextureCache;
 		return tex;
 	}
 	
-#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-	// prevents overloading the autorelease pool
-	UIImage *image = [[UIImage alloc] initWithCGImage:imageref];
-	tex = [[CCTexture2D alloc] initWithImage: image];
-	[image release];
-
-#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
-	tex = [[CCTexture2D alloc] initWithImage: imageref];
-#endif
+	tex = [[CCTexture2D alloc] initWithCGImage: imageref];
 	
 	if(tex && key)
 		[textures_ setObject: tex forKey:key];

--- a/tests/Texture2dTest.h
+++ b/tests/Texture2dTest.h
@@ -54,6 +54,18 @@
 {}
 @end
 
+@interface TextureDrawAtPoint : TextureDemo
+{
+    CCTexture2D *tex;
+}
+@end
+
+@interface TextureDrawInRect : TextureDemo
+{
+    CCTexture2D *tex;
+}
+@end
+
 @interface TextureMipMap : TextureDemo
 {}
 @end

--- a/tests/Texture2dTest.m
+++ b/tests/Texture2dTest.m
@@ -45,6 +45,8 @@ static NSString *transitions[] = {
 	@"TextureJPEG",
 	@"TextureTIFF",
 	@"TextureGIF",
+    @"TextureDrawAtPoint",
+    @"TextureDrawInRect",    
 	@"TextureCGImage",
 	@"TexturePixelFormat",
 	@"TextureBlend",
@@ -271,6 +273,77 @@ Class restartAction()
 -(NSString *) title
 {
 	return @"GIF Test";
+}
+@end
+
+@implementation TextureDrawAtPoint
+-(void) onEnter
+{
+	[super onEnter];
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+	UIImage *image = [[UIImage alloc] initWithContentsOfFile:[CCFileUtils fullPathFromRelativePath: @"test_image.png" ]];
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+	NSString *fullpath = [CCFileUtils fullPathFromRelativePath:@"test_image.png"];
+	NSData *data = [NSData dataWithContentsOfFile:fullpath];
+	NSBitmapImageRep *image = [[NSBitmapImageRep alloc] initWithData:data];
+#endif
+	CGImageRef imageref = [image CGImage];
+    
+	tex = [[CCTexture2D alloc] initWithCGImage:imageref];
+	[image release];    
+}
+
+-(void) draw
+{
+	CGSize s = [[CCDirector sharedDirector] winSize];
+    [tex drawAtPoint:CGPointMake(s.width/2 - tex.contentSizeInPixels.width/2, s.height/2 - tex.contentSizeInPixels.height/2)];
+}
+
+-(void) onExit
+{
+    [super onExit];
+	[[CCTextureCache sharedTextureCache] dumpCachedTextureInfo];    
+}
+
+-(NSString *) title
+{
+	return @"Texture drawAtPoint Test";
+}
+@end
+
+@implementation TextureDrawInRect
+-(void) onEnter
+{
+	[super onEnter];
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+	UIImage *image = [[UIImage alloc] initWithContentsOfFile:[CCFileUtils fullPathFromRelativePath: @"test_image.png" ]];
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+	NSString *fullpath = [CCFileUtils fullPathFromRelativePath:@"test_image.png"];
+	NSData *data = [NSData dataWithContentsOfFile:fullpath];
+	NSBitmapImageRep *image = [[NSBitmapImageRep alloc] initWithData:data];
+#endif
+	CGImageRef imageref = [image CGImage];
+    
+	tex = [[CCTexture2D alloc] initWithCGImage:imageref];
+	[image release];    
+}
+
+-(void) draw
+{
+	CGSize s = [[CCDirector sharedDirector] winSize];
+    CGFloat side = MIN(s.width, s.height);
+    [tex drawInRect:CGRectMake((s.width - side)/2, (s.height - side)/2, side, side)];
+}
+
+-(void) onExit
+{
+    [super onExit];
+	[[CCTextureCache sharedTextureCache] dumpCachedTextureInfo];    
+}
+
+-(NSString *) title
+{
+	return @"Texture drawInRect Test";
 }
 @end
 


### PR DESCRIPTION
- Deprecated initWithImage, calls initWithCGImage.
- Added new initWithCGImage (same for iOS and Mac)
- Added glDisableClientState(GL_COLOR_ARRAY) to drawAtPoint and drawInRect.
- Added test cases for the functions drawAtPoint and drawInRect.
- Cleaned up some #ifdef branches that became useless with API change.
