### PR TITLE
Issue 1254, freeze in layoutSubviews call 

### DIFF
--- a/cocos2d/Platforms/iOS/EAGLView.m
+++ b/cocos2d/Platforms/iOS/EAGLView.m
@@ -185,7 +185,6 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 		return NO;
 	
 	context_ = [renderer_ context];
-	[context_ renderbufferStorage:GL_RENDERBUFFER_OES fromDrawable:eaglLayer];
 
 	discardFramebufferSupported_ = [[CCConfiguration sharedConfiguration] supportsDiscardFramebuffer];
 	
@@ -203,10 +202,9 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 - (void) layoutSubviews
 {
-	size_ = [renderer_ backingSize];
-
 	[renderer_ resizeFromLayer:(CAEAGLLayer*)self.layer];
-
+	size_ = [renderer_ backingSize];
+	
 	// Issue #914 #924
 	CCDirector *director = [CCDirector sharedDirector];
 	[director reshapeProjection:size_];
@@ -268,6 +266,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 	CHECK_GL_ERROR();
 #endif
 	
+	if (![renderer_ defaultFrameBuffer]) [renderer_ createFrameBuffer:(CAEAGLLayer*) self.layer]; 
 	// We can safely re-bind the framebuffer here, since this will be the
 	// 1st instruction of the new main loop
 	if( multiSampling_ )

--- a/cocos2d/Platforms/iOS/ES1Renderer.h
+++ b/cocos2d/Platforms/iOS/ES1Renderer.h
@@ -50,14 +50,14 @@
 	unsigned int	pixelFormat_;
 
 	// The OpenGL ES names for the framebuffer and renderbuffer used to render to this view
-    GLuint defaultFramebuffer_;
-	GLuint colorRenderbuffer_;
+    GLuint defaultFrameBuffer_;
+	GLuint colorRenderBuffer_;
 	GLuint depthBuffer_;
 	
 	
 	//buffers for MSAA
-	GLuint msaaFramebuffer_;
-	GLuint msaaColorbuffer_;
+	GLuint msaaFrameBuffer_;
+	GLuint msaaColorBuffer_;
 	
 	EAGLContext *context_;
 }
@@ -66,6 +66,8 @@
 @property (nonatomic,readonly) EAGLContext* context;
 
 - (BOOL)resizeFromLayer:(CAEAGLLayer *)layer;
+- (void) createFrameBuffer:(CAEAGLLayer *)layer;
+- (void) destroyFrameBuffer;
 
 @end
 

--- a/cocos2d/Platforms/iOS/ESRenderer.h
+++ b/cocos2d/Platforms/iOS/ESRenderer.h
@@ -41,6 +41,7 @@
 - (id) initWithDepthFormat:(unsigned int)depthFormat withPixelFormat:(unsigned int)pixelFormat withSharegroup:(EAGLSharegroup*)sharegroup withMultiSampling:(BOOL) multiSampling withNumberOfSamples:(unsigned int) requestedSamples;
 
 - (BOOL) resizeFromLayer:(CAEAGLLayer *)layer;
+- (void) createFrameBuffer:(CAEAGLLayer *)layer;
 
 - (EAGLContext*) context;
 - (CGSize) backingSize;


### PR DESCRIPTION
This fix ensures that OpenGL frame buffers, render buffers are destroyed and recreated when needed. Before the buffers were merely resized. This can lead to a lengthy freeze when starting up.

Tested with bug 914 case.  
