### PR TITLE
fixed #1192

### DIFF
--- a/cocos2d/CCMenuItem.h
+++ b/cocos2d/CCMenuItem.h
@@ -187,17 +187,19 @@
  */
 @interface CCMenuItemFont : CCMenuItemLabel
 {
+	int fontSize_;
+	NSString *fontName_;
 }
-/** set font size */
+/** set default font size */
 +(void) setFontSize: (int) s;
 
-/** get font size */
+/** get default font size */
 +(int) fontSize;
 
-/** set the font name */
+/** set default font name */
 +(void) setFontName: (NSString*) n;
 
-/** get the font name */
+/** get default font name */
 +(NSString*) fontName;
 
 /** creates a menu item from a string without target/selector. To be used with CCMenuItemToggle */
@@ -208,6 +210,18 @@
 
 /** initializes a menu item from a string with a target/selector */
 -(id) initFromString: (NSString*) value target:(id) r selector:(SEL) s;
+
+/** set font size */
+-(void) setFontSize: (int) s;
+
+/** get font size */
+-(int) fontSize;
+
+/** set the font name */
+-(void) setFontName: (NSString*) n;
+
+/** get the font name */
+-(NSString*) fontName;
 
 #if NS_BLOCKS_AVAILABLE
 /** creates a menu item from a string with the specified block.

--- a/cocos2d/CCMenuItem.m
+++ b/cocos2d/CCMenuItem.m
@@ -373,7 +373,10 @@ const uint32_t	kZoomActionTag = 0xc0c05002;
 -(id) initFromString: (NSString*) value target:(id) rec selector:(SEL) cb
 {
 	NSAssert( [value length] != 0, @"Value length must be greater than 0");
-	
+
+	[self setFontName:_fontName];
+	[self setFontSize:_fontSize];
+
 	CCLabelTTF *label = [CCLabelTTF labelWithString:value fontName:_fontName fontSize:_fontSize];
 
 	if((self=[super initWithLabel:label target:rec selector:cb]) ) {
@@ -381,6 +384,32 @@ const uint32_t	kZoomActionTag = 0xc0c05002;
 	}
 	
 	return self;
+}
+
+-(void) recreateLabel {
+	CCLabelTTF *label = [CCLabelTTF labelWithString:[label_ string] fontName:fontName_ fontSize:fontSize_];
+	self.label = label;
+}
+
+-(void) setFontSize: (int) s {
+	fontSize_ = s;
+	[self recreateLabel];
+}
+
+-(int) fontSize {
+	return fontSize_;
+}
+
+-(void) setFontName: (NSString*) n {
+	if (fontName_) {
+		[fontName_ release];
+	}
+	fontName_ = [n copy];
+	[self recreateLabel];
+}
+
+-(NSString*) fontName {
+	return fontName_;
 }
 
 #if NS_BLOCKS_AVAILABLE


### PR DESCRIPTION
Issue: http://code.google.com/p/cocos2d-iphone/issues/detail?id=1192

Example of usage:

```
// set default font name and size
[CCMenuItemFont setFontName:@"Marker Felt"];
[CCMenuItemFont setFontSize:32];

// create new item
CCMenuItemFont *item = [CCMenuItemFont itemFromString:@"Start" target:self selector:@selector(itemSelected)];

// set font name and size only for this item
[item setFontName:@"Verdana"];
[item setFontSize:12];

CCMenu *menu = [CCMenu menuWithItems:item, nil];
menu.position = ccp(size.width/2, size.height/2);
```
