### PR TITLE
Remove the previous registered BGM fading before new BGM fading.

### DIFF
--- a/CocosDenshion/CocosDenshionExtras/CDXPropertyModifierAction.m
+++ b/CocosDenshion/CocosDenshionExtras/CDXPropertyModifierAction.m
@@ -94,6 +94,7 @@
 {
 	//Background music is mapped to the left "channel"
 	CDLongAudioSource *player = [[CDAudioManager sharedManager] audioSourceForChannel:kASC_Left];
+        [[CCActionManager sharedManager] removeAllActionsFromTarget:player];
 	CDLongAudioSourceFader* fader = [[CDLongAudioSourceFader alloc] init:player interpolationType:curve startVal:player.volume endVal:endVol];
 	[fader setStopTargetWhenComplete:stop];
 	//Create a property modifier action to wrap the fader 


### PR DESCRIPTION
When you add a new BGM fading before the end of previous BGM fading, they are running at double.
Since this is likely to cause unintended behavior.
So, please remove the old BGM fading before adding a new BGM fading.
