### PR TITLE
ARC patch

### DIFF
--- a/cocos2d/CCActionManager.h
+++ b/cocos2d/CCActionManager.h
@@ -34,12 +34,18 @@
 typedef struct _hashElement
 {
 	struct ccArray	*actions;
-	id				target;
 	NSUInteger		actionIndex;
-	CCAction		*currentAction;
 	BOOL			currentActionSalvaged;
 	BOOL			paused;	
 	UT_hash_handle	hh;
+	
+#if __has_feature(objc_arc)
+	__unsafe_unretained id				target;
+	__unsafe_unretained CCAction		*currentAction;
+#else
+	id				target;
+	CCAction		*currentAction;
+#endif
 } tHashElement;
 
 

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.h
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.h
@@ -193,7 +193,7 @@ typedef enum {
 {
 	BOOL isRunning;
 	
-	NSAutoreleasePool	*autoreleasePool;
+	id autoreleasePool;
 }
 -(void) mainLoop;
 @end


### PR DESCRIPTION
Just giving you an alternative that doesn't require changing all of the files ccCArray functions to be non-inlined.

It ended up being some pretty trivial changes overall. Just had to change the array to be a __strong id \* array and then ARC knows to retain and release objects as the array is modified. It also required that the array be zeroed to begin with (using calloc) and that removed elements had to be zeroed out so that ARC would release them.
