### PR TITLE
Add ability to pass a userdata param to the scheduler, to be passed along to the scheduled selector when it's called

### DIFF
--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -461,6 +461,7 @@ enum {
  The scheduled selector will be ticked every frame
  */
 -(void) schedule: (SEL) s;
+-(void) schedule: (SEL) s userData:(id)data;
 /** schedules a custom selector with an interval time in seconds.
  If time is 0 it will be ticked every frame.
  If time is 0, it is recommended to use 'scheduleUpdate' instead.
@@ -468,11 +469,13 @@ enum {
  If the selector is already scheduled, then the interval parameter will be updated without scheduling it again.
  */
 -(void) schedule: (SEL) s interval:(ccTime)seconds;
+-(void) schedule: (SEL) s interval:(ccTime)seconds userData:(id)data;
 /**
  repeat will execute the action repeat + 1 times, for a continues action use kCCRepeatForever
  delay is the amount of time the action will wait before execution
  */
 -(void) schedule:(SEL)selector interval:(ccTime)interval repeat: (uint) repeat delay:(ccTime) delay;
+-(void) schedule:(SEL)selector interval:(ccTime)interval repeat: (uint) repeat delay:(ccTime) delay userData:(id)data;
 
 /**
  Schedules a selector that runs only once, with a delay of 0 or larger 
@@ -481,6 +484,7 @@ enum {
 
 /** unschedules a custom selector.*/
 -(void) unschedule: (SEL) s;
+-(void) unschedule: (SEL) s userData:(id)data;
 
 /** unschedule all scheduled selectors: custom selectors, and the 'update' selector.
  Actions are not affected by this method.

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -770,9 +770,19 @@
 	[self schedule:selector interval:0 repeat:kCCRepeatForever delay:0];
 }
 
+-(void) schedule:(SEL)selector userData:(id)data
+{
+	[self schedule:selector interval:0 repeat:kCCRepeatForever delay:0 userData:data];
+}
+
 -(void) schedule:(SEL)selector interval:(ccTime)interval
 {
 	[self schedule:selector interval:interval repeat:kCCRepeatForever delay:0];
+}
+
+-(void) schedule:(SEL)selector interval:(ccTime)interval userData:(id)data
+{
+	[self schedule:selector interval:interval repeat:kCCRepeatForever delay:0 userData:(id)data];
 }
 
 -(void) schedule:(SEL)selector interval:(ccTime)interval repeat: (uint) repeat delay:(ccTime) delay
@@ -781,6 +791,14 @@
 	NSAssert( interval >=0, @"Arguemnt must be positive");
 	
 	[[CCScheduler sharedScheduler] scheduleSelector:selector forTarget:self interval:interval paused:!isRunning_ repeat:repeat delay:delay];
+}
+
+-(void) schedule:(SEL)selector interval:(ccTime)interval repeat: (uint) repeat delay:(ccTime) delay userData:(id)data
+{
+	NSAssert( selector != nil, @"Argument must be non-nil");
+	NSAssert( interval >=0, @"Arguemnt must be positive");
+	
+	[[CCScheduler sharedScheduler] scheduleSelector:selector forTarget:self interval:interval paused:!isRunning_ repeat:repeat delay:delay userData:data];
 }
 
 - (void) scheduleOnce:(SEL) selector delay:(ccTime) delay
@@ -796,6 +814,16 @@
 	
 	[[CCScheduler sharedScheduler] unscheduleSelector:selector forTarget:self];
 }
+
+-(void) unschedule:(SEL)selector userData:(id)data
+{
+	// explicit nil handling
+	if (selector == nil)
+		return;
+	
+	[[CCScheduler sharedScheduler] unscheduleSelector:selector forTarget:self userData:data];
+}
+
 
 -(void) unscheduleAllSelectors
 {

--- a/cocos2d/CCScheduler.h
+++ b/cocos2d/CCScheduler.h
@@ -57,19 +57,19 @@ typedef void (*TICK_IMP_PARAM)(id, SEL, ccTime, id);
 /** interval in seconds */
 @property (nonatomic,readwrite,assign) ccTime interval;
 
-/** Allocates a timer with a target and a selector.
+/** Allocates a timer with a target, a selector, and a userdata (can be nil)
 */
 +(id) timerWithTarget:(id) t selector:(SEL)s userData:(id)data;
 
-/** Allocates a timer with a target, a selector and an interval in seconds.
+/** Allocates a timer with a target, a selector, an interval in seconds, and a userdata (can be nil)
 */
 +(id) timerWithTarget:(id) t selector:(SEL)s interval:(ccTime)seconds userData:(id)data;
 
-/** Initializes a timer with a target and a selector.
+/** Initializes a timer with a target, selector, and a userdata (can be nil)
 */
 -(id) initWithTarget:(id) t selector:(SEL)s userData:(id)data;
 
-/** Initializes a timer with a target, a selector, an interval in seconds, repeat in number of times to repeat, delay in seconds
+/** Initializes a timer with a target, a selector, an interval in seconds, repeat in number of times to repeat, delay in seconds, and a userdata param (can be nil)
 */
 -(id) initWithTarget:(id)t selector:(SEL)s interval:(ccTime) seconds repeat:(uint) r delay:(ccTime) d userData:(id)data;
 
@@ -152,7 +152,7 @@ struct _hashUpdateEntry;
  repeat let the action be repeated repeat + 1 times, use kCCRepeatForever to let the action run continiously 
  delay is the amount of time the action will wait before it'll start
  
- @since v0.99.3, repeat and delay added in v1.1
+ @since v0.99.3, repeat, delay, userdata added in v1.1
  */
 -(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused repeat: (uint) repeat delay: (ccTime) delay;
 -(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused repeat: (uint) repeat delay: (ccTime) delay userData:(id)data;

--- a/cocos2d/CCScheduler.h
+++ b/cocos2d/CCScheduler.h
@@ -29,6 +29,7 @@
 #import "ccTypes.h"
 
 typedef void (*TICK_IMP)(id, SEL, ccTime);
+typedef void (*TICK_IMP_PARAM)(id, SEL, ccTime, id);
 
 //
 // CCTimer
@@ -37,7 +38,9 @@ typedef void (*TICK_IMP)(id, SEL, ccTime);
 @interface CCTimer : NSObject
 {
 	id target;
-	TICK_IMP impMethod;
+	
+	int argCount;
+	IMP impMethod;
 	
 	ccTime elapsed;
 	BOOL runForever;
@@ -49,25 +52,26 @@ typedef void (*TICK_IMP)(id, SEL, ccTime);
 @public					// optimization
 	ccTime interval;
 	SEL selector;
+	id userData;
 }
 /** interval in seconds */
 @property (nonatomic,readwrite,assign) ccTime interval;
 
 /** Allocates a timer with a target and a selector.
 */
-+(id) timerWithTarget:(id) t selector:(SEL)s;
++(id) timerWithTarget:(id) t selector:(SEL)s userData:(id)data;
 
 /** Allocates a timer with a target, a selector and an interval in seconds.
 */
-+(id) timerWithTarget:(id) t selector:(SEL)s interval:(ccTime)seconds;
++(id) timerWithTarget:(id) t selector:(SEL)s interval:(ccTime)seconds userData:(id)data;
 
 /** Initializes a timer with a target and a selector.
 */
- -(id) initWithTarget:(id) t selector:(SEL)s;
+-(id) initWithTarget:(id) t selector:(SEL)s userData:(id)data;
 
 /** Initializes a timer with a target, a selector, an interval in seconds, repeat in number of times to repeat, delay in seconds
 */
--(id) initWithTarget:(id)t selector:(SEL)s interval:(ccTime) seconds repeat:(uint) r delay:(ccTime) d;
+-(id) initWithTarget:(id)t selector:(SEL)s interval:(ccTime) seconds repeat:(uint) r delay:(ccTime) d userData:(id)data;
 
 
 /** triggers the timer */
@@ -151,6 +155,7 @@ struct _hashUpdateEntry;
  @since v0.99.3, repeat and delay added in v1.1
  */
 -(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused repeat: (uint) repeat delay: (ccTime) delay;
+-(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused repeat: (uint) repeat delay: (ccTime) delay userData:(id)data;
 
 /** Schedules the 'update' selector for a given target with a given priority.
  The 'update' selector will be called every frame.
@@ -164,6 +169,7 @@ struct _hashUpdateEntry;
  @since v0.99.3
  */
 -(void) unscheduleSelector:(SEL)selector forTarget:(id)target;
+-(void) unscheduleSelector:(SEL)selector forTarget:(id)target userData:(id)data;
 
 /** Unschedules the update selector for a given target
  @since v0.99.3

--- a/cocos2d/CCScheduler.m
+++ b/cocos2d/CCScheduler.m
@@ -143,7 +143,7 @@ typedef struct _hashSelectorEntry
 	[super dealloc];
 }
 
--(void)dispatch
+-(void)invokeSelector
 {
 	if( argCount == 3 )
 		((TICK_IMP)impMethod)(target, selector, elapsed);
@@ -164,7 +164,7 @@ typedef struct _hashSelectorEntry
 		{//standard timer usage
 			elapsed += dt;
 			if( elapsed >= interval ) {
-				[self dispatch];
+				[self invokeSelector];
 				elapsed = 0;
 				
 			}
@@ -176,7 +176,7 @@ typedef struct _hashSelectorEntry
 			{
 				if( elapsed >= delay )
 				{
-					[self dispatch];
+					[self invokeSelector];
 					elapsed = elapsed - delay;
 					nTimesExecuted+=1;
 					useDelay = NO;
@@ -186,7 +186,7 @@ typedef struct _hashSelectorEntry
 			{
 				if (elapsed >= interval) 
 				{
-					[self dispatch];
+					[self invokeSelector];
 					elapsed = 0;
 					nTimesExecuted += 1; 
 					

--- a/tests/SchedulerTest.h
+++ b/tests/SchedulerTest.h
@@ -64,6 +64,9 @@
 {}
 @end
 
+@interface SchedulerUserdata : SchedulerTest
+{}
+@end
 
 
 

--- a/tests/SchedulerTest.m
+++ b/tests/SchedulerTest.m
@@ -23,6 +23,7 @@ static NSString *transitions[] = {
 	@"SchedulerUpdateFromCustom",
 	@"RescheduleSelector",
 	@"SchedulerDelayAndRepeat",
+	@"SchedulerUserdata"
 
 };
 
@@ -613,6 +614,54 @@ Class restartTest()
 -(void) update:(ccTime)dt
 {
 	NSLog(@"update called:%f", dt);
+}
+
+@end
+
+@implementation SchedulerUserdata
+
+-(id) init
+{
+	if( (self=[super init]) ) {
+		[self schedule:@selector(update:data:) interval:1.0f userData:[NSNumber numberWithInt:1]];
+		[self schedule:@selector(update:data:) interval:2.0f userData:[NSNumber numberWithInt:2]];
+		[self schedule:@selector(testNoData:) interval:3.0f ];
+		CCLOG(@"update:data: should be scheduled twice with different userdata, and testNoData: should be scheduled once with no userdata");
+		
+		CCDelayTime* delayTime = [CCDelayTime actionWithDuration:10.0f];
+		CCCallFunc* callAction = [CCCallFunc actionWithTarget:self selector:@selector(unscheduleUpdateWithData1)];
+		[self runAction:[CCSequence actions:delayTime, callAction, nil]];
+		CCLOG(@"update:data: with userdata 1 should be stopped in 10 seconds");		
+	}
+	
+	return self;
+}
+
+-(NSString *) title
+{
+	return @"Scheduler with userdata";
+}
+
+-(NSString *) subtitle
+{
+	return @"The same function should be scheduled twice with 2 different userdatas. Another function scheduled with no userdata.\n"
+	"The userdata function with '1' as the userdata will be stopped after 10 seconds";
+}			
+
+-(void)update:(ccTime)dt data:(id)userData
+{
+	NSLog(@"update:data called with userdata:%d", [userData intValue]);
+}
+
+-(void)testNoData:(ccTime)dt
+{
+	NSLog(@"testNoData called");
+}
+
+-(void)unscheduleUpdateWithData1
+{
+	[self unschedule:@selector(update:data:) userData:[NSNumber numberWithInt:1]];
+	CCLOG(@"update:data: with userData 1 stopped");
 }
 
 @end


### PR DESCRIPTION
- updated CCNode and CCScheduler to accept a user data parameter
- updated SchedulerTest with test "SchedulerUserdata"
