### PR TITLE
Patch for issue 1216, useSelfRender should be called on all descendants o

### DIFF
--- a/cocos2d/CCSpriteBatchNode.m
+++ b/cocos2d/CCSpriteBatchNode.m
@@ -215,10 +215,11 @@ static 	SEL selUpdate = NULL;
 -(void)removeAllChildrenWithCleanup:(BOOL)doCleanup
 {
 	// Invalidate atlas index. issue #569
-	[children_ makeObjectsPerformSelector:@selector(useSelfRender)];
-	
+	// useSelfRender should be performed on all descendants. issue #1216
+	[descendants_ makeObjectsPerformSelector:@selector(useSelfRender)];
+        
 	[super removeAllChildrenWithCleanup:doCleanup];
-	
+
 	[descendants_ removeAllObjects];
 	[textureAtlas_ removeAllQuads];
 }


### PR DESCRIPTION
Patch for issue 1216, useSelfRender should be called on all descendants of a batchnode, not only the children. 

modified
CCSpriteBatchNode, removeAllChildren:
