### PR TITLE
Issue 1247, repeatforever not correctly updated

### DIFF
--- a/cocos2d/CCAction.m
+++ b/cocos2d/CCAction.m
@@ -158,10 +158,11 @@
 {
 	[innerAction_ step: dt];
 	if( [innerAction_ isDone] ) {
-		ccTime diff = dt + innerAction_.duration - innerAction_.elapsed;
+		ccTime diff = innerAction_.elapsed - innerAction_.duration;
 		[innerAction_ startWithTarget:target_];
 		
 		// to prevent jerk. issue #390
+		[innerAction_ step: 0.0f];
 		[innerAction_ step: diff];
 	}
 }

--- a/cocos2d/CCAction.m
+++ b/cocos2d/CCAction.m
@@ -161,7 +161,7 @@
 		ccTime diff = innerAction_.elapsed - innerAction_.duration;
 		[innerAction_ startWithTarget:target_];
 		
-		// to prevent jerk. issue #390
+		// to prevent jerk. issue #390, 1247
 		[innerAction_ step: 0.0f];
 		[innerAction_ step: diff];
 	}


### PR DESCRIPTION
When a action was finished the delta for the next run was calculated incorrectly. 
CCRepeat and CCRepeatForever now behave identically when run with the same action. 

ActionsTest was run to determine correct behavior. 
