### PR TITLE
Issue 955, new  class CCParticleBatchNode 

### DIFF
--- a/ParticleBatchTest-Info.plist
+++ b/ParticleBatchTest-Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.yourcompany.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/ParticleTestBatched.h
+++ b/ParticleTestBatched.h
@@ -1,0 +1,199 @@
+
+#import "cocos2d.h"
+
+@class CCSprite;
+@class CCParticleBatchNode; 
+
+//CLASS INTERFACE
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+@interface AppController : NSObject <UIApplicationDelegate>
+{
+	UIWindow *window;
+}
+@end
+
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+@interface cocos2dmacAppDelegate : NSObject <NSApplicationDelegate>
+{
+	NSWindow	*window_;
+	MacGLView	*glView_;
+}
+
+@property (assign) IBOutlet NSWindow	*window;
+@property (assign) IBOutlet MacGLView	*glView;
+
+- (IBAction)toggleFullScreen:(id)sender;
+
+@end
+#endif // Mac
+
+@class Emitter;
+
+@interface ParticleDemoBatch : CCLayerColor
+{
+	CCParticleSystem	*emitter_;
+	CCSprite			*background;
+	CCParticleBatchNode* batchNode_;
+}
+
+@property (readwrite,retain) CCParticleSystem *emitter;
+
+-(NSString*) title;
+-(NSString*) subtitle;
+
+@end
+
+@interface DemoBatchFirework : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchFire : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchSun : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchGalaxy : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchFlower : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchBigFlower : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchRotFlower : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchMeteor : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchSpiral : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchExplosion : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchSmoke : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchSnow : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchRain : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchModernArt : ParticleDemoBatch
+{}
+@end
+
+@interface DemoBatchRing : ParticleDemoBatch
+{}
+@end
+
+@interface ParallaxParticle : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner1 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner2 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner3 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner4 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner5 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner6 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner7 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner8 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner9 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner10 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner11 : ParticleDemoBatch
+{}
+@end
+
+@interface ParticleDesigner12 : ParticleDemoBatch
+{}
+@end
+
+@interface RadiusMode1 : ParticleDemoBatch
+{}
+@end
+
+@interface RadiusMode2 : ParticleDemoBatch
+{}
+@end
+
+@interface Issue704 : ParticleDemoBatch
+{}
+@end
+
+@interface Issue872 : ParticleDemoBatch
+{}
+@end
+
+@interface Issue870 : ParticleDemoBatch
+{
+	int index;
+}
+@end
+
+@interface MultipleParticleSystems : ParticleDemoBatch
+{}
+@end
+
+@interface MultipleParticleSystemsBatched : ParticleDemoBatch
+{
+}
+@end
+
+@interface AddAndDeleteParticleSystems : ParticleDemoBatch
+{
+}
+@end
+
+@interface ReorderParticleSystems : ParticleDemoBatch
+{
+}
+@end
+
+

--- a/ParticleTestBatched.m
+++ b/ParticleTestBatched.m
@@ -1,0 +1,2113 @@
+//
+// Particle Batch DemoBatch
+// a cocos2d example
+// http://www.cocos2d-iphone.org
+//
+//created by Marco Tillemans
+
+// local import
+#import "ParticleTestBatched.h"
+#import "CCParticleBatchNode.h" 
+
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+#define PARTICLE_FIRE_NAME @"fire.pvr"
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+#define PARTICLE_FIRE_NAME @"fire.png"
+#endif
+enum {
+	kTagLabelAtlas = 1,
+};
+
+static int sceneIdx=-1;
+static NSString *transitions[] = {
+	@"DemoBatchFlower",
+	@"DemoBatchGalaxy",
+	@"DemoBatchFirework",
+	@"DemoBatchSpiral",
+	@"DemoBatchSun",
+	@"DemoBatchMeteor",
+	@"DemoBatchFire",
+	@"DemoBatchSmoke",
+	@"DemoBatchExplosion",
+	@"DemoBatchSnow",
+	@"DemoBatchRain",
+	@"DemoBatchBigFlower",
+	@"DemoBatchRotFlower",
+	@"DemoBatchModernArt",
+	@"DemoBatchRing",
+	
+	@"ParallaxParticle",
+	
+	@"ParticleDesigner1",
+	@"ParticleDesigner2",
+	@"ParticleDesigner3",
+	@"ParticleDesigner4",
+	@"ParticleDesigner5",
+	@"ParticleDesigner6",
+	@"ParticleDesigner7",
+	@"ParticleDesigner8",
+	@"ParticleDesigner9",
+	@"ParticleDesigner10",
+	@"ParticleDesigner11",
+	@"ParticleDesigner12",
+	
+	@"RadiusMode1",
+	@"RadiusMode2",
+	@"Issue704",
+	@"Issue872",
+	@"Issue870",
+	@"MultipleParticleSystems",
+	@"MultipleParticleSystemsBatched",	
+	@"AddAndDeleteParticleSystems",
+	@"ReorderParticleSystems"
+	
+};
+
+Class nextAction(void);
+Class backAction(void);
+Class restartAction(void);
+
+Class nextAction()
+{
+	
+	sceneIdx++;
+	sceneIdx = sceneIdx % ( sizeof(transitions) / sizeof(transitions[0]) );
+	NSString *r = transitions[sceneIdx];
+	Class c = NSClassFromString(r);
+	return c;
+}
+
+Class backAction()
+{
+	sceneIdx--;
+	int total = ( sizeof(transitions) / sizeof(transitions[0]) );
+	if( sceneIdx < 0 )
+		sceneIdx += total;	
+	
+	NSString *r = transitions[sceneIdx];
+	Class c = NSClassFromString(r);
+	return c;
+}
+
+Class restartAction()
+{
+	NSString *r = transitions[sceneIdx];
+	Class c = NSClassFromString(r);
+	return c;
+}
+
+@implementation ParticleDemoBatch
+
+@synthesize emitter=emitter_;
+-(id) init
+{
+	if( (self=[super initWithColor:ccc4(127,127,127,255)] )) {
+		
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+		self.isTouchEnabled = YES;
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+		self.isMouseEnabled = YES;
+#endif
+		
+		
+		CGSize s = [[CCDirector sharedDirector] winSize];
+		CCLabelTTF *label = [CCLabelTTF labelWithString:[self title] fontName:@"Arial" fontSize:32];
+		[self addChild:label z:100];
+		[label setPosition: ccp(s.width/2, s.height-50)];
+		
+		NSString *subtitle = [self subtitle];
+		if( subtitle ) {
+			CCLabelTTF *l = [CCLabelTTF labelWithString:subtitle fontName:@"Thonburi" fontSize:16];
+			[self addChild:l z:100];
+			[l setPosition:ccp(s.width/2, s.height-80)];
+		}			
+		
+		CCMenuItemImage *item1 = [CCMenuItemImage itemFromNormalImage:@"b1.png" selectedImage:@"b2.png" target:self selector:@selector(backCallback:)];
+		CCMenuItemImage *item2 = [CCMenuItemImage itemFromNormalImage:@"r1.png" selectedImage:@"r2.png" target:self selector:@selector(restartCallback:)];
+		CCMenuItemImage *item3 = [CCMenuItemImage itemFromNormalImage:@"f1.png" selectedImage:@"f2.png" target:self selector:@selector(nextCallback:)];
+		
+		CCMenuItemToggle *item4 = [CCMenuItemToggle itemWithTarget:self selector:@selector(toggleCallback:) items:
+								   [CCMenuItemFont itemFromString: @"Free Movement"],
+								   [CCMenuItemFont itemFromString: @"Relative Movement"],
+								   [CCMenuItemFont itemFromString: @"Grouped Movement"],
+								   
+								   nil];
+		
+		CCMenu *menu = [CCMenu menuWithItems:item1, item2, item3, item4, nil];
+		
+		menu.position = CGPointZero;
+		item1.position = ccp( s.width/2 - 100,30);
+		item2.position = ccp( s.width/2, 30);
+		item3.position = ccp( s.width/2 + 100,30);
+		item4.position = ccp( 0, 100);
+		item4.anchorPoint = ccp(0,0);
+		
+		[self addChild: menu z:100];	
+		
+		CCLabelAtlas *labelAtlas = [CCLabelAtlas labelWithString:@"0000" charMapFile:@"fps_images.png" itemWidth:16 itemHeight:24 startCharMap:'.'];
+		[self addChild:labelAtlas z:100 tag:kTagLabelAtlas];
+		labelAtlas.position = ccp(s.width-66,50);
+		
+		// moving background
+		background = [CCSprite spriteWithFile:@"background3.png"];
+		[self addChild:background z:5];
+		[background setPosition:ccp(s.width/2, s.height-180)];
+		
+		id move = [CCMoveBy actionWithDuration:4 position:ccp(300,0)];
+		id move_back = [move reverse];
+		id seq = [CCSequence actions: move, move_back, nil];
+		[background runAction:[CCRepeatForever actionWithAction:seq]];
+		
+		batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:background.texture capacity:500 useQuad:YES additiveBlending:NO]; 
+		[background addChild:batchNode_]; 
+		
+		[self scheduleUpdate];
+	}
+	
+	return self;
+}
+
+- (void) dealloc
+{
+	//[batchNode_ release];
+	[emitter_ release];
+	[super dealloc];
+}
+
+
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+-(void) registerWithTouchDispatcher
+{
+	[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:self priority:0 swallowsTouches:NO];
+}
+
+-(BOOL) ccTouchBegan:(UITouch*)touch withEvent:(UIEvent*)event
+{
+	[self ccTouchEnded:touch withEvent:event];
+	
+	// claim the touch
+	return YES;
+}
+- (void)ccTouchMoved:(UITouch*)touch withEvent:(UIEvent *)event
+{
+	[self ccTouchEnded:touch withEvent:event];
+}
+
+- (void)ccTouchEnded:(UITouch*)touch withEvent:(UIEvent *)event
+{
+	CGPoint location = [touch locationInView: [touch view]];
+	CGPoint convertedLocation = [[CCDirector sharedDirector] convertToGL:location];
+	
+	CGPoint pos = CGPointZero;
+	
+	if( background )
+		pos = [background convertToWorldSpace:CGPointZero];
+	emitter_.position = ccpSub(convertedLocation, pos);	
+}
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+
+
+-(BOOL) ccMouseDragged:(NSEvent *)event
+{
+	CGPoint convertedLocation = [[CCDirector sharedDirector] convertEventToGL:event];
+	
+	CGPoint pos = CGPointZero;
+	
+	if( background )
+		pos = [background convertToWorldSpace:CGPointZero];
+	emitter_.position = ccpSub(convertedLocation, pos);	
+	// swallow the event. Don't propagate it
+	return YES;	
+}
+#endif // __MAC_OS_X_VERSION_MAX_ALLOWED
+
+-(void) update:(ccTime) dt
+{
+	CCLabelAtlas *atlas = (CCLabelAtlas*) [self getChildByTag:kTagLabelAtlas];
+	
+	NSString *str = [NSString stringWithFormat:@"%4d", emitter_.particleCount];
+	[atlas setString:str];
+}
+
+-(NSString*) title
+{
+	return @"No title";
+}
+-(NSString*) subtitle
+{
+	return @"Tap the screen";
+}
+
+-(void) toggleCallback: (id) sender
+{
+	if( emitter_.positionType == kCCPositionTypeGrouped )
+		emitter_.positionType = kCCPositionTypeFree;
+	else if( emitter_.positionType == kCCPositionTypeFree )
+		emitter_.positionType = kCCPositionTypeRelative;
+	else if( emitter_.positionType == kCCPositionTypeRelative )
+		emitter_.positionType = kCCPositionTypeGrouped;
+}
+
+-(void) restartCallback: (id) sender
+{
+	//	Scene *s = [Scene node];
+	//	[s addChild: [restartAction() node]];
+	//	[[Director sharedDirector] replaceScene: s];
+	
+	[emitter_ resetSystem];
+	//	[emitter_ stopSystem];
+}
+
+-(void) nextCallback: (id) sender
+{
+	CCScene *s = [CCScene node];
+	[s addChild: [nextAction() node]];
+	[[CCDirector sharedDirector] replaceScene: s];
+}
+
+-(void) backCallback: (id) sender
+{
+	CCScene *s = [CCScene node];
+	[s addChild: [backAction() node]];
+	[[CCDirector sharedDirector] replaceScene: s];
+}
+
+-(void) setEmitterPosition
+{
+	if( CGPointEqualToPoint( emitter_.sourcePosition, CGPointZero ) ) 
+		emitter_.position = ccp(200, 70);
+}
+
+@end
+
+#pragma mark -
+
+@implementation DemoBatchFirework
+-(void) onEnter
+{
+	[super onEnter];
+	self.emitter = [CCParticleFireworks node];
+	
+	
+	//[background addChild:emitter_ z:10];
+	
+	// testing "alpha" blending in premultiplied images
+	//	emitter_.blendFunc = (ccBlendFunc) {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: @"stars.png"];
+	emitter_.blendAdditive = YES;
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ additiveBlending];
+	[batchNode_ addChild:emitter_]; 
+	
+	[self setEmitterPosition];
+}
+-(NSString *) title
+{
+	return @"ParticleFireworks";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchFire
+-(void) onEnter
+{
+	[super onEnter];
+	self.emitter = [CCParticleFire node];
+	[batchNode_ removeAllChildrenWithCleanup:YES];
+	
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: PARTICLE_FIRE_NAME];
+	CGPoint p = emitter_.position;
+	emitter_.position = ccp(p.x, 100);
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ additiveBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"ParticleFire";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchSun
+-(void) onEnter
+{
+	[super onEnter];
+	[batchNode_ removeAllChildrenWithCleanup:YES];
+	
+	self.emitter = [CCParticleSun node];
+	
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: PARTICLE_FIRE_NAME];
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ additiveBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"ParticleSun";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchGalaxy
+-(void) onEnter
+{
+	[super onEnter];
+	//[batchNode_ removeAllChildrenWithCleanup:YES];
+	self.emitter = [CCParticleGalaxy node];
+
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: PARTICLE_FIRE_NAME];
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ additiveBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"ParticleGalaxy";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchFlower
+-(void) onEnter
+{
+	[super onEnter];
+
+	self.emitter = [CCParticleFlower node];
+
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: @"stars-grayscale.png"];
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ additiveBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"ParticleFlower";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchBigFlower
+-(void) onEnter
+{
+	[super onEnter];
+	emitter_ = [[CCParticleSystemQuad alloc] initWithTotalParticles:50];
+
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: @"stars-grayscale.png"];
+	
+	// duration
+	emitter_.duration = kCCParticleDurationInfinity;
+	
+	// Gravity Mode: gravity
+	emitter_.gravity = CGPointZero;
+	
+	// Set "Gravity" mode (default one)
+	emitter_.emitterMode = kCCParticleModeGravity;
+	
+	// Gravity Mode: speed of particles
+	emitter_.speed = 160;
+	emitter_.speedVar = 20;
+	
+	// Gravity Mode: radial
+	emitter_.radialAccel = -120;
+	emitter_.radialAccelVar = 0;
+	
+	// Gravity Mode: tagential
+	emitter_.tangentialAccel = 30;
+	emitter_.tangentialAccelVar = 0;
+	
+	// angle
+	emitter_.angle = 90;
+	emitter_.angleVar = 360;
+	
+	// emitter position
+	emitter_.position = ccp(160,240);
+	emitter_.posVar = CGPointZero;
+	
+	// life of particles
+	emitter_.life = 4;
+	emitter_.lifeVar = 1;
+	
+	// spin of particles
+	emitter_.startSpin = 0;
+	emitter_.startSpinVar = 0;
+	emitter_.endSpin = 0;
+	emitter_.endSpinVar = 0;
+	
+	// color of particles
+	ccColor4F startColor = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColor = startColor;
+	
+	ccColor4F startColorVar = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColorVar = startColorVar;
+	
+	ccColor4F endColor = {0.1f, 0.1f, 0.1f, 0.2f};
+	emitter_.endColor = endColor;
+	
+	ccColor4F endColorVar = {0.1f, 0.1f, 0.1f, 0.2f};	
+	emitter_.endColorVar = endColorVar;
+	
+	// size, in pixels
+	emitter_.startSize = 80.0f;
+	emitter_.startSizeVar = 40.0f;
+	emitter_.endSize = kCCParticleStartSizeEqualToEndSize;
+	
+	// emits per second
+	emitter_.emissionRate = emitter_.totalParticles/emitter_.life;
+	
+	// additive
+	emitter_.blendAdditive = YES;
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ additiveBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"Big Particles";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchRotFlower
+-(void) onEnter
+{
+	[super onEnter];
+	emitter_ = [[CCParticleSystemQuad alloc] initWithTotalParticles:300];
+
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: @"stars2-grayscale.png"];
+	
+	// duration
+	emitter_.duration = kCCParticleDurationInfinity;
+	
+	// Set "Gravity" mode (default one)
+	emitter_.emitterMode = kCCParticleModeGravity;
+	
+	// Gravity mode: gravity
+	emitter_.gravity = CGPointZero;
+	
+	// Gravity mode: speed of particles
+	emitter_.speed = 160;
+	emitter_.speedVar = 20;
+	
+	// Gravity mode: radial
+	emitter_.radialAccel = -120;
+	emitter_.radialAccelVar = 0;
+	
+	// Gravity mode: tagential
+	emitter_.tangentialAccel = 30;
+	emitter_.tangentialAccelVar = 0;
+	
+	// emitter position
+	emitter_.position = ccp(160,240);
+	emitter_.posVar = CGPointZero;
+	
+	// angle
+	emitter_.angle = 90;
+	emitter_.angleVar = 360;
+	
+	// life of particles
+	emitter_.life = 3;
+	emitter_.lifeVar = 1;
+	
+	// spin of particles
+	emitter_.startSpin = 0;
+	emitter_.startSpinVar = 0;
+	emitter_.endSpin = 0;
+	emitter_.endSpinVar = 2000;
+	
+	// color of particles
+	ccColor4F startColor = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColor = startColor;
+	
+	ccColor4F startColorVar = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColorVar = startColorVar;
+	
+	ccColor4F endColor = {0.1f, 0.1f, 0.1f, 0.2f};
+	emitter_.endColor = endColor;
+	
+	ccColor4F endColorVar = {0.1f, 0.1f, 0.1f, 0.2f};	
+	emitter_.endColorVar = endColorVar;
+	
+	// size, in pixels
+	emitter_.startSize = 30.0f;
+	emitter_.startSizeVar = 00.0f;
+	emitter_.endSize = kCCParticleStartSizeEqualToEndSize;
+	
+	// emits per second
+	emitter_.emissionRate = emitter_.totalParticles/emitter_.life;
+	
+	// additive
+	emitter_.blendAdditive = NO;
+	
+	[self setEmitterPosition];
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ normalBlending];	
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"Spinning Particles";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchMeteor
+-(void) onEnter
+{
+	[super onEnter];
+	self.emitter = [CCParticleMeteor node];
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: PARTICLE_FIRE_NAME];
+	
+	[self setEmitterPosition];
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ additiveBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"ParticleMeteor";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchSpiral
+-(void) onEnter
+{
+	[super onEnter];
+	self.emitter = [CCParticleSpiral node];
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: PARTICLE_FIRE_NAME];
+	
+	[self setEmitterPosition];
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ normalBlending];	
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"ParticleSpiral";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchExplosion
+-(void) onEnter
+{
+	[super onEnter];
+	self.emitter = [CCParticleExplosion node];
+
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: @"stars-grayscale.png"];
+	
+	emitter_.autoRemoveOnFinish = YES;
+	
+	[self setEmitterPosition];
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ normalBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"ParticleExplosion";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchSmoke
+-(void) onEnter
+{
+	[super onEnter];
+	self.emitter = [CCParticleSmoke node];
+	
+	
+	CGPoint p = emitter_.position;
+	emitter_.position = ccp( p.x, 100);
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ normalBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"ParticleSmoke";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchSnow
+-(void) onEnter
+{
+	[super onEnter];
+	self.emitter = [CCParticleSnow node];
+	
+	CGPoint p = emitter_.position;
+	emitter_.position = ccp( p.x, p.y-110);
+	emitter_.life = 3;
+	emitter_.lifeVar = 1;
+	
+	// gravity
+	emitter_.gravity = ccp(0,-10);
+	
+	// speed of particles
+	emitter_.speed = 130;
+	emitter_.speedVar = 30;
+	
+	
+	ccColor4F startColor = emitter_.startColor;
+	startColor.r = 0.9f;
+	startColor.g = 0.9f;
+	startColor.b = 0.9f;
+	emitter_.startColor = startColor;
+	
+	ccColor4F startColorVar = emitter_.startColorVar;
+	startColorVar.b = 0.1f;
+	emitter_.startColorVar = startColorVar;
+	
+	emitter_.emissionRate = emitter_.totalParticles/emitter_.life;
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: @"snow.png"];
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ normalBlending];
+	[batchNode_ addChild:emitter_]; 
+	
+}
+-(NSString *) title
+{
+	return @"ParticleSnow";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchRain
+-(void) onEnter
+{
+	[super onEnter];
+	self.emitter = [CCParticleRain node];
+
+	
+	CGPoint p = emitter_.position;
+	emitter_.position = ccp( p.x, p.y-100);
+	emitter_.life = 4;
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: PARTICLE_FIRE_NAME];
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ normalBlending];
+	[batchNode_ addChild:emitter_]; 
+	
+}
+-(NSString *) title
+{
+	return @"ParticleRain";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchModernArt
+-(void) onEnter
+{
+	[super onEnter];
+	emitter_ = [[CCParticleSystemPoint alloc] initWithTotalParticles:1000];
+
+	
+	CGSize s = [[CCDirector sharedDirector] winSize];
+	
+	// duration
+	emitter_.duration = kCCParticleDurationInfinity;
+	
+	// Gravity mode
+	emitter_.emitterMode = kCCParticleModeGravity;
+	
+	// Gravity mode: gravity
+	emitter_.gravity = ccp(0,0);
+	
+	// Gravity mode: radial
+	emitter_.radialAccel = 70;
+	emitter_.radialAccelVar = 10;
+	
+	// Gravity mode: tagential
+	emitter_.tangentialAccel = 80;
+	emitter_.tangentialAccelVar = 0;
+	
+	// Gravity mode: speed of particles
+	emitter_.speed = 50;
+	emitter_.speedVar = 10;
+	
+	// angle
+	emitter_.angle = 0;
+	emitter_.angleVar = 360;
+	
+	// emitter position
+	emitter_.position = ccp( s.width/2, s.height/2);
+	emitter_.posVar = CGPointZero;
+	
+	// life of particles
+	emitter_.life = 2.0f;
+	emitter_.lifeVar = 0.3f;
+	
+	// emits per frame
+	emitter_.emissionRate = emitter_.totalParticles/emitter_.life;
+	
+	// color of particles
+	ccColor4F startColor = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColor = startColor;
+	
+	ccColor4F startColorVar = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColorVar = startColorVar;
+	
+	ccColor4F endColor = {0.1f, 0.1f, 0.1f, 0.2f};
+	emitter_.endColor = endColor;
+	
+	ccColor4F endColorVar = {0.1f, 0.1f, 0.1f, 0.2f};	
+	emitter_.endColorVar = endColorVar;
+	
+	// size, in pixels
+	emitter_.startSize = 1.0f;
+	emitter_.startSizeVar = 1.0f;
+	emitter_.endSize = 32.0f;
+	emitter_.endSizeVar = 8.0f;
+	
+	// texture
+	//	emitter_.texture = [[TextureCache sharedTextureCache] addImage:@"fire-grayscale.png"];
+	
+	// additive
+	emitter_.blendAdditive = NO;
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ normalBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"Varying size";
+}
+
+-(NSString *) subTitle
+{
+	return @"doesn't work, is a point particle system";
+}
+@end
+
+#pragma mark -
+
+@implementation DemoBatchRing
+-(void) onEnter
+{
+	[super onEnter];
+	emitter_ = [[CCParticleFlower alloc] initWithTotalParticles:500];
+
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: @"stars-grayscale.png"];
+	emitter_.lifeVar = 0;
+	emitter_.life = 10;
+	emitter_.speed = 100;
+	emitter_.speedVar = 0;
+	emitter_.emissionRate = 10000;
+	
+	[self setEmitterPosition];
+	
+	[batchNode_ setTexture:emitter_.texture]; 
+	
+	[batchNode_ additiveBlending];
+	[batchNode_ addChild:emitter_]; 
+}
+-(NSString *) title
+{
+	return @"Ring DemoBatch";
+}
+@end
+
+#pragma mark -
+
+@implementation ParallaxParticle
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[[background parent] removeChild:background cleanup:YES];
+	background = nil;
+	
+	CCParallaxNode *p = [CCParallaxNode node];
+	[self addChild:p z:5];
+	
+	CCSprite *p1 = [CCSprite spriteWithFile:@"background3.png"];
+	background = p1;
+	
+	CCSprite *p2 = [CCSprite spriteWithFile:@"background3.png"];
+	
+	[p addChild:p1 z:1 parallaxRatio:ccp(0.5f,1) positionOffset:ccp(0,250)];
+	[p addChild:p2 z:2 parallaxRatio:ccp(1.5f,1) positionOffset:ccp(0,50)];
+	
+	
+	emitter_ = [[CCParticleFlower alloc] initWithTotalParticles:500];
+
+	[emitter_ setPosition:ccp(250,200)];
+	
+	
+	
+	id move = [CCMoveBy actionWithDuration:4 position:ccp(300,0)];
+	id move_back = [move reverse];
+	id seq = [CCSequence actions: move, move_back, nil];
+	[p runAction:[CCRepeatForever actionWithAction:seq]];	
+	
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:100 useQuad:YES additiveBlending:NO]; 
+	[p1 addChild:batchNode_];
+	
+	[batchNode_ additiveBlending];
+	[batchNode_ addChild:emitter_]; 
+	
+	//new batchNode
+	CCParticleSystem* par = [[CCParticleSun alloc] initWithTotalParticles:250];
+
+	
+	CCParticleBatchNode* bNode = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:300 useQuad:YES additiveBlending:YES]; 
+	[p2 addChild:bNode];
+	[bNode addChild:par];
+ 	
+	[par release];
+	
+	
+}
+
+-(NSString *) title
+{
+	return @"Parallax + Particles";
+}
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner1
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/SpookyPeas.plist"];
+	
+	// custom spinning
+	emitter_.startSpin = 0;
+	emitter_.startSpinVar = 360;
+	emitter_.endSpin = 720;
+	emitter_.endSpinVar = 360;
+	
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:NO]; 
+	[self addChild:batchNode_];
+	
+
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Spooky Peas";
+}
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner2
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/SpinningPeas.plist"];
+	
+	
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:NO]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Spinning Peas";
+}
+@end
+
+
+#pragma mark -
+
+@implementation ParticleDesigner3
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/LavaFlow.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:YES]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Lava Flow";
+}
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner4
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/ExplodingRing.plist"];
+
+	
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:YES]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Exploding Ring";
+}
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner5
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/Comet.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:YES]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Comet";
+}
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner6
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/BurstPipe.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:YES]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Burst Pipe";
+}
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner7
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/BoilingFoam.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:YES]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Boiling Foam";
+}
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner8
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/Flower.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:YES]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Flower";
+}
+
+-(NSString*) subtitle
+{
+	return @"Testing radial & tangential accel";
+}
+
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner9
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/Spiral.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:NO]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Blur Spiral";
+}
+
+-(NSString*) subtitle
+{
+	return @"Testing radial & tangential accel";
+}
+
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner10
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/Galaxy.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:YES]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Galaxy";
+}
+-(NSString*) subtitle
+{
+	return @"Testing radial & tangential accel";
+}
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner11
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/debian.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:NO]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Debian";
+}
+-(NSString*) subtitle
+{
+	return @"Testing radial & tangential accel";
+}
+@end
+
+#pragma mark -
+
+@implementation ParticleDesigner12
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/Phoenix.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:YES]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+}
+
+-(NSString *) title
+{
+	return @"PD: Phoenix";
+}
+-(NSString*) subtitle
+{
+	return @"Testing radial and duration";
+}
+@end
+
+#pragma mark -
+
+@implementation RadiusMode1
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	emitter_ = [[CCParticleSystemQuad alloc] initWithTotalParticles:200];
+
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: @"stars-grayscale.png"];
+	
+	// duration
+	emitter_.duration = kCCParticleDurationInfinity;
+	
+	// radius mode
+	emitter_.emitterMode = kCCParticleModeRadius;
+	
+	// radius mode: start and end radius in pixels
+	emitter_.startRadius = 0;
+	emitter_.startRadiusVar = 0;
+	emitter_.endRadius = 160;
+	emitter_.endRadiusVar = 0;
+	
+	// radius mode: degrees per second
+	emitter_.rotatePerSecond = 180;
+	emitter_.rotatePerSecondVar = 0;
+	
+	
+	// angle
+	emitter_.angle = 90;
+	emitter_.angleVar = 0;
+	
+	// emitter position
+	CGSize size = [[CCDirector sharedDirector] winSize];
+	emitter_.position = ccp( size.width/2, size.height/2);
+	emitter_.posVar = CGPointZero;
+	
+	// life of particles
+	emitter_.life = 5;
+	emitter_.lifeVar = 0;
+	
+	// spin of particles
+	emitter_.startSpin = 0;
+	emitter_.startSpinVar = 0;
+	emitter_.endSpin = 0;
+	emitter_.endSpinVar = 0;
+	
+	// color of particles
+	ccColor4F startColor = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColor = startColor;
+	
+	ccColor4F startColorVar = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColorVar = startColorVar;
+	
+	ccColor4F endColor = {0.1f, 0.1f, 0.1f, 0.2f};
+	emitter_.endColor = endColor;
+	
+	ccColor4F endColorVar = {0.1f, 0.1f, 0.1f, 0.2f};	
+	emitter_.endColorVar = endColorVar;
+	
+	// size, in pixels
+	emitter_.startSize = 32;
+	emitter_.startSizeVar = 0;
+	emitter_.endSize = kCCParticleStartSizeEqualToEndSize;
+	
+	// emits per second
+	emitter_.emissionRate = emitter_.totalParticles/emitter_.life;
+	
+	// additive
+	emitter_.blendAdditive = NO;
+
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:NO]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 	
+}
+
+
+-(NSString *) title
+{
+	return @"Radius Mode: Spiral";
+}
+@end
+
+#pragma mark -
+
+@implementation RadiusMode2
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	//200
+	emitter_ = [[CCParticleSystemQuad alloc] initWithTotalParticles:200];
+	
+	
+	emitter_.texture = [[CCTextureCache sharedTextureCache] addImage: @"stars-grayscale.png"];
+	
+	// duration
+	emitter_.duration = kCCParticleDurationInfinity;
+	
+	// radius mode
+	emitter_.emitterMode = kCCParticleModeRadius;
+	
+	// radius mode: 100 pixels from center
+	emitter_.startRadius = 100;
+	emitter_.startRadiusVar = 0;
+	emitter_.endRadius = kCCParticleStartRadiusEqualToEndRadius;
+	emitter_.endRadiusVar = 0;	// not used when start == end
+	
+	// radius mode: degrees per second
+	// 45 * 4 seconds of life = 180 degrees
+	emitter_.rotatePerSecond = 45;
+	emitter_.rotatePerSecondVar = 0;
+	
+	
+	// angle
+	emitter_.angle = 90;
+	emitter_.angleVar = 0;
+	
+	// emitter position
+	CGSize size = [[CCDirector sharedDirector] winSize];
+	emitter_.position = ccp( size.width/2, size.height/2);
+	emitter_.posVar = CGPointZero;
+	
+	// life of particles
+	emitter_.life = 4;
+	emitter_.lifeVar = 0;
+	
+	// spin of particles
+	emitter_.startSpin = 0;
+	emitter_.startSpinVar = 0;
+	emitter_.endSpin = 0;
+	emitter_.endSpinVar = 0;
+	
+	// color of particles
+	ccColor4F startColor = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColor = startColor;
+	
+	ccColor4F startColorVar = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColorVar = startColorVar;
+	
+	ccColor4F endColor = {0.1f, 0.1f, 0.1f, 0.2f};
+	emitter_.endColor = endColor;
+	
+	ccColor4F endColorVar = {0.1f, 0.1f, 0.1f, 0.2f};	
+	emitter_.endColorVar = endColorVar;
+	
+	// size, in pixels
+	emitter_.startSize = 32;
+	emitter_.startSizeVar = 0;
+	emitter_.endSize = kCCParticleStartSizeEqualToEndSize;
+	
+	// emits per second
+	emitter_.emissionRate = emitter_.totalParticles/emitter_.life;
+	
+	// additive
+	emitter_.blendAdditive = NO;
+	
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:NO]; 
+	[self addChild:batchNode_];
+
+	
+	[batchNode_ addChild:emitter_]; 	
+}
+
+-(NSString *) title
+{
+	return @"Radius Mode: Semi Circle";
+}
+@end
+
+#pragma mark -
+
+@implementation Issue704
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	emitter_ = [[CCParticleSystemQuad alloc] initWithTotalParticles:100];
+
+	emitter_.duration = kCCParticleDurationInfinity;
+	
+	// radius mode
+	emitter_.emitterMode = kCCParticleModeRadius;
+	
+	// radius mode: 50 pixels from center
+	emitter_.startRadius = 50;
+	emitter_.startRadiusVar = 0;
+	emitter_.endRadius = kCCParticleStartRadiusEqualToEndRadius;
+	emitter_.endRadiusVar = 0;	// not used when start == end
+	
+	// radius mode: degrees per second
+	// 45 * 4 seconds of life = 180 degrees
+	emitter_.rotatePerSecond = 0;
+	emitter_.rotatePerSecondVar = 0;
+	
+	
+	// angle
+	emitter_.angle = 90;
+	emitter_.angleVar = 0;
+	
+	// emitter position
+	CGSize size = [[CCDirector sharedDirector] winSize];
+	emitter_.position = ccp( size.width/2, size.height/2);
+	emitter_.posVar = CGPointZero;
+	
+	// life of particles
+	emitter_.life = 5;
+	emitter_.lifeVar = 0;
+	
+	// spin of particles
+	emitter_.startSpin = 0;
+	emitter_.startSpinVar = 0;
+	emitter_.endSpin = 0;
+	emitter_.endSpinVar = 0;
+	
+	// color of particles
+	ccColor4F startColor = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColor = startColor;
+	
+	ccColor4F startColorVar = {0.5f, 0.5f, 0.5f, 1.0f};
+	emitter_.startColorVar = startColorVar;
+	
+	ccColor4F endColor = {0.1f, 0.1f, 0.1f, 0.2f};
+	emitter_.endColor = endColor;
+	
+	ccColor4F endColorVar = {0.1f, 0.1f, 0.1f, 0.2f};	
+	emitter_.endColorVar = endColorVar;
+	
+	// size, in pixels
+	emitter_.startSize = 16;
+	emitter_.startSizeVar = 0;
+	emitter_.endSize = kCCParticleStartSizeEqualToEndSize;
+	
+	// emits per second
+	emitter_.emissionRate = emitter_.totalParticles/emitter_.life;
+	
+	// additive
+	emitter_.blendAdditive = NO;
+	
+	id rot = [CCRotateBy actionWithDuration:16 angle:360];
+	[emitter_ runAction: [CCRepeatForever actionWithAction:rot] ];
+	
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:NO]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; }
+
+-(NSString *) title
+{
+	return @"Issue 704. Free + Rot";
+}
+
+-(NSString*) subtitle
+{
+	return @"Emitted particles should not rotate";
+}
+@end
+
+#pragma mark -
+
+@implementation Issue872
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	emitter_ = [[CCParticleSystemQuad alloc] initWithFile:@"Particles/Upsidedown.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:YES]; 
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; }
+
+-(NSString *) title
+{
+	return @"Issue 872. UpsideDown";
+}
+
+-(NSString*) subtitle
+{
+	return @"Particles should NOT be Upside Down. M should appear, not W.";
+}
+@end
+
+#pragma mark -
+
+@implementation Issue870
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	CCParticleSystemQuad *system = [[CCParticleSystemQuad alloc] initWithFile:@"Particles/SpinningPeas.plist"];
+	
+	[system setTexture: [[CCTextureCache sharedTextureCache] addImage:@"particles.png"] withRect:CGRectMake(0,0,32,32)];
+
+	
+	emitter_ = system;
+	
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithTexture:emitter_.texture capacity:500 useQuad:YES additiveBlending:NO]; 
+	//the texture particles is premultiplied according to the loading code, but it still gives incorrect results
+	[batchNode_ switchBlendingBetweenMultipliedAndPreMultiplied];
+	[self addChild:batchNode_];
+	
+	
+	[batchNode_ addChild:emitter_]; 
+	
+	index = 0;
+	
+	[self schedule:@selector(updateQuads:) interval:2];
+}
+
+-(void) updateQuads:(ccTime)dt
+{
+	index = (index + 1) % 4;
+	CGRect rect = CGRectMake(index*32, 0,32,32);
+	
+	CCParticleSystemQuad *system = (CCParticleSystemQuad*) emitter_;
+	[system setTexture:[emitter_ texture] withRect:rect];
+}
+
+-(NSString *) title
+{
+	return @"Issue 870. SubRect";
+}
+
+-(NSString*) subtitle
+{
+	return @"Every 2 seconds the particle should change";
+}
+@end
+
+@implementation MultipleParticleSystems
+
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	[[CCTextureCache sharedTextureCache] addImage:@"particles.png"]; 
+	
+	for (int i = 0; i<5; i++) {
+		CCParticleSystemQuad *particleSystem = [CCParticleSystemQuad 
+												particleWithFile:@"Particles/SpinningPeas.plist"];
+	
+		[particleSystem setTexture:[[CCTextureCache sharedTextureCache] textureForKey:@"particles.png"]]; 
+		particleSystem.position = ccp(i*50 ,i*50);
+		
+		particleSystem.positionType = kCCPositionTypeGrouped;
+		[self addChild:particleSystem];
+	}
+	
+	emitter_ = nil;
+	
+}
+
+-(NSString *) title
+{
+	return @"Multiple particle systems";
+}
+
+-(NSString*) subtitle
+{
+	return @"FPS should be lower than next test";
+}
+
+-(void) update:(ccTime) dt
+{
+	CCLabelAtlas *atlas = (CCLabelAtlas*) [self getChildByTag:kTagLabelAtlas];
+	
+	uint count = 0; 
+	CCNode* item;
+	CCARRAY_FOREACH(children_, item)
+	{
+		if ([item isKindOfClass:[CCParticleSystem class]])
+		{
+			count += [(CCParticleSystem*) item particleCount];	
+		}
+	}
+	NSString *str = [NSString stringWithFormat:@"%4d", count];
+	[atlas setString:str];
+}
+
+@end
+
+@implementation MultipleParticleSystemsBatched
+
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	CGRect rect = CGRectMake(0.f,0.f,0.f,0.f);
+	CCParticleBatchNode *batchNode = [[CCParticleBatchNode alloc] initWithFile:@"particles.png" capacity:3000 useQuad:YES additiveBlending:NO];
+	//particles is loaded as pre multiplied, but using pre multiplied blending mode gives incorrect results
+	[batchNode switchBlendingBetweenMultipliedAndPreMultiplied];
+	
+	[self addChild:batchNode z:1 tag:2];
+	
+	for (int i = 0; i<5; i++) {
+
+		CCParticleSystemQuad *particleSystem = [CCParticleSystemQuad particleWithFile:@"Particles/SpinningPeas.plist" batchNode:batchNode rect:rect];
+	
+		particleSystem.positionType = kCCPositionTypeGrouped;		 
+		[particleSystem setTexture:[[CCTextureCache sharedTextureCache] textureForKey:@"particles.png"]]; 
+		particleSystem.position = ccp(i*50 ,i*50);
+		
+		[batchNode addChild:particleSystem];
+	}
+	
+	[batchNode release];
+	
+	emitter_ = nil;
+}
+
+-(void) update:(ccTime) dt
+{
+	CCLabelAtlas *atlas = (CCLabelAtlas*) [self getChildByTag:kTagLabelAtlas];
+	
+	uint count = 0; 
+	CCNode* item;
+	CCNode* batchNode = [self getChildByTag:2];
+	CCARRAY_FOREACH(batchNode.children, item)
+	{
+		if ([item isKindOfClass:[CCParticleSystem class]])
+		{
+			count += [(CCParticleSystem*) item particleCount];	
+		}
+	}
+	NSString *str = [NSString stringWithFormat:@"%4d", count];
+	[atlas setString:str];
+}
+
+-(NSString *) title
+{
+	return @"Multiple particle systems batched";
+}
+
+-(NSString*) subtitle
+{
+	return @"should perform better than previous test";
+}
+@end
+
+@implementation AddAndDeleteParticleSystems
+
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	CGRect rect = CGRectMake(0.f,0.f,0.f,0.f);
+	//adds the texture inside the plist to the texture cache
+	[CCParticleBatchNode extractTextureFromPlist:@"Particles/Spiral.plist"];
+	batchNode_ = [CCParticleBatchNode particleBatchNodeWithFile:@"Spiral.png" capacity:20 useQuad:YES additiveBlending:NO];
+
+	[self addChild:batchNode_ z:1 tag:2];
+	
+	for (int i = 0; i<5; i++) {
+		
+		CCParticleSystemQuad *particleSystem = [CCParticleSystemQuad particleWithFile:@"Particles/Spiral.plist" batchNode:batchNode_ rect:rect];
+		
+		particleSystem.positionType = kCCPositionTypeGrouped;		 
+		particleSystem.totalParticles = 2;
+
+		particleSystem.position = ccp(i*15 +100,i*15+100);
+		
+		
+		[batchNode_ addChild:particleSystem z:i tag:-1];
+		
+	}
+	
+	[self schedule:@selector(removeSystem) interval:2];
+	emitter_ = nil;
+	
+}
+
+- (void) removeSystem
+{
+	if ([[batchNode_ children] count] > 0) 
+	{
+		
+		[batchNode_ removeChild:[[batchNode_ children] objectAtIndex:0] cleanup:YES];
+		CCParticleSystemQuad *particleSystem = [CCParticleSystemQuad particleWithFile:@"Particles/Spiral.plist" batchNode:batchNode_ rect:CGRectMake(0.f,0.f,0.f,0.f)];
+		
+		particleSystem.positionType = kCCPositionTypeGrouped;		 
+		particleSystem.totalParticles = 2;
+		
+		particleSystem.position = ccp(150 ,300);
+		
+		//[batchNode_ addChild:particleSystem z:2 tag:-1];
+	}
+}
+
+-(void) update:(ccTime) dt
+{
+	CCLabelAtlas *atlas = (CCLabelAtlas*) [self getChildByTag:kTagLabelAtlas];
+	
+	uint count = 0; 
+	CCNode* item;
+	CCNode* batchNode = [self getChildByTag:2];
+	CCARRAY_FOREACH(batchNode.children, item)
+	{
+		if ([item isKindOfClass:[CCParticleSystem class]])
+		{
+			count += [(CCParticleSystem*) item particleCount];	
+		}
+	}
+	NSString *str = [NSString stringWithFormat:@"%4d", count];
+	[atlas setString:str];
+}
+
+-(NSString *) title
+{
+	return @"add and remove";
+}
+
+-(NSString*) subtitle
+{
+	return @"every 2 sec 2 particles disappear";
+}
+@end
+
+
+@implementation ReorderParticleSystems
+
+-(void) onEnter
+{
+	[super onEnter];
+	
+	[self setColor:ccBLACK];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+	
+	CGRect rect = CGRectMake(0.f,0.f,0.f,0.f);
+	batchNode_ = [CCParticleBatchNode  particleBatchNodeWithFile:@"stars-grayscale.png" capacity:3000 useQuad:YES additiveBlending:NO];
+	
+	[self addChild:batchNode_ z:1 tag:2];
+
+	
+	for (int i = 0; i<2; i++) {
+		
+		CCParticleSystemQuad* particleSystem = [[CCParticleSystemQuad alloc] initWithTotalParticles:200 batchNode:batchNode_ rect:rect];
+		
+		// duration
+		particleSystem.duration = kCCParticleDurationInfinity;
+		
+		// radius mode
+		particleSystem.emitterMode = kCCParticleModeRadius;
+		
+		// radius mode: 100 pixels from center
+		particleSystem.startRadius = 100;
+		particleSystem.startRadiusVar = 0;
+		particleSystem.endRadius = kCCParticleStartRadiusEqualToEndRadius;
+		particleSystem.endRadiusVar = 0;	// not used when start == end
+		
+		// radius mode: degrees per second
+		// 45 * 4 seconds of life = 180 degrees
+		particleSystem.rotatePerSecond = 45;
+		particleSystem.rotatePerSecondVar = 0;
+		
+		
+		// angle
+		particleSystem.angle = 90;
+		particleSystem.angleVar = 0;
+		
+		// emitter position
+				particleSystem.posVar = CGPointZero;
+		
+		// life of particles
+		particleSystem.life = 4;
+		particleSystem.lifeVar = 0;
+		
+		// spin of particles
+		particleSystem.startSpin = 0;
+		particleSystem.startSpinVar = 0;
+		particleSystem.endSpin = 0;
+		particleSystem.endSpinVar = 0;
+		
+		// color of particles
+		ccColor4F startColor = {0.5f, 0.5f, 0.5f, 1.0f};
+		particleSystem.startColor = startColor;
+		
+		ccColor4F startColorVar = {0.5f, 0.5f, 0.5f, 1.0f};
+		particleSystem.startColorVar = startColorVar;
+		
+		ccColor4F endColor = {0.1f, 0.1f, 0.1f, 0.2f};
+		particleSystem.endColor = endColor;
+		
+		ccColor4F endColorVar = {0.1f, 0.1f, 0.1f, 0.2f};	
+		particleSystem.endColorVar = endColorVar;
+		
+		// size, in pixels
+		particleSystem.startSize = 32;
+		particleSystem.startSizeVar = 0;
+		particleSystem.endSize = kCCParticleStartSizeEqualToEndSize;
+		
+		// emits per second
+		particleSystem.emissionRate = particleSystem.totalParticles/particleSystem.life;
+		
+		// additive
+
+		particleSystem.position = ccp(i*10+120 ,200);
+		
+		
+		[batchNode_ addChild:particleSystem];
+		[particleSystem setPositionType:kCCPositionTypeFree];
+		
+		[particleSystem release];
+		
+		//[pBNode addChild:particleSystem z:10 tag:0];
+		
+	}
+	
+	[self schedule:@selector(reorderSystem:) interval:2];
+	emitter_ = nil;
+	
+}
+
+- (void) reorderSystem:(ccTime) time
+{
+	CCParticleSystem* system = [[batchNode_ children] objectAtIndex:1];
+	[batchNode_ reorderChild:system z:[system zOrder] - 1]; 	
+}
+
+
+-(void) update:(ccTime) dt
+{
+	CCLabelAtlas *atlas = (CCLabelAtlas*) [self getChildByTag:kTagLabelAtlas];
+	
+	uint count = 0; 
+	CCNode* item;
+	CCNode* batchNode = [self getChildByTag:2];
+	CCARRAY_FOREACH(batchNode.children, item)
+	{
+		if ([item isKindOfClass:[CCParticleSystem class]])
+		{
+			count += [(CCParticleSystem*) item particleCount];	
+		}
+	}
+	NSString *str = [NSString stringWithFormat:@"%4d", count];
+	[atlas setString:str];
+}
+
+-(NSString *) title
+{
+	return @"reorder systems";
+}
+
+-(NSString*) subtitle
+{
+	return @"changes every 2 seconds";
+}
+@end
+
+
+#pragma mark -
+#pragma mark App Delegate
+
+// CLASS IMPLEMENTATIONS
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+@implementation AppController
+
+- (void) applicationDidFinishLaunching:(UIApplication*)application
+{
+	// CC_DIRECTOR_INIT()
+	//
+	// 1. Initializes an EAGLView with 0-bit depth format, and RGB565 render buffer
+	// 2. EAGLView multiple touches: disabled
+	// 3. creates a UIWindow, and assign it to the "window" var (it must already be declared)
+	// 4. Parents EAGLView to the newly created window
+	// 5. Creates Display Link Director
+	// 5a. If it fails, it will use an NSTimer director
+	// 6. It will try to run at 60 FPS
+	// 7. Display FPS: NO
+	// 8. Device orientation: Portrait
+	// 9. Connects the director to the EAGLView
+	//
+	CC_DIRECTOR_INIT();
+	
+	// Obtain the shared director in order to...
+	CCDirector *director = [CCDirector sharedDirector];
+	
+	// Turn on display FPS
+	[director setDisplayFPS:YES];
+	
+	// Enables High Res mode (Retina Display) on iPhone 4 and maintains low res on all other devices
+	if( ! [director enableRetinaDisplay:YES] )
+		CCLOG(@"Retina Display Not supported");
+	
+	// Default texture format for PNG/BMP/TIFF/JPEG/GIF images
+	// It can be RGBA8888, RGBA4444, RGB5_A1, RGB565
+	// You can change anytime.
+	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
+	
+	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
+	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
+	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
+	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	
+	CCScene *scene = [CCScene node];
+	[scene addChild: [nextAction() node]];
+	
+	[director runWithScene: scene];
+}
+
+- (void) dealloc
+{
+	[window release];
+	[super dealloc];
+}
+
+
+// getting a call, pause the game
+-(void) applicationWillResignActive:(UIApplication *)application
+{
+	[[CCDirector sharedDirector] pause];
+}
+
+// call got rejected
+-(void) applicationDidBecomeActive:(UIApplication *)application
+{
+	[[CCDirector sharedDirector] resume];
+}
+
+-(void) applicationDidEnterBackground:(UIApplication*)application
+{
+	[[CCDirector sharedDirector] stopAnimation];
+}
+
+-(void) applicationWillEnterForeground:(UIApplication*)application
+{
+	[[CCDirector sharedDirector] startAnimation];
+}
+
+// application will be killed
+- (void)applicationWillTerminate:(UIApplication *)application
+{	
+	CC_DIRECTOR_END();
+}
+
+// purge memory
+- (void)applicationDidReceiveMemoryWarning:(UIApplication *)application
+{
+	[[CCDirector sharedDirector] purgeCachedData];
+}
+
+// next delta time will be zero
+-(void) applicationSignificantTimeChange:(UIApplication *)application
+{
+	[[CCDirector sharedDirector] setNextDeltaTimeZero:YES];
+}
+@end
+
+
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+
+@implementation cocos2dmacAppDelegate
+
+@synthesize window=window_, glView=glView_;
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification
+{
+	CCDirectorMac *director = (CCDirectorMac*) [CCDirector sharedDirector];
+	
+	[director setDisplayFPS:YES];
+	
+	[director setOpenGLView:glView_];
+	
+	//	[director setProjection:kCCDirectorProjection2D];
+	
+	// Enable "moving" mouse event. Default no.
+	[window_ setAcceptsMouseMovedEvents:NO];
+	
+	// EXPERIMENTAL stuff.
+	// 'Effects' don't work correctly when autoscale is turned on.
+	[director setResizeMode:kCCDirectorResize_AutoScale];	
+	
+	CCScene *scene = [CCScene node];
+	[scene addChild: [nextAction() node]];
+	
+	[director runWithScene:scene];
+}
+
+- (BOOL) applicationShouldTerminateAfterLastWindowClosed: (NSApplication *) theApplication
+{
+	return YES;
+}
+
+- (IBAction)toggleFullScreen: (id)sender
+{
+	CCDirectorMac *director = (CCDirectorMac*) [CCDirector sharedDirector];
+	[director setFullScreen: ! [director isFullScreen] ];
+}
+
+@end
+#endif
+

--- a/Resources/Info copy.plist
+++ b/Resources/Info copy.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIconFiles</key>
+	<array>
+		<string>Icon.png</string>
+		<string>Icon@2x.png</string>
+		<string>Icon-72.png</string>
+		<string>Icon-Small-50.png</string>
+		<string>Icon-Small.png</string>
+		<string>Icon-Small@2x.png</string>
+	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.yourcompany.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIPrerenderedIcon</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<dict>
+		<key>accelerometer</key>
+		<true/>
+		<key>opengles-1</key>
+		<true/>
+	</dict>
+	<key>UIStatusBarHidden</key>
+	<true/>
+</dict>
+</plist>

--- a/cocos2d/CCParticleBatchNode.h
+++ b/cocos2d/CCParticleBatchNode.h
@@ -1,0 +1,128 @@
+/*
+ * cocos2d for iPhone: http://www.cocos2d-iphone.org
+ *
+ * Copyright (C) 2009 Matt Oswald
+ *
+ * Copyright (c) 2009-2010 Ricardo Quesada
+ * Copyright (c) 2011 Zynga Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#import "CCNode.h"
+@class CCTextureAtlas;
+@class CCParticleSystem;
+
+//don't use lazy sorting for particle systems
+@interface CCNode (extension) 
+-(void) setZOrder:(uint) z; 
+@end
+
+/** CCParticleBatchNode is like a batch node: if it contains children, it will draw them in 1 single OpenGL call
+ * (often known as "batch draw").
+ *
+ * A CCParticleBatchNode can reference one and only one texture (one image file, one texture atlas).
+ * Only the CCParticleSystems that are contained in that texture can be added to the CCSpriteBatchNode.
+ * All CCParticleSystems added to a CCSpriteBatchNode are drawn in one OpenGL ES draw call.
+ * If the CCParticleSystems are not added to a CCParticleBatchNode then an OpenGL ES draw call will be needed for each one, which is less efficient.
+ *
+ *
+ * Limitations:
+ * - At the moment only CCParticleSystemQuad is supported
+ * - All systems need to be drawn with the same parameters, blend function, aliasing, texture
+ * 
+ * Most efficient usage
+ * - Initialize the ParticleBatchNode with the texture and enough capacity for all the particle systems
+ * - Initialize all particle systems and add them as child to the batch node
+ * @since v1.1
+ */
+
+@interface CCParticleBatchNode : CCNode <CCTextureProtocol> {
+
+	CCTextureAtlas	*textureAtlas_;
+	ccBlendFunc		blendFunc_;
+	
+	BOOL useQuad_; //YES childs are quad particle systems, NO childs are point particle systems
+	
+	BOOL reorderDirty_; //YES if one of the childs is reordered
+}
+
+/** the texture atlas used for drawing the quads */
+@property (nonatomic, retain) CCTextureAtlas* textureAtlas;
+/** the blend function used for drawing the quads */
+@property (nonatomic, readwrite) ccBlendFunc blendFunc;
+
+/** initializes the particle system with CCTexture2D, a default capacity of 500, quad particle system and normal blending */
++(id)particleBatchNodeWithTexture:(CCTexture2D *)tex;
+
+/** initializes the particle system with CCTexture2D, 
+    a capacity of particles, which particle system to use and a choice between normal or additive blending
+*/
++(id)particleBatchNodeWithTexture:(CCTexture2D *)tex capacity:(NSUInteger) capacity useQuad:(BOOL) useQuad additiveBlending:(BOOL) additive;
+
+/** initializes the particle system with the name of a file on disk (for a list of supported formats look at the CCTexture2D class), 
+ a default capacity of 500 particles, quad particle system and normal blending
+ */
++(id)particleBatchNodeWithFile:(NSString*) imageFile;
+
+/** initializes the particle system with the name of a file on disk (for a list of supported formats look at the CCTexture2D class), 
+ a capacity of particles, which particle system to use and a choice between normal or additive blending
+ */
++(id)particleBatchNodeWithFile:(NSString*)fileImage capacity:(NSUInteger)capacity useQuad:(BOOL) useQuad additiveBlending:(BOOL) additive;
+
+/** extracts texture data from a plist and puts the texture in the texture cache. Use it before loading the batch node */
++(BOOL) extractTextureFromPlist:(NSString*) plistFile;
+
+/** initializes the particle system with CCTexture2D, 
+ a capacity of particles, which particle system to use and a choice between normal or additive blending
+ */
+-(id)initWithTexture:(CCTexture2D *)tex capacity:(NSUInteger)capacity useQuad:(BOOL) useQuad additiveBlending:(BOOL) additive;
+
+/** initializes the particle system with the name of a file on disk (for a list of supported formats look at the CCTexture2D class), 
+ a capacity of particles, which particle system to use and a choice between normal or additive blending
+ */
+-(id)initWithFile:(NSString *)fileImage capacity:(NSUInteger)capacity useQuad:(BOOL) useQuad additiveBlending:(BOOL) additive;
+
+/** only CCParticleSystemQuad is supported for the moment */
+-(void) addChild:(CCParticleSystem*)child z:(NSInteger)z tag:(NSInteger) aTag;
+
+/** helper method for addChild, adds room to texture atlas for particles of child */ 
+-(void) insertChild:(CCParticleSystem*) pSystem inAtlasAtIndex:(NSUInteger)index;
+
+/** helper method for removeChild, removes child's particles from texture atlas */ 
+-(void) removeChildFromAtlas:(CCParticleSystem*) pSystem cleanup:(BOOL) doCleanUp;
+
+/** disables a particle by inserting a 0'd quad into the texture atlas */
+-(void) disableParticle:(uint) particleIndex;
+
+/** switch between multiplied and premultiplied blending modes */ 
+-(void) switchBlendingBetweenMultipliedAndPreMultiplied;
+
+/** set a additive blending mode */
+-(void) additiveBlending;
+
+/** set a normal blending mode, taking premultiplied / non premultiplied into account */
+-(void) normalBlending;
+
+/** conforming to CCTextureProtocol */
+-(void) updateBlendFunc;
+-(void) setTexture:(CCTexture2D*)texture;
+-(CCTexture2D*) texture;
+@end

--- a/cocos2d/CCParticleBatchNode.m
+++ b/cocos2d/CCParticleBatchNode.m
@@ -1,0 +1,528 @@
+/*
+ * cocos2d for iPhone: http://www.cocos2d-iphone.org
+ *
+ * Copyright (C) 2009 Matt Oswald
+ *
+ * Copyright (c) 2009-2010 Ricardo Quesada
+ * Copyright (c) 2011 Zynga Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#import "CCParticleBatchNode.h"
+#import "CCTextureCache.h"
+#import "CCTextureAtlas.h"
+#import "ccConfig.h"
+#import "ccMacros.h"
+#import "CCGrid.h"
+#import "Support/CGPointExtension.h"
+#import "CCParticleSystem.h"
+#import "CCParticleSystem.h"
+#import "CCParticleSystemPoint.h"
+
+#import "Support/base64.h"
+#import "Support/ZipUtils.h"
+#import "Support/CCFileUtils.h"
+
+#define kDefaultCapacity 500
+
+//need to set z-order manualy, because fast reordering of childs would be complexer / slower
+@implementation CCNode (extension)
+-(void) setZOrder:(uint) z
+{
+	zOrder_ = z; 	
+}
+@end
+
+@interface CCParticleBatchNode (private)
+-(void) updateAllAtlasIndexes;
+-(void) increaseAtlasCapacityTo:(NSUInteger) quantity;
+-(NSUInteger) searchNewPositionInChildrenForZ:(NSInteger) z;
+-(NSUInteger) addChildHelper: (CCNode*) child z:(NSInteger)z tag:(NSInteger) aTag;
+-(void) moveSystem:(CCParticleSystem*) system toNewIndex:(NSUInteger) newIndex;
+@end
+
+@implementation CCParticleBatchNode
+
+@synthesize textureAtlas = textureAtlas_;
+@synthesize blendFunc = blendFunc_;
+
++(BOOL) extractTextureFromPlist:(NSString*) plistFile
+{
+	NSString *path = [CCFileUtils fullPathFromRelativePath:plistFile];
+	NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:path];
+	
+	NSAssert( dict != nil, @"ParticleBatchNode: plist file not found");
+	
+	NSString *textureName = [dict valueForKey:@"textureFileName"];
+	
+	CCTexture2D *tex = [[CCTextureCache sharedTextureCache] addImage:textureName];
+	
+	if( !tex )
+	{
+		NSString *textureData = [dict valueForKey:@"textureImageData"];
+		NSAssert( textureData, @"CCuseQuad: Couldn't load texture");
+		
+		// if it fails, try to get it from the base64-gzipped data			
+		unsigned char *buffer = NULL;
+		int len = base64Decode((unsigned char*)[textureData UTF8String], (unsigned int)[textureData length], &buffer);
+		NSAssert( buffer != NULL, @"CCuseQuad: error decoding textureImageData");
+		
+		unsigned char *deflated = NULL;
+		NSUInteger deflatedLen = ccInflateMemory(buffer, len, &deflated);
+		free( buffer );
+		
+		NSAssert( deflated != NULL, @"CCuseQuad: error ungzipping textureImageData");
+		NSData *data = [[NSData alloc] initWithBytes:deflated length:deflatedLen];
+		
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+		UIImage *image = [[UIImage alloc] initWithData:data];
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+		NSBitmapImageRep *image = [[NSBitmapImageRep alloc] initWithData:data];
+#endif
+		
+		free(deflated); deflated = NULL;
+		
+		tex = [ [CCTextureCache sharedTextureCache] addCGImage:[image CGImage] forKey:textureName];
+		[data release];
+		[image release];
+	}
+	if (tex) return YES; 
+	else return NO;
+}
+
+/*
+ * creation with CCTexture2D
+ */
++(id)particleBatchNodeWithTexture:(CCTexture2D *)tex
+{
+	return [[[self alloc] initWithTexture:tex capacity:kDefaultCapacity useQuad:YES additiveBlending:NO] autorelease];
+}
+
++(id)particleBatchNodeWithTexture:(CCTexture2D *)tex capacity:(NSUInteger) capacity useQuad:(BOOL) useQuad additiveBlending:(BOOL) additive
+{
+	return [[[self alloc] initWithTexture:tex capacity:capacity useQuad:YES additiveBlending:additive] autorelease];
+}
+
+/*
+ * creation with File Image
+ */
++(id)particleBatchNodeWithFile:(NSString*)fileImage capacity:(NSUInteger)capacity useQuad:(BOOL) useQuad additiveBlending:(BOOL) additive
+{
+	return [[[self alloc] initWithFile:fileImage capacity:capacity useQuad:useQuad additiveBlending:additive] autorelease];
+}
+
++(id)particleBatchNodeWithFile:(NSString*) imageFile
+{
+	return [[[self alloc] initWithFile:imageFile capacity:kDefaultCapacity useQuad:YES additiveBlending:NO] autorelease];
+}
+
+/*
+ * init with CCTexture2D
+ */
+-(id)initWithTexture:(CCTexture2D *)tex capacity:(NSUInteger)capacity useQuad:(BOOL) useQuad additiveBlending:(BOOL) additive
+{
+	if (self = [super init])
+	{
+		useQuad_ = useQuad; 
+		reorderDirty_ = NO;
+		
+		//TODO initialize point atlas here
+		if (useQuad_) textureAtlas_ = [[CCTextureAtlas alloc] initWithTexture:tex capacity:capacity];
+		
+		if (additive) [self additiveBlending];
+		else [self normalBlending];
+		
+		// no lazy alloc in this node
+		children_ = [[CCArray alloc] initWithCapacity:5];
+	}
+
+	return self;
+}
+
+/*
+ * init with FileImage
+ */
+-(id)initWithFile:(NSString *)fileImage capacity:(NSUInteger)capacity useQuad:(BOOL) useQuad additiveBlending:(BOOL) additive
+{
+	CCTexture2D *tex = [[CCTextureCache sharedTextureCache] addImage:fileImage];
+	return [self initWithTexture:tex capacity:capacity useQuad:useQuad additiveBlending:additive];
+}
+
+-(NSString*) description
+{
+	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i>", [self class], self, tag_ ];
+}
+
+-(void)dealloc
+{	
+	[textureAtlas_ release];
+	[super dealloc];
+}
+
+#pragma mark CCParticleBatchNode - composition
+
+// override visit.
+// Don't call visit on it's children
+-(void) visit
+{
+	
+	// CAREFUL:
+	// This visit is almost identical to CocosNode#visit
+	// with the exception that it doesn't call visit on it's children
+	//
+	// The alternative is to have a void CCSprite#visit, but
+	// although this is less mantainable, is faster
+	//
+	if (!visible_)
+		return;
+	
+	glPushMatrix();
+	
+	if ( grid_ && grid_.active) {
+		[grid_ beforeDraw];
+		[self transformAncestors];
+	}
+	
+	//update of particle system is called before reordering is done, data in texture atlas is not up to date yet, need to set quads again according to new atlasIndexes
+	if (reorderDirty_) 
+	{	
+		[children_ makeObjectsPerformSelector:@selector(updateWithNoTime)];
+		reorderDirty_ = NO;	
+	}
+	[self transform];
+	
+	[self draw];
+		
+	if ( grid_ && grid_.active)
+		[grid_ afterDraw:self];
+	
+	glPopMatrix();
+}
+
+// override addChild:
+-(void) addChild:(CCParticleSystem*)child z:(NSInteger)z tag:(NSInteger) aTag
+{
+	NSAssert( child != nil, @"Argument must be non-nil");
+	NSAssert( [child isKindOfClass:[CCParticleSystem class]], @"CCParticleBatchNode only supports CCQuadParticleSystems as children");
+	
+	if (useQuad_) 
+	{	
+		NSAssert( child.texture.name == textureAtlas_.texture.name, @"CCParticleSystem is not using the same texture id");
+	}
+	
+	//no lazy sorting, so don't call super addChild, call helper instead
+	uint pos = [self addChildHelper:child z:z tag:aTag];
+	
+	//get new atlasIndex
+	uint atlasIndex;
+	
+	if (pos != 0) atlasIndex = [[children_ objectAtIndex:pos-1] atlasIndex]+[[children_ objectAtIndex:pos-1] totalParticles];
+	else atlasIndex = 0;
+	
+	[child useBatchNode:self];
+	
+	[self insertChild:child inAtlasAtIndex:atlasIndex];
+}
+
+//don't use lazy sorting, reordering the particle systems quads afterwards would be too complex
+//XXX research whether lazy sorting + freeing current quads and calloc a new block with size of capacity would be faster
+//XXX or possibly using vertexZ for reordering, that would be fastest
+//this helper is almost equivalent to CCNode's addChild, but doesn't make use of the lazy sorting
+-(uint) addChildHelper: (CCNode*) child z:(NSInteger)z tag:(NSInteger) aTag
+{	
+	NSAssert( child != nil, @"Argument must be non-nil");
+	NSAssert( child.parent == nil, @"child already added. It can't be added again");
+	
+	if( ! children_ ) children_ = [[CCArray alloc] initWithCapacity:4];
+			
+	//don't use a lazy insert
+	uint pos = [self searchNewPositionInChildrenForZ:z];
+	
+	[children_ insertObject:child atIndex:pos];
+	
+	child.tag = aTag;
+	[child setZOrder:z]; 
+	
+	[child setParent: self];
+		
+	if( isRunning_ ) {
+		[child onEnter];
+		[child onEnterTransitionDidFinish];
+	}
+	return pos;
+}
+
+// override reorderChild
+-(void) reorderChild:(CCParticleSystem*)child z:(NSInteger)z
+{
+	NSAssert( child != nil, @"Child must be non-nil");
+	NSAssert( [children_ containsObject:child], @"Child doesn't belong to Sprite" );
+	
+	if( z == child.zOrder )
+		return;
+	
+	if ([children_ count] == 1) [child setZOrder:z];
+	else
+	{	
+		reorderDirty_ = YES;
+		[child retain]; 
+		
+		uint oldPos = [children_ indexOfObject:child]; 
+
+		//only remove the child, not the scheduled update 
+		[children_ removeObject:child]; 
+		
+		uint pos = [self searchNewPositionInChildrenForZ:z]; 
+		
+		if (pos != oldPos)
+		{
+			uint newIndex;
+			if (pos == [children_ count]) newIndex = textureAtlas_.totalQuads;
+			else newIndex = [[children_ objectAtIndex:MIN([children_ count]-1,pos)] atlasIndex];
+			
+			//to correctly move the quads, the new index needs to be the left border of where the quads will be placed
+			if (z > child.zOrder) newIndex -= child.totalParticles;
+			
+			 //move quads in textureAtlas
+			[self moveSystem:child toNewIndex:newIndex]; 
+		}
+		[children_ insertObject:child atIndex:pos];  
+		
+		[child release];
+		
+		//renew atlasIndexes of children
+		[self updateAllAtlasIndexes];
+	}
+}
+					 
+-(NSUInteger) searchNewPositionInChildrenForZ: (NSInteger) z
+{
+	int i = 0;
+	uint count = [children_ count];
+	CCNode* child;
+	
+	while (i < count) 
+	{
+		child = [children_ objectAtIndex:i];
+		if (child.zOrder > z) return MAX(0,(i-1));
+		
+		i++;
+	}
+
+	if (z >= 0) return MAX(0,count);
+	else return 0;
+}
+
+// override removeChild:
+-(void)removeChild: (CCParticleSystem*) child cleanup:(BOOL) doCleanup
+{
+	// explicit nil handling
+	if (child == nil)
+		return;
+	
+	NSAssert([children_ containsObject:child], @"CCParticleBatchNode doesn't contain the sprite. Can't remove it");
+	
+	[super removeChild:child cleanup:doCleanup];
+	
+	// cleanup before removing
+	[self removeChildFromAtlas:child cleanup:doCleanup];
+}
+
+-(void)removeChildAtIndex:(NSUInteger)index cleanup:(BOOL) doCleanup
+{
+	[self removeChild:(CCParticleSystem *)[children_ objectAtIndex:index] cleanup:doCleanup];
+}
+
+-(void)removeAllChildrenWithCleanup:(BOOL)doCleanup
+{
+	[children_ makeObjectsPerformSelector:@selector(useSelfRender)];
+	
+	[super removeAllChildrenWithCleanup:doCleanup];
+	
+	[textureAtlas_ removeAllQuads];
+}
+
+#pragma mark CCParticleBatchNode - draw
+-(void) draw
+{
+	//don't call super draw, it's empty
+	//[super draw];
+	
+	if( textureAtlas_.totalQuads == 0 )
+		return;	
+
+	// Default GL states: GL_TEXTURE_2D, GL_VERTEX_ARRAY, GL_COLOR_ARRAY, GL_TEXTURE_COORD_ARRAY
+	// Needed states: GL_TEXTURE_2D, GL_VERTEX_ARRAY, GL_COLOR_ARRAY, GL_TEXTURE_COORD_ARRAY
+	// Unneeded states: -
+	
+	BOOL newBlend = blendFunc_.src != CC_BLEND_SRC || blendFunc_.dst != CC_BLEND_DST;
+	if( newBlend )
+		glBlendFunc( blendFunc_.src, blendFunc_.dst );
+	
+	[textureAtlas_ drawQuads];
+	if( newBlend )
+		glBlendFunc(CC_BLEND_SRC, CC_BLEND_DST);
+}
+
+#pragma mark CCParticleBatchNode - private
+
+-(void) increaseAtlasCapacityTo:(NSUInteger) quantity
+{
+	CCLOG(@"cocos2d: CCParticleBatchNode: resizing TextureAtlas capacity from [%lu] to [%lu].",
+		  (long)textureAtlas_.capacity,
+		  (long)quantity);
+		
+	if( ! [textureAtlas_ resizeCapacity:quantity] ) {
+		// serious problems
+		CCLOG(@"cocos2d: WARNING: Not enough memory to resize the atlas");
+		NSAssert(NO,@"XXX: CCParticleBatchNode #increaseAtlasCapacity SHALL handle this assert");
+	}	
+}
+
+-(void) moveSystem:(CCParticleSystem*) system toNewIndex:(NSUInteger) newIndex
+{
+	[textureAtlas_ insertQuadsFromIndex:system.atlasIndex amount:system.totalParticles atIndex:newIndex];
+}
+
+//sets a 0'd quad into the quads array
+-(void) disableParticle:(uint) particleIndex
+{
+	ccV3F_C4B_T2F_Quad* quad = &((textureAtlas_.quads)[particleIndex]);
+	quad->br.vertices.x = quad->br.vertices.y = quad->tr.vertices.x = quad->tr.vertices.y = quad->tl.vertices.x = quad->tl.vertices.y = quad->bl.vertices.x = quad->bl.vertices.y = 0.0f;		
+}
+
+#pragma mark CCParticleBatchNode - add / remove / reorder helper methods
+
+// add child helper
+-(void) insertChild:(CCParticleSystem*) pSystem inAtlasAtIndex:(NSUInteger)index
+{
+	pSystem.atlasIndex = index;
+	
+	if(textureAtlas_.totalQuads + pSystem.totalParticles > textureAtlas_.capacity)
+	{	
+		[self increaseAtlasCapacityTo:textureAtlas_.totalQuads + pSystem.totalParticles];
+		
+		//after a realloc empty quads of textureAtlas can be filled with gibberish (realloc doesn't perform calloc), insert empty quads to prevent it
+		[textureAtlas_ fillWithEmptyQuadsFromIndex:textureAtlas_.capacity - pSystem.totalParticles amount:pSystem.totalParticles];
+	}
+	
+	if (useQuad_) 
+	{	
+		//make room for quads, not necessary for last child		
+		if (pSystem.atlasIndex+pSystem.totalParticles != textureAtlas_.totalQuads) [textureAtlas_ moveQuadsFromIndex:index to:index+pSystem.totalParticles];
+		
+		//increase totalParticles here for new particles, update method of particlesystem will fill the quads
+		[textureAtlas_ increaseTotalQuadsWith:pSystem.totalParticles];
+		
+		[pSystem batchNodeInitialization];
+	}
+	
+	[self updateAllAtlasIndexes];
+}
+
+// remove child helper
+-(void) removeChildFromAtlas:(CCParticleSystem*) pSystem cleanup:(BOOL) doCleanUp
+{
+	[textureAtlas_ removeQuadsAtIndex:pSystem.atlasIndex amount:pSystem.totalParticles];
+	
+	//after memove of data, empty the quads at the end of array
+	[textureAtlas_ fillWithEmptyQuadsFromIndex:textureAtlas_.totalQuads amount:pSystem.totalParticles];
+	
+	//with no cleanup the particle system could be reused for self rendering
+	if (!doCleanUp) [pSystem useSelfRender];
+	
+	[self updateAllAtlasIndexes];
+}
+
+//rebuild atlas indexes
+-(void) updateAllAtlasIndexes
+{
+	CCParticleSystem* child;
+	uint index = 0;
+
+	CCARRAY_FOREACH(children_,child)
+	{
+		child.atlasIndex = index; 
+		index += child.totalParticles;
+	}
+}	
+	
+#pragma mark CCParticleBatchNode - CocosNodeTexture protocol
+
+-(void) additiveBlending
+{
+	blendFunc_.src = GL_SRC_ALPHA;
+	blendFunc_.dst = GL_ONE;		
+}
+
+-(void) normalBlending
+{
+	if( ! [textureAtlas_.texture hasPremultipliedAlpha] ) {
+		blendFunc_.src = GL_SRC_ALPHA;
+		blendFunc_.dst = GL_ONE_MINUS_SRC_ALPHA;
+	}
+	else 
+	{
+		blendFunc_.src = GL_ONE;
+		blendFunc_.dst = GL_ONE_MINUS_SRC_ALPHA;	
+	}
+}
+
+-(void) switchBlendingBetweenMultipliedAndPreMultiplied
+{
+	if (blendFunc_.src == GL_ONE) 
+	{
+		blendFunc_.src = GL_SRC_ALPHA;
+		blendFunc_.dst = GL_ONE_MINUS_SRC_ALPHA;
+	}
+	else 
+	{
+		blendFunc_.src = GL_ONE;
+		blendFunc_.dst = GL_ONE_MINUS_SRC_ALPHA;	
+	}
+}
+
+-(void) updateBlendFunc
+{
+	if( ! [textureAtlas_.texture hasPremultipliedAlpha] ) {
+		blendFunc_.src = GL_SRC_ALPHA;
+		blendFunc_.dst = GL_ONE_MINUS_SRC_ALPHA;
+	}
+}
+
+-(void) setTexture:(CCTexture2D*)texture
+{
+	textureAtlas_.texture = texture;
+			
+	// If the new texture has No premultiplied alpha, AND the blendFunc hasn't been changed, then update it
+	if( texture && ! [texture hasPremultipliedAlpha] && ( blendFunc_.src == CC_BLEND_SRC && blendFunc_.dst == CC_BLEND_DST ) ) 
+	{
+			blendFunc_.src = GL_SRC_ALPHA;
+			blendFunc_.dst = GL_ONE_MINUS_SRC_ALPHA;
+	}
+}
+
+-(CCTexture2D*) texture
+{
+	return textureAtlas_.texture;
+}
+
+@end

--- a/cocos2d/CCParticleSystem.h
+++ b/cocos2d/CCParticleSystem.h
@@ -30,8 +30,10 @@
 #import "ccTypes.h"
 #import "ccConfig.h"
 
+@class CCParticleBatchNode;
 #if CC_ENABLE_PROFILERS
 @class CCProfilingTimer;
+
 #endif
 
 //* @enum
@@ -87,6 +89,7 @@ enum {
  */
 typedef struct sCCParticle {
 	CGPoint		pos;
+	float		z;
 	CGPoint		startPos;
 
 	ccColor4F	color;
@@ -99,6 +102,8 @@ typedef struct sCCParticle {
 	float		deltaRotation;
 
 	ccTime		timeToLive;
+	
+	uint		atlasIndex;
 
 	union {
 		// Mode A: gravity, direction, radial accel, tangential accel
@@ -260,17 +265,13 @@ typedef void (*CC_UPDATE_PARTICLE_IMP)(id, SEL, tCCParticle*, CGPoint);
 	// end angle ariance
 	float endSpinVar;
 	
-	
 	// Array of particles
 	tCCParticle *particles;
 	// Maximum particles
 	NSUInteger totalParticles;
 	// Count of active particles
 	NSUInteger particleCount;
-	
-	// color modulate
-//	BOOL colorModulate;
-	
+		
 	// How many particles can be emitted per second
 	float emissionRate;
 	float emitCounter;
@@ -292,6 +293,14 @@ typedef void (*CC_UPDATE_PARTICLE_IMP)(id, SEL, tCCParticle*, CGPoint);
 	// Optimization
 	CC_UPDATE_PARTICLE_IMP	updateParticleImp;
 	SEL						updateParticleSel;
+	
+	//for batching
+	CCParticleBatchNode *batchNode_; 
+	BOOL useBatchNode_; 
+	//index of system in batch node array
+	uint atlasIndex_; 
+	//YES if scaled or rotated
+	BOOL transformSystemDirty_;
 	
 // profiling
 #if CC_ENABLE_PROFILERS
@@ -401,6 +410,10 @@ typedef void (*CC_UPDATE_PARTICLE_IMP)(id, SEL, tCCParticle*, CGPoint);
  */
 @property (nonatomic,readwrite) NSInteger emitterMode;
 
+@property (nonatomic,readwrite) uint atlasIndex;
+
+@property (nonatomic,readonly) BOOL useBatchNode; 
+
 /** creates an initializes a CCParticleSystem from a plist file.
  This plist files can be creted manually or with Particle Designer:
 	http://particledesigner.71squared.com/
@@ -420,7 +433,7 @@ typedef void (*CC_UPDATE_PARTICLE_IMP)(id, SEL, tCCParticle*, CGPoint);
  */
 -(id) initWithDictionary:(NSDictionary*)dictionary;
 
-//! Initializes a system with a fixed number of particles
+//! Initializes a system with a fixed number of particles and whether a batchnode is used for rendering
 -(id) initWithTotalParticles:(NSUInteger) numberOfParticles;
 //! Add a particle to the emitter
 -(BOOL) addParticle;
@@ -441,5 +454,13 @@ typedef void (*CC_UPDATE_PARTICLE_IMP)(id, SEL, tCCParticle*, CGPoint);
 //! called in every loop.
 -(void) update: (ccTime) dt;
 
-@end
+-(void) updateWithNoTime;
 
+//switch to self rendering
+-(void) useSelfRender;
+//switch to batch node rendering
+-(void) useBatchNode:(CCParticleBatchNode*) batchNode;
+
+//used internally by CCParticleBathNode 
+-(void) batchNodeInitialization;
+@end

--- a/cocos2d/CCParticleSystem.m
+++ b/cocos2d/CCParticleSystem.m
@@ -51,7 +51,9 @@
 #import "Support/CCProfiling.h"
 #endif
 #import "CCParticleSystem.h"
+#import "CCParticleBatchNode.h"
 #import "CCTextureCache.h"
+#import "CCTextureAtlas.h"
 #import "ccMacros.h"
 
 // support
@@ -77,6 +79,8 @@
 @synthesize positionType = positionType_;
 @synthesize autoRemoveOnFinish = autoRemoveOnFinish_;
 @synthesize emitterMode = emitterMode_;
+@synthesize atlasIndex = atlasIndex_;
+@synthesize useBatchNode = useBatchNode_;
 
 
 +(id) particleWithFile:(NSString*) plistFile
@@ -103,8 +107,9 @@
 {
 	NSUInteger maxParticles = [[dictionary valueForKey:@"maxParticles"] intValue];
 	// self, not super
-	if ((self=[self initWithTotalParticles:maxParticles] ) ) {
-		
+	
+	if ((self=[self initWithTotalParticles:maxParticles] ) )
+	{	
 		// angle
 		angle = [[dictionary valueForKey:@"angle"] floatValue];
 		angleVar = [[dictionary valueForKey:@"angleVariance"] floatValue];
@@ -149,7 +154,6 @@
 		endSize = [[dictionary valueForKey:@"finishParticleSize"] floatValue];
 		endSizeVar = [[dictionary valueForKey:@"finishParticleSizeVariance"] floatValue];
 		
-		
 		// position
 		float x = [[dictionary valueForKey:@"sourcePositionx"] floatValue];
 		float y = [[dictionary valueForKey:@"sourcePositiony"] floatValue];
@@ -157,7 +161,6 @@
 		posVar.x = [[dictionary valueForKey:@"sourcePositionVariancex"] floatValue];
 		posVar.y = [[dictionary valueForKey:@"sourcePositionVariancey"] floatValue];
 				
-		
 		// Spinning
 		startSpin = [[dictionary valueForKey:@"rotationStart"] floatValue];
 		startSpinVar = [[dictionary valueForKey:@"rotationStartVariance"] floatValue];
@@ -192,7 +195,6 @@
 			mode.A.tangentialAccelVar = tmp ? [tmp floatValue] : 0;
 		}
 		
-		
 		// or Mode B: radius movement
 		else if( emitterMode_ == kCCParticleModeRadius ) {
 			float maxRadius = [[dictionary valueForKey:@"maxRadius"] floatValue];
@@ -217,49 +219,51 @@
 		// emission Rate
 		emissionRate = totalParticles/life;
 
+		//don't get the internal texture if a batchNode is used
+		if (!batchNode_) 
+		{
 		// texture		
 		// Try to get the texture from the cache
-		NSString *textureName = [dictionary valueForKey:@"textureFileName"];
-
-		CCTexture2D *tex = [[CCTextureCache sharedTextureCache] addImage:textureName];
-
-		if( tex )
-			self.texture = tex;
-
-		else {
-
-			NSString *textureData = [dictionary valueForKey:@"textureImageData"];
-			NSAssert( textureData, @"CCParticleSystem: Couldn't load texture");
+			NSString *textureName = [dictionary valueForKey:@"textureFileName"];
 			
-			// if it fails, try to get it from the base64-gzipped data			
-			unsigned char *buffer = NULL;
-			int len = base64Decode((unsigned char*)[textureData UTF8String], (unsigned int)[textureData length], &buffer);
-			NSAssert( buffer != NULL, @"CCParticleSystem: error decoding textureImageData");
-				
-			unsigned char *deflated = NULL;
-			NSUInteger deflatedLen = ccInflateMemory(buffer, len, &deflated);
-			free( buffer );
-				
-			NSAssert( deflated != NULL, @"CCParticleSystem: error ungzipping textureImageData");
-			NSData *data = [[NSData alloc] initWithBytes:deflated length:deflatedLen];
+			CCTexture2D *tex = [[CCTextureCache sharedTextureCache] addImage:textureName];
 			
+			if( tex )
+				[self setTexture:tex];
+			else {
+				
+				NSString *textureData = [dictionary valueForKey:@"textureImageData"];
+				NSAssert( textureData, @"CCParticleSystem: Couldn't load texture");
+				
+				// if it fails, try to get it from the base64-gzipped data			
+				unsigned char *buffer = NULL;
+				int len = base64Decode((unsigned char*)[textureData UTF8String], (unsigned int)[textureData length], &buffer);
+				NSAssert( buffer != NULL, @"CCParticleSystem: error decoding textureImageData");
+				
+				unsigned char *deflated = NULL;
+				NSUInteger deflatedLen = ccInflateMemory(buffer, len, &deflated);
+				free( buffer );
+				
+				NSAssert( deflated != NULL, @"CCParticleSystem: error ungzipping textureImageData");
+				NSData *data = [[NSData alloc] initWithBytes:deflated length:deflatedLen];
+				
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-			UIImage *image = [[UIImage alloc] initWithData:data];
+				UIImage *image = [[UIImage alloc] initWithData:data];
 #elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
-			NSBitmapImageRep *image = [[NSBitmapImageRep alloc] initWithData:data];
+				NSBitmapImageRep *image = [[NSBitmapImageRep alloc] initWithData:data];
 #endif
+				
+				free(deflated); deflated = NULL;
+				
+				[self setTexture:  [ [CCTextureCache sharedTextureCache] addCGImage:[image CGImage] forKey:textureName]];
+				[data release];
+				[image release];				
+			}
 			
-			free(deflated); deflated = NULL;
-
-			self.texture = [[CCTextureCache sharedTextureCache] addCGImage:[image CGImage] forKey:textureName];
-			[data release];
-			[image release];
+			NSAssert( [self texture] != NULL, @"CCParticleSystem: error loading the texture");
 		}
+	}	
 		
-		NSAssert( [self texture] != NULL, @"CCParticleSystem: error loading the texture");
-		
-	}
-	
 	return self;
 }
 
@@ -277,6 +281,14 @@
 			return nil;
 		}
 		
+		if (batchNode_)
+		{
+			for (int i = 0; i < totalParticles; i++)
+			{
+				particles[i].atlasIndex=i;	
+			}
+		}
+		
 		// default, active
 		active = YES;
 		
@@ -288,11 +300,7 @@
 		
 		// by default be in mode A:
 		emitterMode_ = kCCParticleModeGravity;
-				
-		// default: modulate
-		// XXX: not used
-	//	colorModulate = YES;
-		
+						
 		autoRemoveOnFinish_ = NO;
 
 		// profiling
@@ -303,12 +311,13 @@
 		// Optimization: compile udpateParticle method
 		updateParticleSel = @selector(updateQuadWithParticle:newPosition:);
 		updateParticleImp = (CC_UPDATE_PARTICLE_IMP) [self methodForSelector:updateParticleSel];
+		
+		//for batchNode
+		transformSystemDirty_ = NO;
 
 		// udpate after action in run!
 		[self scheduleUpdateWithPriority:1];
-		
 	}
-
 	return self;
 }
 
@@ -340,7 +349,7 @@
 
 -(void) initParticle: (tCCParticle*) particle
 {
-
+	//CGPoint currentPosition = position_;
 	// timeToLive
 	// no negative life. prevent division by 0
 	particle->timeToLive = life + lifeVar * CCRANDOM_MINUS1_1();
@@ -348,8 +357,10 @@
 
 	// position
 	particle->pos.x = sourcePosition.x + posVar.x * CCRANDOM_MINUS1_1();
-	particle->pos.x *= CC_CONTENT_SCALE_FACTOR();
 	particle->pos.y = sourcePosition.y + posVar.y * CCRANDOM_MINUS1_1();
+	
+	//CCLOG(@"particle pos %f %f n pos %f %f",particle->pos.x,particle->pos.y, position_.x,position_.y);
+	particle->pos.x *= CC_CONTENT_SCALE_FACTOR();
 	particle->pos.y *= CC_CONTENT_SCALE_FACTOR();
 	
 	// Color
@@ -443,6 +454,8 @@
 		particle->mode.B.angle = a;
 		particle->mode.B.degreesPerSecond = CC_DEGREES_TO_RADIANS(mode.B.rotatePerSecond + mode.B.rotatePerSecondVar * CCRANDOM_MINUS1_1());
 	}	
+	
+	particle->z=vertexZ_; 
 }
 
 -(void) stopSystem
@@ -460,6 +473,7 @@
 		tCCParticle *p = &particles[particleIdx];
 		p->timeToLive = 0;
 	}
+
 }
 
 -(BOOL) isFull
@@ -485,113 +499,141 @@
 	
 	particleIdx = 0;
 	
-	
 #if CC_ENABLE_PROFILERS
 	CCProfilingBeginTimingBlock(_profilingTimer);
 #endif
+		
+	CGPoint currentPosition;
+	//if (useBatchNode_) currentPosition = [self.parent convertToWorldSpace:self.position];
+	//else 
+	currentPosition = CGPointZero;
 	
-	
-	CGPoint currentPosition = CGPointZero;
 	if( positionType_ == kCCPositionTypeFree ) {
 		currentPosition = [self convertToWorldSpace:CGPointZero];
 		currentPosition.x *= CC_CONTENT_SCALE_FACTOR();
 		currentPosition.y *= CC_CONTENT_SCALE_FACTOR();
 	}
 	else if( positionType_ == kCCPositionTypeRelative ) {
+	//currentPosition = [self convertToWorldSpace:CGPointZero];
 		currentPosition = position_;
 		currentPosition.x *= CC_CONTENT_SCALE_FACTOR();
 		currentPosition.y *= CC_CONTENT_SCALE_FACTOR();
 	}
 	
-	while( particleIdx < particleCount )
+	if (visible_) 
 	{
-		tCCParticle *p = &particles[particleIdx];
-		
-		// life
-		p->timeToLive -= dt;
+		while( particleIdx < particleCount )
+		{
+			tCCParticle *p = &particles[particleIdx];
+			
+			// life
+			p->timeToLive -= dt;
 
-		if( p->timeToLive > 0 ) {
-			
-			// Mode A: gravity, direction, tangential accel & radial accel
-			if( emitterMode_ == kCCParticleModeGravity ) {
-				CGPoint tmp, radial, tangential;
+			if( p->timeToLive > 0 ) {
 				
-				radial = CGPointZero;
-				// radial acceleration
-				if(p->pos.x || p->pos.y)
-					radial = ccpNormalize(p->pos);
+				// Mode A: gravity, direction, tangential accel & radial accel
+				if( emitterMode_ == kCCParticleModeGravity ) {
+					CGPoint tmp, radial, tangential;
+					
+					radial = CGPointZero;
+					// radial acceleration
+					if(p->pos.x || p->pos.y)
+						radial = ccpNormalize(p->pos);
+					
+					tangential = radial;
+					radial = ccpMult(radial, p->mode.A.radialAccel);
+					
+					// tangential acceleration
+					float newy = tangential.x;
+					tangential.x = -tangential.y;
+					tangential.y = newy;
+					tangential = ccpMult(tangential, p->mode.A.tangentialAccel);
+					
+					// (gravity + radial + tangential) * dt
+					tmp = ccpAdd( ccpAdd( radial, tangential), mode.A.gravity);
+					tmp = ccpMult( tmp, dt);
+					p->mode.A.dir = ccpAdd( p->mode.A.dir, tmp);
+					tmp = ccpMult(p->mode.A.dir, dt);
+					p->pos = ccpAdd( p->pos, tmp );
+				}
 				
-				tangential = radial;
-				radial = ccpMult(radial, p->mode.A.radialAccel);
+				// Mode B: radius movement
+				else {				
+					// Update the angle and radius of the particle.
+					p->mode.B.angle += p->mode.B.degreesPerSecond * dt;
+					p->mode.B.radius += p->mode.B.deltaRadius * dt;
+					
+					p->pos.x = - cosf(p->mode.B.angle) * p->mode.B.radius;
+					p->pos.y = - sinf(p->mode.B.angle) * p->mode.B.radius;					
+				}
 				
-				// tangential acceleration
-				float newy = tangential.x;
-				tangential.x = -tangential.y;
-				tangential.y = newy;
-				tangential = ccpMult(tangential, p->mode.A.tangentialAccel);
+				// color
+				p->color.r += (p->deltaColor.r * dt);
+				p->color.g += (p->deltaColor.g * dt);
+				p->color.b += (p->deltaColor.b * dt);
+				p->color.a += (p->deltaColor.a * dt);
 				
-				// (gravity + radial + tangential) * dt
-				tmp = ccpAdd( ccpAdd( radial, tangential), mode.A.gravity);
-				tmp = ccpMult( tmp, dt);
-				p->mode.A.dir = ccpAdd( p->mode.A.dir, tmp);
-				tmp = ccpMult(p->mode.A.dir, dt);
-				p->pos = ccpAdd( p->pos, tmp );
-			}
-			
-			// Mode B: radius movement
-			else {				
-				// Update the angle and radius of the particle.
-				p->mode.B.angle += p->mode.B.degreesPerSecond * dt;
-				p->mode.B.radius += p->mode.B.deltaRadius * dt;
+				// size
+				p->size += (p->deltaSize * dt);
+				p->size = MAX( 0, p->size );
 				
-				p->pos.x = - cosf(p->mode.B.angle) * p->mode.B.radius;
-				p->pos.y = - sinf(p->mode.B.angle) * p->mode.B.radius;
-			}
-			
-			// color
-			p->color.r += (p->deltaColor.r * dt);
-			p->color.g += (p->deltaColor.g * dt);
-			p->color.b += (p->deltaColor.b * dt);
-			p->color.a += (p->deltaColor.a * dt);
-			
-			// size
-			p->size += (p->deltaSize * dt);
-			p->size = MAX( 0, p->size );
-			
-			// angle
-			p->rotation += (p->deltaRotation * dt);
-						
-			//
-			// update values in quad
-			//
-			
-			CGPoint	newPos;
-			
-			if( positionType_ == kCCPositionTypeFree || positionType_ == kCCPositionTypeRelative ) {
-				CGPoint diff = ccpSub( currentPosition, p->startPos );
-				newPos = ccpSub(p->pos, diff);
+				// angle
+				p->rotation += (p->deltaRotation * dt);
+							
+				//
+				// update values in quad
+				//
 				
-			} else
-				newPos = p->pos;
+				CGPoint	newPos;
+				
+				if( positionType_ == kCCPositionTypeFree || positionType_ == kCCPositionTypeRelative ) 
+				{
+					CGPoint diff = ccpSub( currentPosition, p->startPos );
+					newPos = ccpSub(p->pos, diff);	
+				} else
+					newPos = p->pos;
+				
+				//translate newPos to correct position, since matrix transform isn't performed in batchnode
+				//don't update the particle with the new position information, it will interfere with the radius and tangential calculations
+				if (useBatchNode_)
+				{
+						newPos.x+=position_.x; 
+						newPos.y+=position_.y;
+				}
+				
+				p->z = vertexZ_;
+				
+				updateParticleImp(self, updateParticleSel, p, newPos);
+				
+				// update particle counter
+				particleIdx++;
 
-			
-			updateParticleImp(self, updateParticleSel, p, newPos);
-			
-			// update particle counter
-			particleIdx++;
-			
-		} else {
-			// life < 0
-			if( particleIdx != particleCount-1 )
-				particles[particleIdx] = particles[particleCount-1];
-			particleCount--;
-			
-			if( particleCount == 0 && autoRemoveOnFinish_ ) {
-				[self unscheduleUpdate];
-				[parent_ removeChild:self cleanup:YES];
-				return;
+			} else {
+				// life < 0
+				uint currentIndex = p->atlasIndex;
+				
+				if( particleIdx != particleCount-1 )
+					particles[particleIdx] = particles[particleCount-1];
+								
+				if (useBatchNode_) 
+				{
+					//disable the switched particle 
+					[batchNode_ disableParticle:(atlasIndex_+currentIndex)];
+					
+					//switch indexes
+					particles[particleCount-1].atlasIndex = currentIndex; 
+				}
+				 
+				particleCount--;
+								
+				if( particleCount == 0 && autoRemoveOnFinish_ ) {
+					[self unscheduleUpdate];
+					[parent_ removeChild:self cleanup:YES];
+					return;
+				}
 			}
-		}
+		}//while
+		transformSystemDirty_ = NO;
 	}
 	
 #if CC_ENABLE_PROFILERS
@@ -599,8 +641,13 @@
 #endif
 	
 #ifdef CC_USES_VBO
-	[self postStep];
+	if (!useBatchNode_) [self postStep];
 #endif
+}
+
+-(void) updateWithNoTime
+{
+	[self update:0.0f];	
 }
 
 -(void) updateQuadWithParticle:(tCCParticle*)particle newPosition:(CGPoint)pos;
@@ -617,7 +664,6 @@
 
 -(void) setTexture:(CCTexture2D*) texture
 {
-	[texture_ release];
 	texture_ = [texture retain];
 
 	// If the new texture has No premultiplied alpha, AND the blendFunc hasn't been changed, then update it
@@ -803,6 +849,54 @@
 	NSAssert( emitterMode_ == kCCParticleModeRadius, @"Particle Mode should be Radius");
 	return mode.B.rotatePerSecondVar;
 }
+
+#pragma mark ParticleSystem - methods for batchNode rendering
+
+-(void) useSelfRender
+{
+	useBatchNode_ = NO;
+}
+
+-(void) useBatchNode:(CCParticleBatchNode*) batchNode
+{
+	batchNode_ = batchNode; 
+	useBatchNode_ = YES;
+	
+	//each particle needs a unique index
+	for (int i = 0; i < totalParticles; i++)
+	{
+		particles[i].atlasIndex=i;	
+	}
+}
+
+-(void) batchNodeInitialization
+{//override this
+}
+
+//don't use a transform matrix, this is faster
+-(void) setScale:(float) s
+{
+	transformSystemDirty_ = YES;
+	[super setScale:s];
+}
+
+-(void) setRotation: (float)newRotation
+{
+	transformSystemDirty_ = YES;
+	[super setRotation:newRotation];
+}
+
+-(void) setScaleX: (float)newScaleX
+{
+	transformSystemDirty_ = YES;
+	[super setScaleX:newScaleX];
+}
+
+-(void) setScaleY: (float)newScaleY
+{
+	transformSystemDirty_ = YES;
+	[super setScaleY:newScaleY];
+}
+
+
 @end
-
-

--- a/cocos2d/CCParticleSystemQuad.h
+++ b/cocos2d/CCParticleSystemQuad.h
@@ -44,16 +44,30 @@
   - On 3rd gen iPhone and iPads: It is MUCH faster than CCParticleSystemPoint
   - It consumes more RAM and more GPU memory than CCParticleSystemPoint
   - It supports subrects
+  - It supports batched rendering since 1.1
  @since v0.8
  */
 @interface CCParticleSystemQuad : CCParticleSystem
 {
-	ccV2F_C4B_T2F_Quad	*quads_;		// quads to be rendered
+	ccV3F_C4B_T2F_Quad	*quads_;		// quads to be rendered
 	GLushort			*indices_;		// indices
+	CGRect				textureRect_;
 #if CC_USES_VBO
 	GLuint				quadsID_;		// VBO id
 #endif
 }
+
+@property (nonatomic, readwrite) ccV3F_C4B_T2F_Quad* quads;
+
+/** create system with properties from plist, batchnode and rect on the sprite sheet 
+   use nil for batchNode to not use batch rendering 
+   if rect is (0.0f,0.0f,0.0f,0.0f) the whole texture width and height will be used
+*/ 
++(id) particleWithFile:(NSString*) plistFile batchNode:(CCParticleBatchNode*) batchNode rect:(CGRect) rect;
+
+-(id) initWithFile:(NSString *)plistFile batchNode:(CCParticleBatchNode*) batchNode rect:(CGRect) rect;
+
+-(id) initWithTotalParticles:(NSUInteger)numberOfParticles batchNode:(CCParticleBatchNode*) batchNode rect:(CGRect) rect;
 
 /** initialices the indices for the vertices */
 -(void) initIndices;
@@ -63,9 +77,10 @@
 
 /** Sets a new CCSpriteFrame as particle.
  WARNING: this method is experimental. Use setTexture:withRect instead.
+ uses the texture and the rect of the spriteframe to call setTexture:Rect:
  @since v0.99.4
  */
--(void)setDisplayFrame:(CCSpriteFrame*)spriteFrame;
+-(void) setDisplayFrame:(CCSpriteFrame*)spriteFrame;
 
 /** Sets a new texture with a rect. The rect is in Points.
  @since v0.99.4
@@ -73,4 +88,3 @@
 -(void) setTexture:(CCTexture2D *)texture withRect:(CGRect)rect;
 
 @end
-

--- a/cocos2d/CCParticleSystemQuad.m
+++ b/cocos2d/CCParticleSystemQuad.m
@@ -36,21 +36,69 @@
 #import "CCTextureCache.h"
 #import "ccMacros.h"
 #import "CCSpriteFrame.h"
+#import "CCParticleBatchNode.h"
+#import "CCTextureAtlas.h"
 
 // support
 #import "Support/OpenGL_Internal.h"
 #import "Support/CGPointExtension.h"
 
+@interface CCParticleSystemQuad (private)
+-(id) initializeParticleSystemWithBatchNode:(CCParticleBatchNode*) batchNode rect:(CGRect) rect;
+@end
+
 @implementation CCParticleSystemQuad
 
+@synthesize quads=quads_;
++(id) particleWithFile:(NSString*) plistFile batchNode:(CCParticleBatchNode*) batchNode rect:(CGRect) rect
+{
+	return [[[self alloc] initWithFile:plistFile batchNode:batchNode rect:rect] autorelease];
+}
 
-// overriding the init method
+-(id) initWithFile:(NSString *)plistFile  batchNode:(CCParticleBatchNode*) batchNode rect:(CGRect) rect
+{
+	batchNode_ = batchNode; 	
+	textureRect_ = rect; 
+	return [super initWithFile:plistFile];
+}
+
+// overriding the init method, this is the base initializer
+-(id) initWithTotalParticles:(NSUInteger)numberOfParticles batchNode:(CCParticleBatchNode*) batchNode rect:(CGRect) rect
+{
+	batchNode_ = batchNode; 
+	textureRect_ = rect;
+	
+	//first super then self 
+	if( (self=[super initWithTotalParticles:numberOfParticles]) ) {
+		if ([self initializeParticleSystemWithBatchNode:batchNode rect:rect]==nil) return nil; 
+	}
+	
+	return self;
+}
+
 -(id) initWithTotalParticles:(NSUInteger) numberOfParticles
 {
-	// base initialization
-	if( (self=[super initWithTotalParticles:numberOfParticles]) ) {
+	CCParticleBatchNode* batchNode = nil;
+	CGRect rect = CGRectMake(0.0f,0.0f,0.0f,0.0f); 
+	if (batchNode_) 
+	{
+		batchNode = batchNode_; 
+		rect = textureRect_; 
+	}	
+	return [self initWithTotalParticles:numberOfParticles batchNode:batchNode rect:rect];
+}
+
+-(id) initializeParticleSystemWithBatchNode:(CCParticleBatchNode*) batchNode rect:(CGRect) rect
+{
+	if (rect.size.width == 0.f && rect.size.height == 0.f && batchNode != nil) 
+	{	
+		rect.size = CGSizeMake([batchNode.textureAtlas.texture pixelsWide], [batchNode.textureAtlas.texture pixelsHigh]);
+	}	
 	
-		// allocating data space
+	// allocating data space
+	if (batchNode == nil) 
+	{	
+		
 		quads_ = calloc( sizeof(quads_[0]) * totalParticles, 1 );
 		indices_ = calloc( sizeof(indices_[0]) * totalParticles * 6, 1 );
 		
@@ -66,10 +114,10 @@
 		}
 		
 		// initialize only once the texCoords and the indices
-		[self initTexCoordsWithRect:CGRectMake(0, 0, [texture_ pixelsWide], [texture_ pixelsHigh])];
+		[self initTexCoordsWithRect:rect];
 		[self initIndices];
-
-#if CC_USES_VBO
+		
+	#if CC_USES_VBO
 		// create the VBO buffer
 		glGenBuffers(1, &quadsID_);
 		
@@ -77,18 +125,32 @@
 		glBindBuffer(GL_ARRAY_BUFFER, quadsID_);
 		glBufferData(GL_ARRAY_BUFFER, sizeof(quads_[0])*totalParticles, quads_,GL_DYNAMIC_DRAW);	
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
-#endif
-	}
+	#endif
 		
-	return self;
+		useBatchNode_ = NO;
+	}
+	else {
+		quads_ = NULL;
+		indices_ = NULL;
+		
+		batchNode_ = batchNode;
+		
+		//can't use setTexture here since system isn't added to batchnode yet
+		texture_ = [batchNode.textureAtlas.texture retain];
+		textureRect_ = rect; 
+
+		useBatchNode_ = YES;
+	}
+
+	return [NSNumber numberWithInt:1];
 }
 
 -(void) dealloc
 {
-	free(quads_);
-	free(indices_);
+	if (quads_) free(quads_);
+	if (indices_) free(indices_);
 #if CC_USES_VBO
-	glDeleteBuffers(1, &quadsID_);
+	if (!useBatchNode_) glDeleteBuffers(1, &quadsID_);
 #endif
 	
 	[super dealloc];
@@ -97,44 +159,65 @@
 // pointRect is in Points coordinates.
 -(void) initTexCoordsWithRect:(CGRect)pointRect
 {
-	// convert to pixels coords
-	CGRect rect = CGRectMake(
-							 pointRect.origin.x * CC_CONTENT_SCALE_FACTOR(),
-							 pointRect.origin.y * CC_CONTENT_SCALE_FACTOR(),
-							 pointRect.size.width * CC_CONTENT_SCALE_FACTOR(),
-							 pointRect.size.height * CC_CONTENT_SCALE_FACTOR() );
+	textureRect_ = pointRect;
+	
+	if (texture_)
+	{
+		// convert to pixels coords
+		CGRect rect = CGRectMake(
+								 pointRect.origin.x * CC_CONTENT_SCALE_FACTOR(),
+								 pointRect.origin.y * CC_CONTENT_SCALE_FACTOR(),
+								 pointRect.size.width * CC_CONTENT_SCALE_FACTOR(),
+								 pointRect.size.height * CC_CONTENT_SCALE_FACTOR() );
 
-	GLfloat wide = [texture_ pixelsWide];
-	GLfloat high = [texture_ pixelsHigh];
+		GLfloat wide = [texture_ pixelsWide];
+		GLfloat high = [texture_ pixelsHigh];
+		
 
 #if CC_FIX_ARTIFACTS_BY_STRECHING_TEXEL
-	GLfloat left = (rect.origin.x*2+1) / (wide*2);
-	GLfloat bottom = (rect.origin.y*2+1) / (high*2);
-	GLfloat right = left + (rect.size.width*2-2) / (wide*2);
-	GLfloat top = bottom + (rect.size.height*2-2) / (high*2);
+		GLfloat left = (rect.origin.x*2+1) / (wide*2);
+		GLfloat bottom = (rect.origin.y*2+1) / (high*2);
+		GLfloat right = left + (rect.size.width*2-2) / (wide*2);
+		GLfloat top = bottom + (rect.size.height*2-2) / (high*2);
 #else
-	GLfloat left = rect.origin.x / wide;
-	GLfloat bottom = rect.origin.y / high;
-	GLfloat right = left + rect.size.width / wide;
-	GLfloat top = bottom + rect.size.height / high;
+		GLfloat left = rect.origin.x / wide;
+		GLfloat bottom = rect.origin.y / high;
+		GLfloat right = left + rect.size.width / wide;
+		GLfloat top = bottom + rect.size.height / high;
 #endif // ! CC_FIX_ARTIFACTS_BY_STRECHING_TEXEL
 	
 	// Important. Texture in cocos2d are inverted, so the Y component should be inverted
-	CC_SWAP( top, bottom);
-	
-	for(NSUInteger i=0; i<totalParticles; i++) {
-		// bottom-left vertex:
-		quads_[i].bl.texCoords.u = left;
-		quads_[i].bl.texCoords.v = bottom;
-		// bottom-right vertex:
-		quads_[i].br.texCoords.u = right;
-		quads_[i].br.texCoords.v = bottom;
-		// top-left vertex:
-		quads_[i].tl.texCoords.u = left;
-		quads_[i].tl.texCoords.v = top;
-		// top-right vertex:
-		quads_[i].tr.texCoords.u = right;
-		quads_[i].tr.texCoords.v = top;
+		CC_SWAP( top, bottom);
+		
+		ccV3F_C4B_T2F_Quad *quadCollection; 
+		uint start, end; 
+		if (useBatchNode_)
+		{
+			quadCollection = [[batchNode_ textureAtlas] quads]; 
+			start = atlasIndex_; 
+			end = atlasIndex_ + totalParticles; 
+		}
+		else 
+		{
+			quadCollection = quads_; 
+			start = 0; 
+			end = totalParticles; 
+		}
+
+		for(int i=start; i<end; i++) {
+			// bottom-left vertex:
+			quadCollection[i].bl.texCoords.u = left;
+			quadCollection[i].bl.texCoords.v = bottom;
+			// bottom-right vertex:
+			quadCollection[i].br.texCoords.u = right;
+			quadCollection[i].br.texCoords.v = bottom;
+			// top-left vertex:
+			quadCollection[i].tl.texCoords.u = left;
+			quadCollection[i].tl.texCoords.v = top;
+			// top-right vertex:
+			quadCollection[i].tr.texCoords.u = right;
+			quadCollection[i].tr.texCoords.v = top;
+		}
 	}
 }
 
@@ -155,12 +238,11 @@
 
 -(void) setDisplayFrame:(CCSpriteFrame *)spriteFrame
 {
-
 	NSAssert( CGPointEqualToPoint( spriteFrame.offsetInPixels , CGPointZero ), @"QuadParticle only supports SpriteFrames with no offsets");
 
 	// update texture before updating texture rect
 	if ( spriteFrame.texture.name != texture_.name )
-		[self setTexture: spriteFrame.texture];	
+		[self setTexture: spriteFrame.texture withRect:spriteFrame.rect];	
 }
 
 -(void) initIndices
@@ -181,7 +263,14 @@
 -(void) updateQuadWithParticle:(tCCParticle*)p newPosition:(CGPoint)newPos
 {
 	// colors
-	ccV2F_C4B_T2F_Quad *quad = &(quads_[particleIdx]);
+	ccV3F_C4B_T2F_Quad *quad; 
+
+	if (useBatchNode_) 
+	{	
+		ccV3F_C4B_T2F_Quad *batchQuads = [[batchNode_ textureAtlas] quads]; 
+		quad = &(batchQuads[atlasIndex_+p->atlasIndex]); 
+	}
+	else quad = &(quads_[particleIdx]);
 	
 	ccColor4B color = { p->color.r*255, p->color.g*255, p->color.b*255, p->color.a*255};
 	quad->bl.colors = color;
@@ -191,7 +280,51 @@
 	
 	// vertices
 	GLfloat size_2 = p->size/2;
-	if( p->rotation ) {
+	//don't transform particles if type is free
+	if (useBatchNode_ && transformSystemDirty_ && positionType_!=kCCPositionTypeFree)
+	{
+		GLfloat x1 = -size_2*scaleX_;
+		GLfloat y1 = -size_2*scaleY_;
+		
+		GLfloat x2 = size_2*scaleX_;
+		GLfloat y2 = size_2*scaleY_;
+		GLfloat x = newPos.x;
+		GLfloat y = newPos.y;
+		
+		GLfloat r = (GLfloat)-CC_DEGREES_TO_RADIANS(p->rotation+rotation_);
+		GLfloat cr = cosf(r) * scaleX_;
+		GLfloat sr = sinf(r) * scaleX_;
+		GLfloat cr2 = cosf(r) * scaleY_;
+		GLfloat sr2 = sinf(r) * scaleY_;
+		GLfloat ax = x1 * cr - y1 * sr2 + x;
+		GLfloat ay = x1 * sr + y1 * cr2 + y;
+		GLfloat bx = x2 * cr - y1 * sr2 + x;
+		GLfloat by = x2 * sr + y1 * cr2 + y;
+		GLfloat cx = x2 * cr - y2 * sr2 + x;
+		GLfloat cy = x2 * sr + y2 * cr2 + y;
+		GLfloat dx = x1 * cr - y2 * sr2 + x;
+		GLfloat dy = x1 * sr + y2 * cr2 + y;
+		
+		// bottom-left
+		quad->bl.vertices.x = ax;
+		quad->bl.vertices.y = ay;
+		quad->bl.vertices.z = p->z;
+		
+		// bottom-right vertex:
+		quad->br.vertices.x = bx;
+		quad->br.vertices.y = by;
+		quad->br.vertices.z = p->z;
+		
+		// top-left vertex:
+		quad->tl.vertices.x = dx;
+		quad->tl.vertices.y = dy;
+		quad->tl.vertices.z = p->z;
+		// top-right vertex:
+		quad->tr.vertices.x = cx;
+		quad->tr.vertices.y = cy;
+		quad->tr.vertices.z = p->z;	
+	}
+	else if( p->rotation ) {
 		GLfloat x1 = -size_2;
 		GLfloat y1 = -size_2;
 		
@@ -260,6 +393,8 @@
 {	
 	[super draw];
 
+	NSAssert(!useBatchNode_,@"draw should not be called when added to a particleBatchNode"); 
+	
 	// Default GL states: GL_TEXTURE_2D, GL_VERTEX_ARRAY, GL_COLOR_ARRAY, GL_TEXTURE_COORD_ARRAY
 	// Needed states: GL_TEXTURE_2D, GL_VERTEX_ARRAY, GL_COLOR_ARRAY, GL_TEXTURE_COORD_ARRAY
 	// Unneeded states: -
@@ -271,25 +406,25 @@
 #if CC_USES_VBO
 	glBindBuffer(GL_ARRAY_BUFFER, quadsID_);
 
-	glVertexPointer(2,GL_FLOAT, kQuadSize, 0);
+	glVertexPointer(3,GL_FLOAT, kQuadSize, 0);
 
-	glColorPointer(4, GL_UNSIGNED_BYTE, kQuadSize, (GLvoid*) offsetof(ccV2F_C4B_T2F,colors) );
+	glColorPointer(4, GL_UNSIGNED_BYTE, kQuadSize, (GLvoid*) offsetof(ccV3F_C4B_T2F,colors) );
 	
-	glTexCoordPointer(2, GL_FLOAT, kQuadSize, (GLvoid*) offsetof(ccV2F_C4B_T2F,texCoords) );
+	glTexCoordPointer(2, GL_FLOAT, kQuadSize, (GLvoid*) offsetof(ccV3F_C4B_T2F,texCoords) );
 #else // vertex array list
 
 	NSUInteger offset = (NSUInteger) quads_;
 
 	// vertex
-	NSUInteger diff = offsetof( ccV2F_C4B_T2F, vertices);
+	NSUInteger diff = offsetof( ccV3F_C4B_T2F, vertices);
 	glVertexPointer(2,GL_FLOAT, kQuadSize, (GLvoid*) (offset+diff) );
 	
 	// color
-	diff = offsetof( ccV2F_C4B_T2F, colors);
+	diff = offsetof( ccV3F_C4B_T2F, colors);
 	glColorPointer(4, GL_UNSIGNED_BYTE, kQuadSize, (GLvoid*)(offset + diff));
 	
 	// tex coords
-	diff = offsetof( ccV2F_C4B_T2F, texCoords);
+	diff = offsetof( ccV3F_C4B_T2F, texCoords);
 	glTexCoordPointer(2, GL_FLOAT, kQuadSize, (GLvoid*)(offset + diff));		
 
 #endif // ! CC_USES_VBO
@@ -313,6 +448,36 @@
 	// -
 }
 
+-(void) useSelfRender
+{
+	if (useBatchNode_)
+	{
+		[self initializeParticleSystemWithBatchNode:nil rect:textureRect_];
+		useBatchNode_ = NO;
+	}
+}
+
+-(void) batchNodeInitialization
+{
+	[self initTexCoordsWithRect:textureRect_]; 	
+}
+
+-(void) useBatchNode:(CCParticleBatchNode*) batchNode
+{
+	if (!useBatchNode_)
+	{	
+		[super useBatchNode:batchNode]; 
+		
+		if (quads_) free(quads_);
+		quads_ = NULL;
+		
+		if (indices_) free(indices_);
+		indices_ = NULL;
+
+#if CC_USES_VBO
+		glDeleteBuffers(1, &quadsID_);
+#endif
+	}
+}
+
 @end
-
-

--- a/cocos2d/CCTextureAtlas.h
+++ b/cocos2d/CCTextureAtlas.h
@@ -100,11 +100,23 @@
  */
 -(void) insertQuad:(ccV3F_C4B_T2F_Quad*)quad atIndex:(NSUInteger)index;
 
+/** Inserts a c array of quads at a given index
+ index must be between 0 and the atlas capacity - 1
+ this method doesn't enlarge the array when amount + index > totalQuads
+ @since v1.1
+*/
+-(void) insertQuads:(ccV3F_C4B_T2F_Quad*)quads atIndex:(NSUInteger)index amount:(uint) amount;
+
 /** Removes the quad that is located at a certain index and inserts it at a new index
  This operation is faster than removing and inserting in a quad in 2 different steps
  @since v0.7.2
 */
 -(void) insertQuadFromIndex:(NSUInteger)fromIndex atIndex:(NSUInteger)newIndex;
+
+/** Inserts a amount of quads from oldIndex at newIndex, while moving quads at newIndex - oldIndex back accordingly 
+ @since v1.1
+ */
+-(void) insertQuadsFromIndex:(NSUInteger)oldIndex amount:(NSUInteger) amount atIndex:(NSUInteger)newIndex;
 
 /** removes a quad at a given index number.
  The capacity remains the same, but the total number of quads to be drawn is reduced in 1
@@ -112,6 +124,10 @@
  */
 -(void) removeQuadAtIndex:(NSUInteger) index;
 
+/** removes a amount of quads starting from index 
+	@since 1.1
+ */
+- (void) removeQuadsAtIndex:(NSUInteger) index amount:(uint) amount;
 /** removes all Quads.
  The TextureAtlas capacity remains untouched. No memory is freed.
  The total number of quads to be drawn will be 0
@@ -126,12 +142,35 @@
  */
 -(BOOL) resizeCapacity: (NSUInteger) n;
 
+/** 
+ Used internally by CCParticleBatchNode
+ don't use this unless you know what you're doing
+ @since 1.1
+*/
+- (void) increaseTotalQuadsWith:(uint) amount;
+
+/** 
+ Moves quads from index till totalQuads to the newIndex
+ Used internally by CCParticleBatchNode
+ This method doesn't enlarge the array if newIndex + quads to be moved > capacity
+ @since 1.1
+*/
+- (void) moveQuadsFromIndex:(NSUInteger) index to:(NSUInteger) newIndex;
+
+/** 
+ Ensures that after a realloc quads are still empty
+ Used internally by CCParticleBatchNode
+ @since 1.1
+*/
+- (void) fillWithEmptyQuadsFromIndex:(uint) index amount:(uint) amount;
+
+- (void) printAllQuads;
 
 /** draws n quads
  * n can't be greater than the capacity of the Atlas
  */
--(void) drawNumberOfQuads: (NSUInteger) n;
 
+-(void) drawNumberOfQuads: (NSUInteger) n;
 
 /** draws n quads from an index (offset).
  n + start can't be greater than the capacity of the atlas

--- a/cocos2d/CCTextureAtlas.m
+++ b/cocos2d/CCTextureAtlas.m
@@ -30,6 +30,8 @@
 #import "ccMacros.h"
 #import "CCTexture2D.h"
 #import "CCTextureCache.h"
+#import "CGPointExtension.h"
+#import "CCDrawingPrimitives.h"
 
 
 @interface CCTextureAtlas (Private)
@@ -108,7 +110,7 @@
 	return self;
 }
 
-- (NSString*) description
+-(NSString*) description
 {
 	return [NSString stringWithFormat:@"<%@ = %08X | totalQuads =  %i>", [self class], self, totalQuads_];
 }
@@ -167,6 +169,15 @@
 
 #pragma mark TextureAtlas - Update, Insert, Move & Remove
 
+-(ccV3F_C4B_T2F_Quad *) quads
+{
+	//if someone accesses the quads directly, presume that changes will be made
+#if CC_USES_VBO	
+	dirty_ = YES;
+#endif	
+	return quads_;	
+}
+
 -(void) updateQuad:(ccV3F_C4B_T2F_Quad*)quad atIndex:(NSUInteger) n
 {
 	NSAssert(n < capacity_, @"updateQuadWithTexture: Invalid index");
@@ -180,29 +191,59 @@
 #endif
 }
 
-
 -(void) insertQuad:(ccV3F_C4B_T2F_Quad*)quad atIndex:(NSUInteger)index
 {
 	NSAssert(index < capacity_, @"insertQuadWithTexture: Invalid index");
-
+	
 	totalQuads_++;
 	NSAssert( totalQuads_ <= capacity_, @"invalid totalQuads");
-
+	
 	// issue #575. index can be > totalQuads
 	NSInteger remaining = (totalQuads_-1) - index;
-
+	
 	// last object doesn't need to be moved
 	if( remaining > 0)
 		// tex coordinates
 		memmove( &quads_[index+1],&quads_[index], sizeof(quads_[0]) * remaining );
-
+	
 	quads_[index] = *quad;
-
+	
 #if CC_USES_VBO
 	dirty_ = YES;
 #endif
 }
 
+-(void) insertQuads:(ccV3F_C4B_T2F_Quad*)quads atIndex:(NSUInteger)index amount:(uint) amount
+{
+	NSAssert(index + amount <= capacity_, @"insertQuadWithTexture: Invalid index + amount");
+	
+	totalQuads_+= amount;
+	
+	NSAssert( totalQuads_ <= capacity_, @"invalid totalQuads");
+	
+	// issue #575. index can be > totalQuads
+	NSInteger remaining = (totalQuads_-1) - index - amount;
+	
+	// last object doesn't need to be moved
+	if( remaining > 0)
+		// tex coordinates
+		memmove( &quads_[index+amount],&quads_[index], sizeof(quads_[0]) * remaining );
+	
+	
+	
+	uint max = index + amount;
+	int j = 0;
+	for (int i = index; i < max ; i++)
+	{
+		quads_[index] = quads[j];
+		index++;
+		j++;
+	}
+	
+#if CC_USES_VBO
+	dirty_ = YES;
+#endif
+}
 
 -(void) insertQuadFromIndex:(NSUInteger)oldIndex atIndex:(NSUInteger)newIndex
 {
@@ -230,6 +271,37 @@
 #endif
 }
 
+-(void) insertQuadsFromIndex:(NSUInteger)oldIndex amount:(NSUInteger) amount atIndex:(NSUInteger)newIndex
+{
+	NSAssert(newIndex + amount <= totalQuads_, @"insertQuadFromIndex:atIndex: Invalid index");
+	NSAssert(oldIndex < totalQuads_, @"insertQuadFromIndex:atIndex: Invalid index");
+	
+	if( oldIndex == newIndex )
+		return;
+	
+	//create buffer
+	size_t quadSize = sizeof(ccV3F_C4B_T2F_Quad);
+	ccV3F_C4B_T2F_Quad *tempQuads = malloc(quadSize*amount); 
+	memcpy(tempQuads,&quads_[oldIndex],quadSize*amount); 
+	
+	if (newIndex < oldIndex) 
+	{
+		//move quads from newIndex to newIndex + amount to make room for buffer 
+		memmove(&quads_[newIndex],&quads_[newIndex+amount],(oldIndex-newIndex)*quadSize);
+	}
+	else 
+	{//move quads above back
+		memmove(&quads_[oldIndex],&quads_[oldIndex+amount],(newIndex-oldIndex)*quadSize); 
+	}
+	memcpy(&quads_[newIndex],tempQuads,amount*quadSize);
+	
+	free(tempQuads);
+	
+#if CC_USES_VBO
+	dirty_ = YES;
+#endif
+}
+
 -(void) removeQuadAtIndex:(NSUInteger) index
 {
 	NSAssert(index < totalQuads_, @"removeQuadAtIndex: Invalid index");
@@ -239,7 +311,6 @@
 
 	// last object doesn't need to be moved
 	if( remaining )
-		// tex coordinates
 		memmove( &quads_[index],&quads_[index+1], sizeof(quads_[0]) * remaining );
 
 	totalQuads_--;
@@ -247,6 +318,25 @@
 #if CC_USES_VBO
 	dirty_ = YES;
 #endif
+}
+
+-(void) removeQuadsAtIndex:(NSUInteger) index amount:(uint) amount
+{
+	NSAssert(index + amount <= totalQuads_, @"removeQuadAtIndex: index + amount out of bounds");	
+
+	if (index + amount > totalQuads_) amount = totalQuads_ - index; 
+	
+	NSUInteger remaining = (totalQuads_) - (index + amount);
+
+	totalQuads_-= amount;
+	
+	// last object doesn't need to be moved
+	if ( remaining )
+		memmove( &quads_[index],&quads_[index+amount], sizeof(quads_[0]) * remaining );
+
+	#if CC_USES_VBO
+		dirty_ = YES;
+	#endif
 }
 
 -(void) removeAllQuads
@@ -295,6 +385,42 @@
 	dirty_ = YES;
 #endif	
 	return YES;
+}
+
+#pragma mark TextureAtlas - CCParticleBatchNode Specific
+
+-(void) fillWithEmptyQuadsFromIndex:(uint) index amount:(uint) amount
+{
+	ccV3F_C4B_T2F_Quad *quad = calloc(1,sizeof(ccV3F_C4B_T2F_Quad)); 
+	
+	uint to = index + amount;
+	for (int i = index ; i < to ; i++)
+	{
+		quads_[i] = *quad; 	
+	}
+	
+}
+-(void) increaseTotalQuadsWith:(uint) amount
+{
+	totalQuads_ += amount; 	
+}
+
+-(void) moveQuadsFromIndex:(NSUInteger) index to:(NSUInteger) newIndex
+{
+	NSAssert(newIndex + (totalQuads_ - index) <= capacity_, @"moveQuadsFromIndex move is out of bounds");
+	
+	memmove(quads_ + newIndex,quads_ + index, (totalQuads_ - index) * sizeof(quads_[0]));
+}
+
+- (void) printAllQuads
+{
+	CCLOG(@"total %i cap %i",totalQuads_,capacity_);
+	for (int i = 0; i < capacity_; i++)
+	{
+		ccV3F_C4B_T2F_Quad* quad = &(quads_[i]);
+		CCLOG(@"%i bl %f %f tr %f %f tex bl %f %f tr %f %f",i,quad->bl.vertices.x,quad->bl.vertices.y,quad->tr.vertices.x,quad->tr.vertices.y,quad->bl.texCoords.u,quad->bl.texCoords.v,
+			  quad->tr.texCoords.u,quad->tr.texCoords.v);
+	}
 }
 
 #pragma mark TextureAtlas - Drawing

--- a/cocos2d/cocos2d.h
+++ b/cocos2d/cocos2d.h
@@ -78,6 +78,7 @@
 #import "CCParticleSystemPoint.h"
 #import "CCParticleSystemQuad.h"
 #import "CCParticleExamples.h"
+#import "CCParticleBatchNode.h"
 
 #import "CCTexture2D.h"
 #import "CCTexturePVR.h"


### PR DESCRIPTION
This class provides batch drawing for CCParticleSystemQuad. CCParticleSystemPoint isn't supported yet. 
The structure of CCParticleBatchNode is very similar to CCSpriteBatchNode. 

All the tests from particleTest are in particleTestBatched as well, with the only difference that each one uses a batch node for rendering. Besides particle system tests, there  are a few batchnode specific tests as well. 

I've checked the code with Clang and also checked for memory leaks. The limited performance testing I've done shows that if you're not fill-rate / overdraw bound, the batchnode performs a few frames higher compared to non batched drawing. How much improvement depends on the number of particle systems used and on the device as well. Improvement is less visible on older devices, because their fill-rate is a lot lower.

Pros and Cons batch drawing
+one draw call for all particle systems, more efficient 
+z-coordinate can be used for 3d effects 
+same memory requirements for buffers as non batched systems
-each quad is 16 bytes bigger, because of z coordinate

Additions:
CCParticleBatchNode.h
CCParticleBatchNode.m
ParticleTestBatched.h
ParticleTestBatched.m

Modifications:
CCParticleSystem
CCTextureAtlas
CCParticleSystemQuad
