### PR TITLE
"CCARRAY_FOREACH" has conflict of  variable identifier

### DIFF
--- a/cocos2d/Support/CCArray.h
+++ b/cocos2d/Support/CCArray.h
@@ -39,7 +39,7 @@
 
 #define CCARRAY_FOREACH(__array__, __object__)												\
 if (__array__ && __array__->data->num > 0)													\
-for(id *__arr__ = __array__->data->__arr__, *end = __array__->data->__arr__ + __array__->data->num-1;	\
+for(id *__arr__ = __array__->data->arr, *end = __array__->data->arr + __array__->data->num-1;	\
 	__arr__ <= end && ((__object__ = *__arr__) != nil || true);										\
 	__arr__++)
 

--- a/cocos2d/Support/CCArray.h
+++ b/cocos2d/Support/CCArray.h
@@ -39,9 +39,9 @@
 
 #define CCARRAY_FOREACH(__array__, __object__)												\
 if (__array__ && __array__->data->num > 0)													\
-for(id *arr = __array__->data->arr, *end = __array__->data->arr + __array__->data->num-1;	\
-	arr <= end && ((__object__ = *arr) != nil || true);										\
-	arr++)
+for(id *__arr__ = __array__->data->__arr__, *end = __array__->data->__arr__ + __array__->data->num-1;	\
+	__arr__ <= end && ((__object__ = *__arr__) != nil || true);										\
+	__arr__++)
 
 @interface CCArray : NSObject <NSFastEnumeration, NSCoding, NSCopying>
 {


### PR DESCRIPTION
Hi
It tends to write the following codes. 

CCArray *arr = [CCArray array];
CCNode *node;

CCARRAY_FOREACH(self.children, node) {
  if (true) {
    [arr addObject:node];
  }
}

However, this is build error!
Because, "CCARRAY_FOREACH" has variable identifier "_arr".
"_arr" is a popular variable identifier.

I send corrected code. please merge it.
thanks.
