### PR TITLE
Fix: In some situations the textures can't be loaded.

### DIFF
--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -121,6 +121,7 @@ NSInteger ccLoadFileIntoMemory(const char *filename, unsigned char **out)
 	NSString *newName = [pathWithoutExtension stringByAppendingString:suffix];
 	newName = [newName stringByAppendingPathExtension:extension];
 
+	newName = [NSString stringWithFormat:@"%@/%@", [[NSBundle mainBundle] bundlePath], newName];
 	if( [__localFileManager fileExistsAtPath:newName] )
 		return newName;
 


### PR DESCRIPTION
In such situation, that the textures are placed under some subfolders,
like ${AppDir}/resource/textures, the +(NSString_)
getPath:(NSString_)path forSuffix:(NSString*)suffix of class
CCFileUtils can't find the textures.

Fix it by add line:
newName = [NSString stringWithFormat:@"%@/%@", [[NSBundle mainBundle]
bundlePath], newName];
in line 124.
