### PR TITLE
Fix for Intermittent Mac Audio Glitches

### DIFF
--- a/CocosDenshion/CocosDenshion/CDOpenALSupport.m
+++ b/CocosDenshion/CocosDenshion/CDOpenALSupport.m
@@ -88,6 +88,8 @@ void* CDloadWaveAudioData(CFURLRef inFileURL, ALsizei *outDataSize, ALenum *outD
 	theData = malloc(dataSize);
 	if (theData)
 	{
+		memset(theData, 0, dataSize);
+
 		AudioFileReadBytes(afid, false, 0, &dataSize, theData);
 		if(err == noErr)
 		{
@@ -195,6 +197,8 @@ void* CDloadCafAudioData(CFURLRef inFileURL, ALsizei *outDataSize, ALenum *outDa
 	theData = malloc(dataSize);
 	if (theData)
 	{
+		memset(theData, 0, dataSize);
+
 		AudioBufferList		theDataBuffer;
 		theDataBuffer.mNumberBuffers = 1;
 		theDataBuffer.mBuffers[0].mDataByteSize = dataSize;


### PR DESCRIPTION
This fixes audio glitching we were experiencing on the mac, but might also affect the iPhone. Zero'ing out the data field before use resolved the issue for my projects.
