### PR TITLE
In CCEventDispatcher delegate is not released when freed

### DIFF
--- a/cocos2d/Platforms/Mac/CCEventDispatcher.m
+++ b/cocos2d/Platforms/Mac/CCEventDispatcher.m
@@ -196,6 +196,7 @@ static int		eventQueueCount;
 
 	DL_FOREACH_SAFE( *list, entry, tmp ) {
 		DL_DELETE( *list, entry );
+        [entry->delegate release];
 		free(entry);
 	}
 }


### PR DESCRIPTION
OSX version of CCEventDispatcher has a bug when releasing all delegates the delegates are not freed like when they are released individually. Fortunately this piece of code is rarely if ever used, but it's good to be fixed anyway.
