### PR TITLE
Issue 1069, debug drawing of bounding box that scales, rotates, skews wit

### DIFF
--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -614,10 +614,11 @@ static SEL selSortMethod = NULL;
 	
 #if CC_SPRITE_DEBUG_DRAW == 1
 	// draw bounding box
-	CGSize s = self.contentSize;
-	CGPoint vertices[4] = {
-		ccp(0,0), ccp(s.width,0),
-		ccp(s.width,s.height), ccp(0,s.height)
+	CGPoint vertices[4]={
+		ccp(quad_.tl.vertices.x,quad_.tl.vertices.y),
+		ccp(quad_.bl.vertices.x,quad_.bl.vertices.y),
+		ccp(quad_.br.vertices.x,quad_.br.vertices.y),
+		ccp(quad_.tr.vertices.x,quad_.tr.vertices.y),
 	};
 	ccDrawPoly(vertices, 4, YES);
 #elif CC_SPRITE_DEBUG_DRAW == 2

--- a/cocos2d/CCSpriteBatchNode.m
+++ b/cocos2d/CCSpriteBatchNode.m
@@ -379,13 +379,14 @@ static SEL selSortMethod =NULL;
 			child->updateMethod(child, selUpdate);
 			
 #if CC_SPRITEBATCHNODE_DEBUG_DRAW
-			//Issue #528
-			CGRect rect = [child boundingBox];
+			//Issue #528, 1069
+			ccV3F_C4B_T2F_Quad *quads = [textureAtlas_ quads];
+			ccV3F_C4B_T2F_Quad *quad= &(quads[child.atlasIndex]);
 			CGPoint vertices[4]={
-				ccp(rect.origin.x,rect.origin.y),
-				ccp(rect.origin.x+rect.size.width,rect.origin.y),
-				ccp(rect.origin.x+rect.size.width,rect.origin.y+rect.size.height),
-				ccp(rect.origin.x,rect.origin.y+rect.size.height),
+				ccp(quad->tl.vertices.x,quad->tl.vertices.y),
+				ccp(quad->bl.vertices.x,quad->bl.vertices.y),
+				ccp(quad->br.vertices.x,quad->br.vertices.y),
+				ccp(quad->tr.vertices.x,quad->tr.vertices.y),
 			};
 			ccDrawPoly(vertices, 4, YES);
 #endif // CC_SPRITEBATCHNODE_DEBUG_DRAW


### PR DESCRIPTION
Issue 1069, debug drawing of bounding box that scales, rotates, skews with sprite. 

the boundingBox was used for debug drawing, but this CGRect can't rotate, skew, so the drawn rectangle can be misleading. This fix uses the vertices of the quad to accurately draw a box around the sprite. 
