### PR TITLE
added the facility to overide resource loading to a custom NSBundle

### DIFF
--- a/cocos2d/Support/CCFileUtils.h
+++ b/cocos2d/Support/CCFileUtils.h
@@ -42,6 +42,14 @@
  
  */
 +(NSString*) fullPathFromRelativePath:(NSString*) relPath;
+
+/** Sets the bundle that is used to load resources from the filesystem.
+ 
+ The default bundle is [NSBundle mainBundle]. This can be overriden to specify a custom bundle to load from.
+ 
+ */
++ (void)setBundle:(NSBundle*)bundle;
+
 @end
 
 /** loads a file into memory.

--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -32,6 +32,7 @@
 #import "../ccConfig.h"
 
 static NSFileManager *__localFileManager=nil;
+static NSBundle *__bundle=nil;
 
 // 
 NSInteger ccLoadFileIntoMemory(const char *filename, unsigned char **out) 
@@ -94,8 +95,14 @@ NSString *ccRemoveHDSuffixFromFile( NSString *path )
 
 +(void) initialize
 {
-	if( self == [CCFileUtils class] )
+	if( self == [CCFileUtils class] ) {
 		__localFileManager = [[NSFileManager alloc] init];
+    __bundle = [NSBundle mainBundle];
+  }
+}
+
++ (void)setBundle:(NSBundle*)bundle {
+  __bundle = bundle;
 }
 
 +(NSString*) getDoubleResolutionImage:(NSString*)path
@@ -153,9 +160,9 @@ NSString *ccRemoveHDSuffixFromFile( NSString *path )
 		NSString *file = [relPath lastPathComponent];
 		NSString *imageDirectory = [relPath stringByDeletingLastPathComponent];
 		
-		fullpath = [[NSBundle mainBundle] pathForResource:file
-												   ofType:nil
-											  inDirectory:imageDirectory];
+		fullpath = [__bundle pathForResource:file
+                                  ofType:nil
+                             inDirectory:imageDirectory];
 	}
 	
 	if (fullpath == nil)

--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -101,8 +101,13 @@ NSString *ccRemoveHDSuffixFromFile( NSString *path )
   }
 }
 
+- (void)dealloc {
+  [__bundle release];
+  [super dealloc];
+}
+
 + (void)setBundle:(NSBundle*)bundle {
-  __bundle = bundle;
+  __bundle = [bundle retain];
 }
 
 +(NSString*) getDoubleResolutionImage:(NSString*)path

--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -97,7 +97,7 @@ NSString *ccRemoveHDSuffixFromFile( NSString *path )
 {
 	if( self == [CCFileUtils class] ) {
 		__localFileManager = [[NSFileManager alloc] init];
-    __bundle = [NSBundle mainBundle];
+    __bundle = [[NSBundle mainBundle] retain];
   }
 }
 
@@ -107,6 +107,9 @@ NSString *ccRemoveHDSuffixFromFile( NSString *path )
 }
 
 + (void)setBundle:(NSBundle*)bundle {
+  if (__bundle) {
+    [__bundle release];
+  }
   __bundle = [bundle retain];
 }
 


### PR DESCRIPTION
Hi guys,

We had a requirement to be able to load resources from a custom location outside of the main application bundle on a mac, this is good for level editors and the like.

I've added a method that sets the bundle that CCFIleUtils pulls from. By default this is of course [NSBundle mainBundle] but this can now be overridden using:

[CCFileUtils setBundle:_bundle_];

All the best and thanks for doing such a good job on the project.

Nick
