### PR TITLE
Issue 1084, 1139, when a touch handler is added inside a touch handler it

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,8 @@ Contributors (alphabetically ordered):
 	Improved ESRenderer layoutSubview
 	Improved Debug Drawing for Sprite batched node	
 
+* podhrask...@gmail.com
+	TouchDispatcher: correctly handles addition and removal of handlers when being inside a touch handler. patch
 * Ricardo Ruiz:
 	Added support for RGB888 textures
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 version 1.1-beta2 xx - 2011
-. [NEW] TileMap: supports in-memory TMX map creation (#issue 1239)
+. [NEW] TileMap: supports in-memory TMX map creation (issue #1239)
+. [FIX] TouchDispatcher: correctly handles addition and removal of handlers when being inside a touch handler (issue #1084, #1139)
 
 version 1.1-beta 11-Oct-2011
 . [NEW] Animation: Added file format. AnimationCache can load animations from file

--- a/cocos2d/Platforms/iOS/CCTouchDispatcher.m
+++ b/cocos2d/Platforms/iOS/CCTouchDispatcher.m
@@ -297,16 +297,13 @@ NSComparisonResult sortByPriority(id first, id second, void *context)
 	// the add/removes/quit is done after the iterations
 	//
 	locked = NO;
-	if( toRemove ) {
-		toRemove = NO;
-		for( id delegate in handlersToRemove )
-			[self forceRemoveDelegate:delegate];
-		[handlersToRemove removeAllObjects];
-	}
+	
+	//issue 1084, 1139 first add then remove
 	if( toAdd ) {
 		toAdd = NO;
+		Class targetedClass = [CCTargetedTouchHandler class];
+		
 		for( CCTouchHandler *handler in handlersToAdd ) {
-			Class targetedClass = [CCTargetedTouchHandler class];
 			if( [handler isKindOfClass:targetedClass] )
 				[self forceAddHandler:handler array:targetedHandlers];
 			else
@@ -314,7 +311,14 @@ NSComparisonResult sortByPriority(id first, id second, void *context)
 		}
 		[handlersToAdd removeAllObjects];
 	}
-	if( toQuit ) {
+	
+	if( toRemove ) {
+		toRemove = NO;
+		for( id delegate in handlersToRemove )
+			[self forceRemoveDelegate:delegate];
+		[handlersToRemove removeAllObjects];
+	}
+		if( toQuit ) {
 		toQuit = NO;
 		[self forceRemoveAllDelegates];
 	}


### PR DESCRIPTION
Issue 1084, 1139, when a touch handler is added inside a touch handler it should be added first, before removed. Otherwise a released object can be added to the handler list. 
