### PR TITLE
Fixed leak in [CCTMXMapInfo parseXMLFile]. Issue #1197.

### DIFF
--- a/cocos2d/CCTMXXMLParser.m
+++ b/cocos2d/CCTMXXMLParser.m
@@ -164,8 +164,9 @@
 
 - (void) parseXMLFile:(NSString *)xmlFilename
 {
-	NSURL *url = [NSURL fileURLWithPath:[CCFileUtils fullPathFromRelativePath:xmlFilename] ];
-	NSXMLParser *parser = [[NSXMLParser alloc] initWithContentsOfURL:url];
+  NSURL *url = [NSURL fileURLWithPath:[CCFileUtils fullPathFromRelativePath:xmlFilename] ];
+  NSData *data = [NSData dataWithContentsOfURL:url];
+  NSXMLParser *parser = [[NSXMLParser alloc] initWithData:data];
 
 	// we'll do the parsing
 	[parser setDelegate:self];


### PR DESCRIPTION
Fixed the memory leak described in issue 1197 (http://code.google.com/p/cocos2d-iphone/issues/detail?id=1197).
