### PR TITLE
Scaling of low-res images on Retina devices

### DIFF
--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -567,8 +567,8 @@ typedef struct _KerningHashElement
 		}
 		
 		float yOffset = configuration_->commonHeight_ - fontDef.yOffset;
-        CGPoint fontPos = ccp( (float)nextFontPositionX + fontDef.xOffset + fontDef.rect.size.width*0.5f + kerningAmount, (float)nextFontPositionY + yOffset - rect.size.height*0.5f );
-        fontChar.position = CC_POINT_PIXELS_TO_POINTS(fontPos);
+		CGPoint fontPos = ccp( (float)nextFontPositionX + fontDef.xOffset + fontDef.rect.size.width*0.5f + kerningAmount, (float)nextFontPositionY + yOffset - rect.size.height*0.5f );
+		fontChar.position = CC_POINT_TEXTURE_PIXELS_TO_POINTS(self.texture.resolutionType, fontPos);
 
 		// update kerning
 		nextFontPositionX += configuration_->BMFontArray_[c].xAdvance + kerningAmount;
@@ -591,7 +591,7 @@ typedef struct _KerningHashElement
 	tmpSize.width = longestLine;
 	tmpSize.height = totalHeight;
 
-	[self setContentSize:CC_SIZE_PIXELS_TO_POINTS(tmpSize)];
+	[self setContentSize:CC_SIZE_TEXTURE_PIXELS_TO_POINTS(self.texture.resolutionType, tmpSize)];
 }
 
 #pragma mark LabelBMFont - CCLabelProtocol protocol

--- a/cocos2d/CCSprite.h
+++ b/cocos2d/CCSprite.h
@@ -293,7 +293,10 @@ typedef enum {
 /** updates the texture rect of the CCSprite in points.
  */
 -(void) setTextureRect:(CGRect) rect;
-/** updates the texture rect, rectRotated and untrimmed size of the CCSprite in pixels
+/** updates the texture rect, rectRotated and untrimmed size of the CCSprite in points
+ */
+-(void) setTextureRect:(CGRect)rect rotated:(BOOL)rotated untrimmedSize:(CGSize)size;
+/** updates the texture rect, rectRotated and untrimmed size of the CCSprite in texture pixels
  */
 -(void) setTextureRectInPixels:(CGRect)rect rotated:(BOOL)rotated untrimmedSize:(CGSize)size;
 

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -311,16 +311,22 @@ struct transformValues_ {
 
 -(void) setTextureRect:(CGRect)rect
 {
-	CGRect rectInPixels = CC_RECT_POINTS_TO_PIXELS( rect );
-	[self setTextureRectInPixels:rectInPixels rotated:NO untrimmedSize:rectInPixels.size];
+	[self setTextureRect:rect rotated:NO untrimmedSize:rect.size];
 }
 
 -(void) setTextureRectInPixels:(CGRect)rectInPixels rotated:(BOOL)rotated untrimmedSize:(CGSize)untrimmedSizeInPixels
 {
-	rect_ = CC_RECT_PIXELS_TO_POINTS( rectInPixels );
-    rectInPixels_ = rectInPixels;
+	ccResolutionType rt = self.texture.resolutionType;
+	CGRect rect = CC_RECT_TEXTURE_PIXELS_TO_POINTS( rt, rectInPixels );
+	CGSize untrimmedSize = CC_SIZE_TEXTURE_PIXELS_TO_POINTS( rt, untrimmedSizeInPixels );
+	[self setTextureRect:rect rotated:rotated untrimmedSize:untrimmedSize];
+}
+
+-(void) setTextureRect:(CGRect)rect rotated:(BOOL)rotated untrimmedSize:(CGSize)untrimmedSize
+{
+	rect_ = rect;
+	rectInPixels_ = CC_RECT_POINTS_TO_TEXTURE_PIXELS( self.texture.resolutionType, rect );
 	rectRotated_ = rotated;
-    CGSize untrimmedSize = CC_SIZE_PIXELS_TO_POINTS(untrimmedSizeInPixels);
 
     [self setContentSize:untrimmedSize];
 	[self updateTextureCoords:rectInPixels_];
@@ -904,7 +910,7 @@ struct transformValues_ {
 	// update rect
 	rectRotated_ = frame.rotated;
 
-	[self setTextureRectInPixels:frame.rectInPixels rotated:rectRotated_ untrimmedSize:frame.originalSizeInPixels];
+	[self setTextureRect:frame.rect rotated:rectRotated_ untrimmedSize:frame.originalSize];
 }
 
 -(void) setDisplayFrameWithAnimationName: (NSString*) animationName index:(int) frameIndex

--- a/cocos2d/CCSpriteFrame.h
+++ b/cocos2d/CCSpriteFrame.h
@@ -52,7 +52,7 @@
 /** rect of the frame in points. If it is updated, then rectInPixels will be updated too. */
 @property (nonatomic,readwrite) CGRect rect;
 
-/** rect of the frame in pixels. If it is updated, then rect (points) will be udpated too. */
+/** rect of the frame in texture pixels. If it is updated, then rect (points) will be updated too. */
 @property (nonatomic,readwrite) CGRect rectInPixels;
 
 /** whether or not the rect of the frame is rotated ( x = x+width, y = y+height, width = height, height = width ) */
@@ -61,10 +61,13 @@
 /** offset of the frame in points */
 @property (nonatomic,readwrite) CGPoint offset;
 
-/** offset of the frame in pixels */
+/** offset of the frame in texture pixels */
 @property (nonatomic,readwrite) CGPoint offsetInPixels;
 
-/** original size of the trimmed image in pixels */
+/** original size of the trimmed image in points */
+@property (nonatomic,readwrite) CGSize originalSize;
+
+/** original size of the trimmed image in texture pixels */
 @property (nonatomic,readwrite) CGSize originalSizeInPixels;
 
 /** texture of the frame */

--- a/cocos2d/CCSpriteFrame.m
+++ b/cocos2d/CCSpriteFrame.m
@@ -27,11 +27,18 @@
 
 #import "CCTextureCache.h"
 #import "CCSpriteFrame.h"
+#import "CCFileUtils.h"
 #import "ccMacros.h"
+
+@interface CCSpriteFrame () {
+	ccResolutionType resolutionType_;
+}
+@property (nonatomic,readonly) ccResolutionType resolutionType;
+@end
 
 @implementation CCSpriteFrame
 @synthesize offsetInPixels = offsetInPixels_, offset = offset_;
-@synthesize originalSizeInPixels = originalSizeInPixels_;
+@synthesize originalSizeInPixels = originalSizeInPixels_, originalSize = originalSize_;
 @synthesize textureFilename = textureFilename_;
 @synthesize rotated = rotated_;
 
@@ -72,11 +79,13 @@
 	if( (self=[super init]) )
     {
 		self.texture = texture;
+		ccResolutionType rt = texture.resolutionType;
 		rectInPixels_ = rect;
-		rect_ = CC_RECT_PIXELS_TO_POINTS( rect );
+		rect_ = CC_RECT_TEXTURE_PIXELS_TO_POINTS( rt, rect );
 		offsetInPixels_ = offset;
-        offset_ = CC_POINT_PIXELS_TO_POINTS( offsetInPixels_ );
+        offset_ = CC_POINT_TEXTURE_PIXELS_TO_POINTS( rt, offsetInPixels_ );
 		originalSizeInPixels_ = originalSize;
+        originalSize_ = CC_SIZE_TEXTURE_PIXELS_TO_POINTS( rt, originalSize );
         rotated_ = rotated;
 	}
 	return self;	
@@ -88,11 +97,13 @@
     {
 		texture_ = nil;
 		textureFilename_ = [filename copy];
+		[CCFileUtils fullPathFromRelativePath:textureFilename_ resolutionType:&resolutionType_];
 		rectInPixels_ = rect;
-		rect_ = CC_RECT_PIXELS_TO_POINTS( rect );
+		rect_ = CC_RECT_TEXTURE_PIXELS_TO_POINTS( resolutionType_, rect );
 		offsetInPixels_ = offset;
-        offset_ = CC_POINT_PIXELS_TO_POINTS( offsetInPixels_ );
+        offset_ = CC_POINT_TEXTURE_PIXELS_TO_POINTS( resolutionType_, offsetInPixels_ );
 		originalSizeInPixels_ = originalSize;
+        originalSize_ = CC_SIZE_TEXTURE_PIXELS_TO_POINTS( resolutionType_, originalSize );
         rotated_ = rotated;
 	}
 	return self;	
@@ -134,28 +145,33 @@
 	return rectInPixels_;
 }
 
+-(ccResolutionType) resolutionType
+{
+	return (texture_ ? texture_.resolutionType : resolutionType_);
+}
+
 -(void) setRect:(CGRect)rect
 {
 	rect_ = rect;
-	rectInPixels_ = CC_RECT_POINTS_TO_PIXELS( rect_ );
+	rectInPixels_ = CC_RECT_POINTS_TO_TEXTURE_PIXELS( self.resolutionType, rect_ );
 }
 
 -(void) setRectInPixels:(CGRect)rectInPixels
 {
 	rectInPixels_ = rectInPixels;
-	rect_ = CC_RECT_PIXELS_TO_POINTS( rectInPixels_ );
+	rect_ = CC_RECT_TEXTURE_PIXELS_TO_POINTS( self.resolutionType, rectInPixels_ );
 }
 
 -(void) setOffset:(CGPoint)offsets
 {
     offset_ = offsets;
-    offsetInPixels_ = CC_POINT_POINTS_TO_PIXELS( offset_ );
+    offsetInPixels_ = CC_POINT_POINTS_TO_TEXTURE_PIXELS( self.resolutionType, offset_ );
 }
 
 -(void) setOffsetInPixels:(CGPoint)offsetInPixels
 {
     offsetInPixels_ = offsetInPixels;
-    offset_ = CC_POINT_PIXELS_TO_POINTS( offsetInPixels_ );
+    offset_ = CC_POINT_TEXTURE_PIXELS_TO_POINTS( self.resolutionType, offsetInPixels_ );
 }
 
 -(void) setTexture:(CCTexture2D *)texture

--- a/cocos2d/CCTexture2D.m
+++ b/cocos2d/CCTexture2D.m
@@ -196,10 +196,7 @@ static CCTexture2DPixelFormat defaultAlphaPixelFormat_ = kCCTexture2DPixelFormat
 
 -(CGSize) contentSize
 {
-	CGSize ret;
-	ret.width = size_.width / CC_CONTENT_SCALE_FACTOR();
-	ret.height = size_.height / CC_CONTENT_SCALE_FACTOR();
-	
+	CGSize ret = CC_SIZE_TEXTURE_PIXELS_TO_POINTS(self.resolutionType, size_);
 	return ret;
 }
   

--- a/cocos2d/ccMacros.h
+++ b/cocos2d/ccMacros.h
@@ -265,6 +265,27 @@ CGSizeMake( (__pixels__).width / CC_CONTENT_SCALE_FACTOR(), (__pixels__).height 
 #define CC_SIZE_POINTS_TO_PIXELS(__points__)																		\
 CGSizeMake( (__points__).width * CC_CONTENT_SCALE_FACTOR(), (__points__).height * CC_CONTENT_SCALE_FACTOR())
 
+#define CC_IS_RESOLUTION_TYPE_MISMATCHED(__res__) \
+((__res__) == kCCResolutionStandard && CC_CONTENT_SCALE_FACTOR() == 2)
+
+#define CC_RECT_TEXTURE_PIXELS_TO_POINTS(__res__,__pixels__) \
+(CC_IS_RESOLUTION_TYPE_MISMATCHED(__res__) ? (__pixels__) : CC_RECT_PIXELS_TO_POINTS(__pixels__))
+
+#define CC_RECT_POINTS_TO_TEXTURE_PIXELS(__res__,__points__) \
+(CC_IS_RESOLUTION_TYPE_MISMATCHED(__res__) ? (__points__) : CC_RECT_POINTS_TO_PIXELS(__points__))
+
+#define CC_POINT_TEXTURE_PIXELS_TO_POINTS(__res__,__pixels__) \
+(CC_IS_RESOLUTION_TYPE_MISMATCHED(__res__) ? (__pixels__) : CC_POINT_PIXELS_TO_POINTS(__pixels__))
+
+#define CC_POINT_POINTS_TO_TEXTURE_PIXELS(__res__,__points__) \
+(CC_IS_RESOLUTION_TYPE_MISMATCHED(__res__) ? (__points__) : CC_POINT_POINTS_TO_PIXELS(__points__))
+
+#define CC_SIZE_TEXTURE_PIXELS_TO_POINTS(__res__,__pixels__) \
+(CC_IS_RESOLUTION_TYPE_MISMATCHED(__res__) ? (__pixels__) : CC_SIZE_PIXELS_TO_POINTS(__pixels__))
+
+#define CC_SIZE_POINTS_TO_TEXTURE_PIXELS(__res__,__points__) \
+(CC_IS_RESOLUTION_TYPE_MISMATCHED(__res__) ? (__points__) : CC_SIZE_POINTS_TO_PIXELS(__points__))
+
 
 #elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
 


### PR DESCRIPTION
This patch attempts to solve [#1118](http://code.google.com/p/cocos2d-iphone/issues/detail?id=1118) in a reasonably clean way. The main idea is to separate the concept of screen pixels from texture data pixels. By not assuming they always have a 1:1 ratio to each other (and thus a 2:1 ratio to retina points), low-res images can be given a different ratio to keep them at a constant physical size.

I've done this with a set of macros that bypass point-pixel unit conversion on low-res textures, giving their pixels a 1:1 ratio to points.

Sprites, sprite sheets, and bitmap fonts have been modified to use the new macros and seem to be working for what I'm using them for, but I've almost certainly missed some things. I only took a cursory look at TMX maps and haven't implemented anything for them yet.

Thanks for the great framework!
