### PR TITLE
Gles20 texcache

### DIFF
--- a/cocos2d/CCTexture2D.h
+++ b/cocos2d/CCTexture2D.h
@@ -250,6 +250,12 @@ Note that the generated textures are of type A8 - use the blending mode (GL_SRC_
  */
 -(id) initWithPVRFile: (NSString*) file;
 
+/** Initializes a texture from a PVR file
+ * The format string is used to override the file extension of the input file parameter.
+ * If format is specified, then the file is treated as if it has the specified format.
+ */
+-(id) initWithPVRFile:(NSString*)file fileFormat:(NSString *)format;
+
 /** treats (or not) PVR files as if they have alpha premultiplied.
  Since it is impossible to know at runtime if the PVR images have the alpha channel premultiplied, it is
  possible load them as if they have (or not) the alpha channel premultiplied.

--- a/cocos2d/CCTexture2D.m
+++ b/cocos2d/CCTexture2D.m
@@ -602,7 +602,12 @@ static CCTexture2DPixelFormat defaultAlphaPixelFormat_ = kCCTexture2DPixelFormat
 // By default PVR images are treated as if they don't have the alpha channel premultiplied
 static BOOL PVRHaveAlphaPremultiplied_ = NO;
 
--(id) initWithPVRFile: (NSString*) relPath
+-(id) initWithPVRFile:(NSString*)relPath
+{
+	return [self initWithPVRFile:relPath fileFormat:nil];
+}
+
+-(id) initWithPVRFile:(NSString*)relPath fileFormat:(NSString *)fileFormat
 {
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 	ccResolutionType resolution;
@@ -613,7 +618,7 @@ static BOOL PVRHaveAlphaPremultiplied_ = NO;
 #endif 
 	
 	if( (self = [super init]) ) {
-		CCTexturePVR *pvr = [[CCTexturePVR alloc] initWithContentsOfFile:fullpath];
+		CCTexturePVR *pvr = [[CCTexturePVR alloc] initWithContentsOfFile:fullpath fileFormat:fileFormat];
 		if( pvr ) {
 			pvr.retainName = YES;	// don't dealloc texture on release
 			

--- a/cocos2d/CCTextureCache.h
+++ b/cocos2d/CCTextureCache.h
@@ -93,6 +93,10 @@
  */
 -(CCTexture2D *) textureForKey:(NSString *)key;
 
+/** Cache the specified texture using the given 'key' 
+ */
+- (void)setTexture:(CCTexture2D *)texture forKey:(NSString *)key;
+
 /** Purges the dictionary of loaded textures.
  * Call this method if you receive the "Memory Warning"
  * In the short term: it will free some resources preventing your app from being killed
@@ -128,6 +132,29 @@
  *
  */
 -(CCTexture2D*) addPVRImage:(NSString*) filename;
+
+/** Return a Texture2D object for a given PVR filename, cached using the specified key.
+ * If the file image was not previously loaded, it will create a new CCTexture2D
+ *  object and it will return it. Otherwise it will return a reference of a previosly loaded image
+ */
+-(CCTexture2D*)addPVRImage:(NSString*)path forKey:(NSString *)key;
+
+/** Return a Texture2D instance of the specified class, a given PVR filename and cache key.
+ * The textureClass controls that type of class for texture instance, allowing the method to return custom
+ * CCTexture2D subclasses.
+ * If the file image was not previously loaded, it will create a new CCTexture2D
+ *  object and it will return it. Otherwise it will return a reference of a previosly loaded image
+ */
+-(CCTexture2D*)addPVRImage:(NSString*)path forKey:(NSString *)key class:(Class)textureClass;
+
+/** Return a Texture2D instance of the specified class, a given PVR filename, file format, and cache key.
+ * The format string is treated as a file extension, and causes the file to be treated as if it has that extension.
+ * The textureClass controls that type of class for texture instance, allowing the method to return custom
+ * CCTexture2D subclasses.
+ * If the file image was not previously loaded, it will create a new CCTexture2D
+ *  object and it will return it. Otherwise it will return a reference of a previosly loaded image
+ */
+-(CCTexture2D*)addPVRImage:(NSString*)path forKey:(NSString *)key fileFormat:(NSString *)format class:(Class)textureClass;
 
 @end
 

--- a/cocos2d/CCTexturePVR.h
+++ b/cocos2d/CCTexturePVR.h
@@ -100,8 +100,13 @@ enum {
 	CCTexture2DPixelFormat format_;
 }
 
-/** initializes a CCTexturePVR with a path */
+/** initializes a CCTexturePVR with a file at path */
 - (id)initWithContentsOfFile:(NSString *)path;
+/** initializes a CCTexturePVR with a file at 'path', and specified file format.
+   The format string is used to override the file extension of the input file parameter.
+   If format is specified, then the file is treated as if it has the specified format.
+ */
+- (id)initWithContentsOfFile:(NSString *)path fileFormat:(NSString *)format;
 /** initializes a CCTexturePVR with an URL */
 - (id)initWithContentsOfURL:(NSURL *)url;
 /** creates and initializes a CCTexturePVR with a path */

--- a/cocos2d/CCTexturePVR.m
+++ b/cocos2d/CCTexturePVR.m
@@ -346,16 +346,21 @@ typedef struct _PVRTexHeader
 
 - (id)initWithContentsOfFile:(NSString *)path
 {
+	return [self initWithContentsOfFile:path fileFormat:nil];
+}
+
+- (id)initWithContentsOfFile:(NSString *)path fileFormat:(NSString *)format
+{
 	if((self = [super init]))  
 	{ 
 		unsigned char *pvrdata = NULL;
 		NSInteger pvrlen = 0;
 		NSString *lowerCase = [path lowercaseString];       
 		
-        if ( [lowerCase hasSuffix:@".ccz"]) 
+        if ( [format isEqualToString:@"ccz"] || [lowerCase hasSuffix:@".ccz"]) 
 			pvrlen = ccInflateCCZFile( [path UTF8String], &pvrdata );
-			
-		else if( [lowerCase hasSuffix:@".gz"] )
+		
+		else if( [format isEqualToString:@"gz"] || [lowerCase hasSuffix:@".gz"] )
 			pvrlen = ccInflateGZipFile( [path UTF8String], &pvrdata );
 		
 		else
@@ -366,14 +371,14 @@ typedef struct _PVRTexHeader
 			return nil;
 		}			
 		
-
+		
         numberOfMipmaps_ = 0;
         
 		name_ = 0;
 		width_ = height_ = 0;
 		tableFormatIndex_ = -1;
 		hasAlpha_ = FALSE;
-
+		
 		retainName_ = NO; // cocos2d integration
 		
 		if( ! [self unpackPVRData:pvrdata PVRLen:pvrlen] || ![self createGLTexture]  ) {
@@ -384,7 +389,7 @@ typedef struct _PVRTexHeader
 		
 		free(pvrdata);
 	}
-
+	
 	return self;
 }
 


### PR DESCRIPTION
In some situations, texture files are stored on disk with names that do not match
the content.  For example, a generic game 'resource' system that supports network
loadable assets might require the use of hashes for filenames.  In this situation,
it is necessary to provide params to override the defaults that are normally extracted
from a filename.

This change set provides support for caching instances of custom subclasses of CCTexture2D
with params specifying the cache key, and the "file format" string. The key can be any string,
and is used to cache the texture under a known key. The fileFormat string is currently used to
override the file extension extracted from the filename. Currently, these additional params are
only implemented for methods used to load & cache PVR textures.
