### PR TITLE
-fixed clang warning in spriteFrameCache 

### DIFF
--- a/CocosDenshion/TestsAndDemos/FancyRatMeteringDemo/Classes/AudioVisualization.m
+++ b/CocosDenshion/TestsAndDemos/FancyRatMeteringDemo/Classes/AudioVisualization.m
@@ -34,7 +34,7 @@ static AudioVisualization *sharedAV = nil;
 		avAvgPowerLevelSel_ = @selector(avAvgPowerLevelDidChange:channel:);
 		avPeakPowerLevelSel_ = @selector(avPeakPowerLevelDidChange:channel:);
 
-		[[CCScheduler sharedScheduler] scheduleSelector:@selector(tick:) forTarget:self interval:0 paused:NO];
+		[[CCScheduler sharedScheduler] scheduleSelector:@selector(tick:) forTarget:self interval:0 paused:NO repeat:kCCRepeatForever delay:0.0f];
 
 		[SimpleAudioEngine sharedEngine];
 		if([[SimpleAudioEngine sharedEngine] isBackgroundMusicPlaying]){
@@ -61,7 +61,7 @@ static AudioVisualization *sharedAV = nil;
 -(void)setMeteringInterval:(float) seconds
 {
 	[[CCScheduler sharedScheduler] unscheduleSelector:@selector(tick:) forTarget:self];
-	[[CCScheduler sharedScheduler] scheduleSelector:@selector(tick:) forTarget:self interval:seconds paused:NO];
+	[[CCScheduler sharedScheduler] scheduleSelector:@selector(tick:) forTarget:self interval:seconds paused:NO repeat:kCCRepeatForever delay:0.0f];];
 }
 
 -(void)tick:(ccTime) dt

--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -1528,6 +1528,12 @@
 		50FD7B3C0FFAA8AC004073B5 /* grossini_dance_atlas.png in Resources */ = {isa = PBXBuildFile; fileRef = 509A7A970F61A2400032F449 /* grossini_dance_atlas.png */; };
 		50FD7B3F0FFAA8BC004073B5 /* background.png in Resources */ = {isa = PBXBuildFile; fileRef = 50C1959C0EE4B90800829067 /* background.png */; };
 		50FD7B450FFAA8C6004073B5 /* atlastest.png in Resources */ = {isa = PBXBuildFile; fileRef = 506882680E957C4A00F943E5 /* atlastest.png */; };
+		6513D8901444B78F00917359 /* b1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5001659D0E72DB470085673F /* b1.png */; };
+		6513D8911444B78F00917359 /* b2.png in Resources */ = {isa = PBXBuildFile; fileRef = 5001659E0E72DB470085673F /* b2.png */; };
+		6513D8921444B78F00917359 /* f1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5001659F0E72DB470085673F /* f1.png */; };
+		6513D8931444B78F00917359 /* f2.png in Resources */ = {isa = PBXBuildFile; fileRef = 500165A00E72DB470085673F /* f2.png */; };
+		6513D8941444B78F00917359 /* r1.png in Resources */ = {isa = PBXBuildFile; fileRef = 500165990E72DB0E0085673F /* r1.png */; };
+		6513D8951444B78F00917359 /* r2.png in Resources */ = {isa = PBXBuildFile; fileRef = 5001659A0E72DB0E0085673F /* r2.png */; };
 		6F305B5F0FB9D2790052E700 /* TransformUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F305B5D0FB9D2790052E700 /* TransformUtils.h */; };
 		6F305B600FB9D2790052E700 /* TransformUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F305B5E0FB9D2790052E700 /* TransformUtils.m */; };
 		8E3FC8920F7B8BE900B3E5DE /* trance-loop.ogg in Resources */ = {isa = PBXBuildFile; fileRef = 8E3FC8910F7B8BE900B3E5DE /* trance-loop.ogg */; };
@@ -11338,6 +11344,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6513D8901444B78F00917359 /* b1.png in Resources */,
+				6513D8911444B78F00917359 /* b2.png in Resources */,
+				6513D8921444B78F00917359 /* f1.png in Resources */,
+				6513D8931444B78F00917359 /* f2.png in Resources */,
+				6513D8941444B78F00917359 /* r1.png in Resources */,
+				6513D8951444B78F00917359 /* r2.png in Resources */,
 				A0240EFA139E3AE50075D13F /* Default.png in Resources */,
 				A0240EFB139E3AE50075D13F /* Icon.png in Resources */,
 				A0240EFC139E3AE50075D13F /* fps_images.png in Resources */,

--- a/cocos2d/CCScheduler.h
+++ b/cocos2d/CCScheduler.h
@@ -152,6 +152,9 @@ struct _hashUpdateEntry;
  */
 -(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused repeat: (uint) repeat delay: (ccTime) delay;
 
+/** calls scheduleSelector with kCCRepeatForever and a 0 delay */
+-(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused;
+
 /** Schedules the 'update' selector for a given target with a given priority.
  The 'update' selector will be called every frame.
  The lower the priority, the earlier it is called.

--- a/cocos2d/CCScheduler.m
+++ b/cocos2d/CCScheduler.m
@@ -271,6 +271,11 @@ static CCScheduler *sharedScheduler;
 	free(element);
 }
 
+-(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused
+{
+	[self scheduleSelector:selector forTarget:target interval:interval paused:paused repeat:kCCRepeatForever delay:0.0f];
+}
+
 -(void) scheduleSelector:(SEL)selector forTarget:(id)target interval:(ccTime)interval paused:(BOOL)paused repeat:(uint) repeat delay:(ccTime) delay
 {
 	NSAssert( selector != nil, @"Argument selector must be non-nil");

--- a/cocos2d/CCSpriteFrameCache.m
+++ b/cocos2d/CCSpriteFrameCache.m
@@ -119,7 +119,7 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
 	// add real frames
 	for(NSString *frameDictKey in framesDict) {
 		NSDictionary *frameDict = [framesDict objectForKey:frameDictKey];
-		CCSpriteFrame *spriteFrame;
+		CCSpriteFrame *spriteFrame=nil;
 		if(format == 0) {
 			float x = [[frameDict objectForKey:@"x"] floatValue];
 			float y = [[frameDict objectForKey:@"y"] floatValue];


### PR DESCRIPTION
-added non retina images to Cocos2DExtensionsTest 
-fixed schedule calls in fancy rat demo
-added convenience method to CCScheduler, to simulate old behavior. 
