### PR TITLE
Issue 1262, tiles retrieved as sprite do not need to activate the sorting

### DIFF
--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -669,7 +669,7 @@ static SEL selSortMethod = NULL;
 		if (!isReorderChildDirty_) 
 		{	
 			[self setReorderChildDirtyRecursively];
-			[batchNode_ reorderBatch];
+			[batchNode_ reorderBatch:YES];
 		}	
 	}
 	

--- a/cocos2d/CCSpriteBatchNode.h
+++ b/cocos2d/CCSpriteBatchNode.h
@@ -125,6 +125,6 @@
 -(NSUInteger) rebuildIndexInOrder:(CCSprite*)parent atlasIndex:(NSUInteger)index;
 -(NSUInteger) atlasIndexForChild:(CCSprite*)sprite atZ:(NSInteger)z;
 /* Sprites use this to start sortChildren, don't call this manually */
-- (void) reorderBatch;
+- (void) reorderBatch:(BOOL) reorder;
 
 @end

--- a/cocos2d/CCSpriteBatchNode.m
+++ b/cocos2d/CCSpriteBatchNode.m
@@ -350,9 +350,9 @@ static SEL selSortMethod =NULL;
 	quads[newIndex]=tempItemQuad;
 }
 
-- (void) reorderBatch
+- (void) reorderBatch:(BOOL) reorder
 {
-	isReorderChildDirty_=YES;	
+	isReorderChildDirty_=reorder;	
 }
 
 #pragma mark CCSpriteBatchNode - draw

--- a/cocos2d/CCTMXLayer.m
+++ b/cocos2d/CCTMXLayer.m
@@ -102,6 +102,9 @@
 	
 	// IMPORTANT: Call super, and not self. Avoid adding it to the texture atlas array
 	[super addChild:child z:z tag:aTag];
+	
+	//#issue 1262 don't use lazy sorting, tiles are added as quads not as sprites, so sprites need to be added in order
+	[self reorderBatch:NO];
 	return self;	
 }
 @end


### PR DESCRIPTION
Issue 1262, tiles retrieved as sprite do not need to activate the sorting of children.
