### PR TITLE
Fix for issue 630, added repeat and delay to scheduleSelector

### DIFF
--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -474,6 +474,11 @@ enum {
  */
 -(void) schedule:(SEL)selector interval:(ccTime)interval repeat: (uint) repeat delay:(ccTime) delay;
 
+/**
+ Schedules a selector that runs only once, with a delay of 0 or larger 
+*/
+- (void) scheduleOnce:(SEL) selector delay:(ccTime) delay;
+
 /** unschedules a custom selector.*/
 -(void) unschedule: (SEL) s;
 

--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -468,6 +468,12 @@ enum {
  If the selector is already scheduled, then the interval parameter will be updated without scheduling it again.
  */
 -(void) schedule: (SEL) s interval:(ccTime)seconds;
+/**
+ repeat will execute the action repeat + 1 times, for a continues action use kCCRepeatForever
+ delay is the amount of time the action will wait before execution
+ */
+-(void) schedule:(SEL)selector interval:(ccTime)interval repeat: (uint) repeat delay:(ccTime) delay;
+
 /** unschedules a custom selector.*/
 -(void) unschedule: (SEL) s;
 

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -767,15 +767,20 @@
 
 -(void) schedule:(SEL)selector
 {
-	[self schedule:selector interval:0];
+	[self schedule:selector interval:0 repeat:kCCRepeatForever delay:0];
 }
 
 -(void) schedule:(SEL)selector interval:(ccTime)interval
 {
+	[self schedule:selector interval:interval repeat:kCCRepeatForever delay:0];
+}
+
+-(void) schedule:(SEL)selector interval:(ccTime)interval repeat: (uint) repeat delay:(ccTime) delay
+{
 	NSAssert( selector != nil, @"Argument must be non-nil");
 	NSAssert( interval >=0, @"Arguemnt must be positive");
 	
-	[[CCScheduler sharedScheduler] scheduleSelector:selector forTarget:self interval:interval paused:!isRunning_];
+	[[CCScheduler sharedScheduler] scheduleSelector:selector forTarget:self interval:interval paused:!isRunning_ repeat:repeat delay:delay];
 }
 
 -(void) unschedule:(SEL)selector

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -783,6 +783,11 @@
 	[[CCScheduler sharedScheduler] scheduleSelector:selector forTarget:self interval:interval paused:!isRunning_ repeat:repeat delay:delay];
 }
 
+- (void) scheduleOnce:(SEL) selector delay:(ccTime) delay
+{
+	[self schedule:selector interval:0.f repeat:0 delay:delay];	
+}
+
 -(void) unschedule:(SEL)selector
 {
 	// explicit nil handling

--- a/cocos2d/CCScheduler.h
+++ b/cocos2d/CCScheduler.h
@@ -40,12 +40,16 @@ typedef void (*TICK_IMP)(id, SEL, ccTime);
 	TICK_IMP impMethod;
 	
 	ccTime elapsed;
+	BOOL runForever;
+	BOOL useDelay;
+	uint nTimesExecuted; 
+	uint repeat; //0 = once, 1 is 2 x executed
+	ccTime delay; 
 
 @public					// optimization
 	ccTime interval;
 	SEL selector;
 }
-
 /** interval in seconds */
 @property (nonatomic,readwrite,assign) ccTime interval;
 
@@ -61,9 +65,9 @@ typedef void (*TICK_IMP)(id, SEL, ccTime);
 */
  -(id) initWithTarget:(id) t selector:(SEL)s;
 
-/** Initializes a timer with a target, a selector and an interval in seconds.
+/** Initializes a timer with a target, a selector, an interval in seconds, repeat in number of times to repeat, delay in seconds
 */
--(id) initWithTarget:(id) t selector:(SEL)s interval:(ccTime)seconds;
+-(id) initWithTarget:(id)t selector:(SEL)s interval:(ccTime) seconds repeat:(uint) r delay:(ccTime) d;
 
 
 /** triggers the timer */
@@ -141,10 +145,12 @@ struct _hashUpdateEntry;
  If paused is YES, then it won't be called until it is resumed.
  If 'interval' is 0, it will be called every frame, but if so, it recommened to use 'scheduleUpdateForTarget:' instead.
  If the selector is already scheduled, then only the interval parameter will be updated without re-scheduling it again.
-
- @since v0.99.3
+ repeat let the action be repeated repeat + 1 times, use kCCRepeatForever to let the action run continiously 
+ delay is the amount of time the action will wait before it'll start
+ 
+ @since v0.99.3, repeat and delay added in v1.1
  */
--(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused;
+-(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused repeat: (uint) repeat delay: (ccTime) delay;
 
 /** Schedules the 'update' selector for a given target with a given priority.
  The 'update' selector will be called every frame.

--- a/cocos2d/CCScheduler.m
+++ b/cocos2d/CCScheduler.m
@@ -89,20 +89,20 @@ typedef struct _hashSelectorEntry
 
 +(id) timerWithTarget:(id)t selector:(SEL)s
 {
-	return [[[self alloc] initWithTarget:t selector:s] autorelease];
+	return [[[self alloc] initWithTarget:t selector:s interval:0 repeat:kCCRepeatForever delay:0] autorelease];
 }
 
 +(id) timerWithTarget:(id)t selector:(SEL)s interval:(ccTime) i
 {
-	return [[[self alloc] initWithTarget:t selector:s interval:i] autorelease];
+	return [[[self alloc] initWithTarget:t selector:s interval:i repeat:kCCRepeatForever delay:0] autorelease];
 }
 
 -(id) initWithTarget:(id)t selector:(SEL)s
 {
-	return [self initWithTarget:t selector:s interval:0];
+	return [self initWithTarget:t selector:s interval:0 repeat:kCCRepeatForever delay: 0];
 }
 
--(id) initWithTarget:(id)t selector:(SEL)s interval:(ccTime) seconds
+-(id) initWithTarget:(id)t selector:(SEL)s interval:(ccTime) seconds repeat:(uint) r delay:(ccTime) d 
 {
 	if( (self=[super init]) ) {
 #if COCOS2D_DEBUG
@@ -116,9 +116,15 @@ typedef struct _hashSelectorEntry
 		impMethod = (TICK_IMP) [t methodForSelector:s];
 		elapsed = -1;
 		interval = seconds;
+		repeat = r;
+		delay = d;
+		useDelay = (delay > 0) ? YES : NO;
+		repeat = r;
+		runForever = (repeat == kCCRepeatForever) ? YES : NO; 
 	}
 	return self;
 }
+
 
 - (NSString*) description
 {
@@ -134,12 +140,50 @@ typedef struct _hashSelectorEntry
 -(void) update: (ccTime) dt
 {
 	if( elapsed == - 1)
+	{	
 		elapsed = 0;
+		nTimesExecuted = 0;
+	}
 	else
-		elapsed += dt;
-	if( elapsed >= interval ) {
-		impMethod(target, selector, elapsed);
-		elapsed = 0;
+	{	
+		if (runForever && !useDelay)
+		{//standard timer usage
+			elapsed += dt;
+			if( elapsed >= interval ) {
+				impMethod(target, selector, elapsed);
+				elapsed = 0;
+				
+			}
+		}
+		else 
+		{//advanced usage 
+			elapsed += dt;
+			if (useDelay) 
+			{
+				if( elapsed >= delay )
+				{
+					impMethod(target, selector, elapsed);
+					elapsed = elapsed - delay;
+					nTimesExecuted+=1;
+					useDelay = NO;
+				}
+			}
+			else 
+			{
+				if (elapsed >= interval) 
+				{
+					impMethod(target, selector, elapsed);
+					elapsed = 0;
+					nTimesExecuted += 1; 
+					
+				}
+			}
+			
+			if (nTimesExecuted > repeat) 
+			{//unschedule timer
+				[[CCScheduler sharedScheduler] unscheduleSelector:selector forTarget:target];
+			}
+		}
 	}
 }
 @end
@@ -227,7 +271,7 @@ static CCScheduler *sharedScheduler;
 	free(element);
 }
 
--(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused
+-(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused repeat:(uint) repeat delay:(ccTime) delay
 {
 	NSAssert( selector != nil, @"Argument selector must be non-nil");
 	NSAssert( target != nil, @"Argument target must be non-nil");	
@@ -239,10 +283,10 @@ static CCScheduler *sharedScheduler;
 		element = calloc( sizeof( *element ), 1 );
 		element->target = [target retain];
 		HASH_ADD_INT( hashForSelectors, target, element );
-	
+		
 		// Is this the 1st element ? Then set the pause level to all the selectors of this target
 		element->paused = paused;
-	
+		
 	} else
 		NSAssert( element->paused == paused, @"CCScheduler. Trying to schedule a selector with a pause value different than the target");
 	
@@ -262,7 +306,7 @@ static CCScheduler *sharedScheduler;
 		ccArrayEnsureExtraCapacity(element->timers, 1);
 	}
 	
-	CCTimer *timer = [[CCTimer alloc] initWithTarget:target selector:selector interval:interval];
+	CCTimer *timer = [[CCTimer alloc] initWithTarget:target selector:selector interval:interval repeat:repeat delay:delay];
 	ccArrayAppendObject(element->timers, timer);
 	[timer release];
 }

--- a/cocos2d/ccMacros.h
+++ b/cocos2d/ccMacros.h
@@ -94,6 +94,7 @@ simple macro that swaps 2 variables
  */
 #define CC_RADIANS_TO_DEGREES(__ANGLE__) ((__ANGLE__) * 57.29577951f) // PI * 180
 
+#define kCCRepeatForever UINT_MAX -1
 /** @def CC_BLEND_SRC
 default gl blend src function. Compatible with premultiplied alpha images.
 */

--- a/tests/SchedulerTest.h
+++ b/tests/SchedulerTest.h
@@ -60,6 +60,9 @@
 }
 @end
 
+@interface SchedulerDelayAndRepeat : SchedulerTest
+{}
+@end
 
 
 

--- a/tests/SchedulerTest.m
+++ b/tests/SchedulerTest.m
@@ -22,6 +22,8 @@ static NSString *transitions[] = {
 	@"SchedulerUpdateAndCustom",
 	@"SchedulerUpdateFromCustom",
 	@"RescheduleSelector",
+	@"SchedulerDelayAndRepeat",
+
 };
 
 Class nextTest(void);
@@ -586,6 +588,34 @@ Class restartTest()
 
 @end
 
+@implementation SchedulerDelayAndRepeat
+-(id) init
+{
+	if( (self=[super init]) ) {
+		
+		[self schedule:@selector(update:) interval:0 repeat:4 delay:3.f];
+		CCLOG(@"update is scheduled should begin after 3 seconds");
+	}
+	
+	return self;
+}
+
+-(NSString *) title
+{
+	return @"Schedule with delay of 3 sec, repeat 4 times";
+}
+
+-(NSString *) subtitle
+{
+	return @"After 5 x executed, method unscheduled. See console";
+}								 
+
+-(void) update:(ccTime)dt
+{
+	NSLog(@"update called:%f", dt);
+}
+
+@end
 
 
 // CLASS IMPLEMENTATIONS
@@ -685,3 +715,4 @@ Class restartTest()
 }
 
 @end
+


### PR DESCRIPTION
The improvement to CCTimer makes it a bit bigger (2 bools and 2 floats), but performance of the usual invocation (using it to run indefinitely) is almost as fast as the original implementation. The overhead is checking 2 bools. 

Changed:
CCTimer
-added support for delay and repeat
CCScheduler
-updated methods to support delay and repeat
CCNode
-updated methods to support delay and repeat
SchedularTest
-Added a test to demonstrate repeat and delay
