### PR TITLE
CCTouchDispatcher setPriority implemented

### DIFF
--- a/cocos2d/Platforms/iOS/CCTouchDispatcher.h
+++ b/cocos2d/Platforms/iOS/CCTouchDispatcher.h
@@ -117,6 +117,7 @@ struct ccTouchHandlerHelperData {
  the higher the priority */
 -(void) setPriority:(int) priority forDelegate:(id) delegate;
 
+NSComparisonResult sortByPriority(id first, id second, void *context);
 @end
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED

--- a/cocos2d/Platforms/iOS/CCTouchDispatcher.m
+++ b/cocos2d/Platforms/iOS/CCTouchDispatcher.m
@@ -32,7 +32,6 @@
 #import "CCTouchDispatcher.h"
 #import "CCTouchHandler.h"
 
-
 @implementation CCTouchDispatcher
 
 @synthesize dispatchEvents;
@@ -184,29 +183,51 @@ static CCTouchDispatcher *sharedDispatcher = nil;
 
 #pragma mark Changing priority of added handlers
 
--(void) setPriority:(int) priority forDelegate:(id) delegate
+-(CCTouchHandler*) findHandler:(id)delegate
 {
-	NSAssert(NO, @"Set priority no implemented yet. Don't forget to report this bug!");
-//	if( delegate == nil )
-//		[NSException raise:NSInvalidArgumentException format:@"Got nil touch delegate"];
-//	
-//	CCTouchHandler *handler = nil;
-//	for( handler in touchHandlers )
-//		if( handler.delegate == delegate ) break;
-//	
-//	if( handler == nil )
-//		[NSException raise:NSInvalidArgumentException format:@"Touch delegate not found"];
-//	
-//	if( handler.priority != priority ) {
-//		handler.priority = priority;
-//		
-//		[handler retain];
-//		[touchHandlers removeObject:handler];
-//		[self addHandler:handler];
-//		[handler release];
-//	}
+	for( CCTouchHandler *handler in targetedHandlers ) {
+		if( handler.delegate == delegate ) {
+            return handler;
+		}
+	}
+	
+	for( CCTouchHandler *handler in standardHandlers ) {
+		if( handler.delegate == delegate ) {
+            return handler;
+        }
+	}
+    return nil;
 }
 
+NSComparisonResult sortByPriority(id first, id second, void *context)
+{
+    if (((CCTouchHandler*)first).priority < ((CCTouchHandler*)second).priority)
+        return NSOrderedAscending;
+    else if (((CCTouchHandler*)first).priority > ((CCTouchHandler*)second).priority)
+        return NSOrderedDescending;
+    else 
+        return NSOrderedSame;
+}
+
+-(void) rearrangeHandlers:(NSMutableArray*)array
+{
+    [array sortUsingFunction:sortByPriority context:nil];
+}
+
+-(void) setPriority:(int) priority forDelegate:(id) delegate
+{
+	NSAssert(delegate != nil, @"Got nil touch delegate!");
+	
+	CCTouchHandler *handler = nil;
+    handler = [self findHandler:delegate];
+    
+    NSAssert(handler != nil, @"Delegate not found!");    
+    
+    handler.priority = priority;
+    
+    [self rearrangeHandlers:targetedHandlers];
+    [self rearrangeHandlers:standardHandlers];
+}
 
 //
 // dispatch events

--- a/tests/MenuTest.m
+++ b/tests/MenuTest.m
@@ -23,7 +23,10 @@ enum {
 	
 		[CCMenuItemFont setFontSize:30];
 		[CCMenuItemFont setFontName: @"Courier New"];
-
+        
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+        self.isTouchEnabled = YES;
+#endif
 		// Font Item
 		
 		CCSprite *spriteNormal = [CCSprite spriteWithFile:@"menuitemsprite.png" rect:CGRectMake(0,23*2,115,23)];
@@ -89,6 +92,30 @@ enum {
 	return self;
 }
 
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+-(void) registerWithTouchDispatcher
+{
+	[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:self priority:kCCMenuTouchPriority+1 swallowsTouches:YES];
+}
+
+-(BOOL) ccTouchBegan:(UITouch *)touch withEvent:(UIEvent *)event
+{
+	return YES;
+}
+
+-(void) ccTouchEnded:(UITouch *)touch withEvent:(UIEvent *)event
+{
+}
+
+-(void) ccTouchCancelled:(UITouch *)touch withEvent:(UIEvent *)event
+{
+}
+
+-(void) ccTouchMoved:(UITouch *)touch withEvent:(UIEvent *)event
+{
+}
+
+#endif
 -(void) dealloc
 {
 	[disabledItem release];
@@ -105,7 +132,20 @@ enum {
 	[(CCLayerMultiplex*)parent_ switchTo:3];
 }
 
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+-(void) allowTouches
+{
+    [[CCTouchDispatcher sharedDispatcher] setPriority:kCCMenuTouchPriority+1 forDelegate:self];
+    [self unscheduleAllSelectors];
+}
+#endif
+
 -(void) menuCallbackDisabled:(id) sender {
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+    // hijack all touch events for 5 seconds
+    [[CCTouchDispatcher sharedDispatcher] setPriority:kCCMenuTouchPriority-1 forDelegate:self];
+    [self schedule:@selector(allowTouches) interval:5.0f];
+#endif
 }
 
 -(void) menuCallbackEnable:(id) sender {


### PR DESCRIPTION
CCTouchDispatcher setPriority working, test case is in MenuTest where pressing item 0123456789 will disable touches for 5 seconds.

Priority currently doesn't work very intuitively, lower value means higher priority. This is in original code and I didn't want to change it as it might have unexpected results.
