### PR TITLE
Change converting touch location view to OpenGL view.

### DIFF
--- a/cocos2d/CCMenu.m
+++ b/cocos2d/CCMenu.m
@@ -150,7 +150,7 @@ enum {
 
 -(CCMenuItem *) itemForTouch: (UITouch *) touch
 {
-	CGPoint touchLocation = [touch locationInView: [touch view]];
+	CGPoint touchLocation = [touch locationInView: [[CCDirector sharedDirector] openGLView]];
 	touchLocation = [[CCDirector sharedDirector] convertToGL: touchLocation];
 	
 	CCMenuItem* item;

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -903,14 +903,14 @@
 
 - (CGPoint)convertTouchToNodeSpace:(UITouch *)touch
 {
-	CGPoint point = [touch locationInView: [touch view]];
+	CGPoint point = [touch locationInView: [[CCDirector sharedDirector] openGLView]];
 	point = [[CCDirector sharedDirector] convertToGL: point];
 	return [self convertToNodeSpace:point];
 }
 
 - (CGPoint)convertTouchToNodeSpaceAR:(UITouch *)touch
 {
-	CGPoint point = [touch locationInView: [touch view]];
+	CGPoint point = [touch locationInView: [[CCDirector sharedDirector] openGLView]];
 	point = [[CCDirector sharedDirector] convertToGL: point];
 	return [self convertToNodeSpaceAR:point];
 }


### PR DESCRIPTION
If you create a Cocos2d applications in the complex UIView hierarchy, UITouch's "view" method returns a GLView not always. 
Next line, locations are converted for GLView.
So, please specify explicit the GLView.
