### PR TITLE
Prevent invisible menus from responding to touches

### DIFF
--- a/cocos2d/CCMenu.m
+++ b/cocos2d/CCMenu.m
@@ -174,6 +174,10 @@ enum {
 	if( state_ != kCCMenuStateWaiting || !visible_ )
 		return NO;
 	
+	for( CCNode *c = self.parent; c != nil; c = c.parent )
+		if( c.visible == NO )
+			return NO;
+
 	selectedItem_ = [self itemForTouch:touch];
 	[selectedItem_ selected];
 	


### PR DESCRIPTION
Make sure menus that are not visible because one of their ancestor nodes are invisible do not respond to touches.
