### PR TITLE
Backported CCLabelBMFont from gles20 branch.

### DIFF
--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -13491,6 +13491,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
 				COPY_PHASE_STRIP = NO;
 				DOXYGEN_PATH = /Applications/Doxygen.app/Contents/Resources/doxygen;
@@ -13510,6 +13514,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -14252,6 +14260,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -14264,6 +14276,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				PRODUCT_NAME = FontLabel;
@@ -14416,6 +14432,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -14440,6 +14460,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/cocos2d/CCLabelBMFont.h
+++ b/cocos2d/CCLabelBMFont.h
@@ -79,7 +79,7 @@ enum {
  */
 @interface CCBMFontConfiguration : NSObject
 {
-// XXX: Creating a public interface so that the bitmapFontArray[] is accesible
+    // XXX: Creating a public interface so that the bitmapFontArray[] is accesible
 @public
 	// The characters building up the font
 	ccBMFontDef	BMFontArray_[kCCBMFontMaxChars];
@@ -92,7 +92,7 @@ enum {
 	
 	// atlas name
 	NSString		*atlasName_;
-
+    
 	// values for kerning
 	struct _KerningHashElement	*kerningDictionary_;
 }
@@ -105,30 +105,30 @@ enum {
 
 
 /** CCLabelBMFont is a subclass of CCSpriteBatchNode
-  
+ 
  Features:
  - Treats each character like a CCSprite. This means that each individual character can be:
-   - rotated
-   - scaled
-   - translated
-   - tinted
-   - chage the opacity
+ - rotated
+ - scaled
+ - translated
+ - tinted
+ - chage the opacity
  - It can be used as part of a menu item.
  - anchorPoint can be used to align the "label"
  - Supports AngelCode text format
  
  Limitations:
-  - All inner characters are using an anchorPoint of (0.5f, 0.5f) and it is not recommend to change it
-    because it might affect the rendering
+ - All inner characters are using an anchorPoint of (0.5f, 0.5f) and it is not recommend to change it
+ because it might affect the rendering
  
  CCLabelBMFont implements the protocol CCLabelProtocol, like CCLabel and CCLabelAtlas.
  CCLabelBMFont has the flexibility of CCLabel, the speed of CCLabelAtlas and all the features of CCSprite.
  If in doubt, use CCLabelBMFont instead of CCLabelAtlas / CCLabel.
  
  Supported editors:
-  - http://www.n4te.com/hiero/hiero.jnlp
-  - http://slick.cokeandcode.com/demos/hiero.jnlp
-  - http://www.angelcode.com/products/bmfont/
+ - http://www.n4te.com/hiero/hiero.jnlp
+ - http://slick.cokeandcode.com/demos/hiero.jnlp
+ - http://www.angelcode.com/products/bmfont/
  
  @since v0.8
  */
@@ -137,9 +137,16 @@ enum {
 {
 	// string to render
 	NSString		*string_;
+    
+    // initial string without line breaks
+    NSString *initialString_;
+    // max width until a line break is added
+    float width_;
+    // alignment of all lines
+    CCTextAlignment alignment_;
 	
 	CCBMFontConfiguration	*configuration_;
-
+    
 	// texture RGBA
 	GLubyte		opacity_;
 	ccColor3B	color_;
@@ -152,6 +159,10 @@ enum {
  */
 +(void) purgeCachedData;
 
+@property (nonatomic,copy,readonly) NSString *initialString;
+@property (nonatomic,assign,readonly) float width;
+@property (nonatomic,assign,readonly) CCTextAlignment alignment;
+
 /** conforms to CCRGBAProtocol protocol */
 @property (nonatomic,readwrite) GLubyte opacity;
 /** conforms to CCRGBAProtocol protocol */
@@ -160,16 +171,23 @@ enum {
 
 /** creates a BMFont label with an initial string and the FNT file */
 +(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile;
+/** creates a BMFont label with an initial string, the FNT file, width, and alignment option */
++(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment;
 
 /** init a BMFont label with an initial string and the FNT file */
 -(id) initWithString:(NSString*)string fntFile:(NSString*)fntFile;
+/** init a BMFont label with an initial string and the FNT file, width, and alignment option*/
+-(id) initWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment;
 
 /** updates the font chars based on the string to render */
 -(void) createFontChars;
+
+- (void)setWidth:(float)width;
+- (void)setAlignment:(CCTextAlignment)alignment;
 @end
 
 /** Free function that parses a FNT file a place it on the cache
-*/
+ */
 CCBMFontConfiguration * FNTConfigLoadFile( NSString *file );
 /** Purges the FNT config cache
  */

--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -35,6 +35,7 @@
  */
 
 #import "ccConfig.h"
+#import "ccMacros.h"
 #import "CCLabelBMFont.h"
 #import "CCSprite.h"
 #import "CCDrawingPrimitives.h"
@@ -93,6 +94,9 @@ typedef struct _KerningHashElement
 -(void) purgeKerningDictionary;
 @end
 
+#pragma mark -
+#pragma mark CCBMFontConfiguration
+
 @implementation CCBMFontConfiguration
 
 +(id) configurationWithFNTFile:(NSString*)FNTfile
@@ -105,7 +109,7 @@ typedef struct _KerningHashElement
 	if((self=[super init])) {
 		
 		kerningDictionary_ = NULL;
-
+        
 		[self parseConfigFile:fntFile];
 	}
 	return self;
@@ -143,7 +147,7 @@ typedef struct _KerningHashElement
 	NSString *fullpath = [CCFileUtils fullPathFromRelativePath:fntFile];
 	NSError *error;
 	NSString *contents = [NSString stringWithContentsOfFile:fullpath encoding:NSUTF8StringEncoding error:&error];
-
+    
 	NSAssert1( contents, @"cocos2d: Error parsing FNTfile: %@", error);
 	
 	
@@ -162,7 +166,7 @@ typedef struct _KerningHashElement
 		if([line hasPrefix:@"info face"]) {
 			// XXX: info parsing is incomplete
 			// Not needed for the Hiero editors, but needed for the AngelCode editor
-//			[self parseInfoArguments:line];
+            //			[self parseInfoArguments:line];
 		}
 		// Check to see if the start of the line is something we are interested in
 		else if([line hasPrefix:@"common lineHeight"]) {
@@ -178,7 +182,7 @@ typedef struct _KerningHashElement
 			// Parse the current line and create a new CharDef
 			ccBMFontDef characterDefinition;
 			[self parseCharacterDefinition:line charDef:&characterDefinition];
-
+            
 			// Add the CharDef returned to the charArray
 			BMFontArray_[ characterDefinition.charID ] = characterDefinition;
 		}
@@ -196,7 +200,7 @@ typedef struct _KerningHashElement
 -(void) parseImageFileName:(NSString*)line fntFile:(NSString*)fntFile
 {
 	NSString *propertyValue = nil;
-
+    
 	// Break the values for this line up using =
 	NSArray *values = [line componentsSeparatedByString:@"="];
 	
@@ -219,7 +223,7 @@ typedef struct _KerningHashElement
 	// Supports subdirectories
 	NSString *dir = [fntFile stringByDeletingLastPathComponent];
 	atlasName_ = [dir stringByAppendingPathComponent:propertyValue];
-
+    
 	[atlasName_ retain];
 }
 
@@ -242,22 +246,22 @@ typedef struct _KerningHashElement
 	
 	// size (ignore)
 	[nse nextObject];
-
+    
 	// bold (ignore)
 	[nse nextObject];
-
+    
 	// italic (ignore)
 	[nse nextObject];
 	
 	// charset (ignore)
 	[nse nextObject];
-
+    
 	// unicode (ignore)
 	[nse nextObject];
-
+    
 	// strechH (ignore)
 	[nse nextObject];
-
+    
 	// smooth (ignore)
 	[nse nextObject];
 	
@@ -277,7 +281,7 @@ typedef struct _KerningHashElement
 		// padding right
 		propertyValue = [paddingEnum nextObject];
 		padding_.right = [propertyValue intValue];
-
+        
 		// padding bottom
 		propertyValue = [paddingEnum nextObject];
 		padding_.bottom = [propertyValue intValue];
@@ -288,7 +292,7 @@ typedef struct _KerningHashElement
 		
 		CCLOG(@"cocos2d: padding: %d,%d,%d,%d", padding_.left, padding_.top, padding_.right, padding_.bottom);
 	}
-
+    
 	// spacing (ignore)
 	[nse nextObject];	
 }
@@ -343,7 +347,7 @@ typedef struct _KerningHashElement
 	propertyValue = [propertyValue substringToIndex: [propertyValue rangeOfString: @" "].location];
 	characterDefinition->charID = [propertyValue intValue];
 	NSAssert(characterDefinition->charID < kCCBMFontMaxChars, @"BitmpaFontAtlas: CharID bigger than supported");
-
+    
 	// Character x
 	propertyValue = [nse nextObject];
 	characterDefinition->rect.origin.x = [propertyValue intValue];
@@ -370,23 +374,23 @@ typedef struct _KerningHashElement
 -(void) parseKerningCapacity:(NSString*) line
 {
 	// When using uthash there is not need to parse the capacity.
-
-//	NSAssert(!kerningDictionary, @"dictionary already initialized");
-//	
-//	// Break the values for this line up using =
-//	NSArray *values = [line componentsSeparatedByString:@"="];
-//	NSEnumerator *nse = [values objectEnumerator];	
-//	NSString *propertyValue;
-//	
-//	// We need to move past the first entry in the array before we start assigning values
-//	[nse nextObject];
-//	
-//	// count
-//	propertyValue = [nse nextObject];
-//	int capacity = [propertyValue intValue];
-//	
-//	if( capacity != -1 )
-//		kerningDictionary = ccHashSetNew(capacity, targetSetEql);
+    
+    //	NSAssert(!kerningDictionary, @"dictionary already initialized");
+    //	
+    //	// Break the values for this line up using =
+    //	NSArray *values = [line componentsSeparatedByString:@"="];
+    //	NSEnumerator *nse = [values objectEnumerator];	
+    //	NSString *propertyValue;
+    //	
+    //	// We need to move past the first entry in the array before we start assigning values
+    //	[nse nextObject];
+    //	
+    //	// count
+    //	propertyValue = [nse nextObject];
+    //	int capacity = [propertyValue intValue];
+    //	
+    //	if( capacity != -1 )
+    //		kerningDictionary = ccHashSetNew(capacity, targetSetEql);
 }
 
 -(void) parseKerningEntry:(NSString*) line
@@ -409,7 +413,7 @@ typedef struct _KerningHashElement
 	// second
 	propertyValue = [nse nextObject];
 	int amount = [propertyValue intValue];
-
+    
 	tKerningHashElement *element = calloc( sizeof( *element ), 1 );
 	element->amount = amount;
 	element->key = (first<<16) | (second&0xffff);
@@ -426,11 +430,19 @@ typedef struct _KerningHashElement
 
 -(int) kerningAmountForFirst:(unichar)first second:(unichar)second;
 
+-(void) updateLabel;
+-(void) setString:(NSString*) newString fromUpdate:(bool)fromUpdate;
+
 @end
+
+#pragma mark -
+#pragma mark CCLabelBMFont
 
 @implementation CCLabelBMFont
 
+@synthesize initialString = initialString_, width = width_, alignment = alignment_;
 @synthesize opacity = opacity_, color = color_;
+
 
 #pragma mark LabelBMFont - Purge Cache
 +(void) purgeCachedData
@@ -445,39 +457,201 @@ typedef struct _KerningHashElement
 	return [[[self alloc] initWithString:string fntFile:fntFile] autorelease];
 }
 
++(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment
+{
+    return [[[self alloc] initWithString:string fntFile:fntFile width:width alignment:alignment] autorelease];
+}
+
 -(id) initWithString:(NSString*)theString fntFile:(NSString*)fntFile
+{
+    return [self initWithString:theString fntFile:fntFile width:-1 alignment:CCTextAlignmentLeft];
+}
+
+-(id) initWithString:(NSString*)theString fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment
 {	
 	
 	[configuration_ release]; // allow re-init
-
+    
 	configuration_ = FNTConfigLoadFile(fntFile);
 	[configuration_ retain];
-
+    
 	NSAssert( configuration_, @"Error creating config for LabelBMFont");
-
+    
 	
 	if ((self=[super initWithFile:configuration_->atlasName_ capacity:[theString length]])) {
-
+        
+        initialString_ = [theString copy];
+        width_ = width;
+        alignment_ = alignment;
+        
 		opacity_ = 255;
 		color_ = ccWHITE;
-
+        
 		contentSize_ = CGSizeZero;
 		
 		opacityModifyRGB_ = [[textureAtlas_ texture] hasPremultipliedAlpha];
-
+        
 		anchorPoint_ = ccp(0.5f, 0.5f);
-
+        
+        
+        
 		[self setString:theString];
+        
+        [self updateLabel];
 	}
-
+    
 	return self;
 }
 
 -(void) dealloc
 {
 	[string_ release];
+    [initialString_ release], initialString_ = nil;
 	[configuration_ release];
 	[super dealloc];
+}
+
+#pragma mark LabelBMFont - Alignment
+
+- (void)updateLabel {
+    
+    [self setString:initialString_ fromUpdate:YES];
+    
+    if (width_ > 0){
+        //Step 1: Make multiline
+        
+        NSString *multilineString = @"", *lastWord = @"";
+        int line = 1, i = 0;
+        NSUInteger stringLength = [self.string length];
+        float startOfLine = -1, startOfWord = -1;
+        int skip = 0;
+        //Go through each character and insert line breaks as necessary
+        for (int j = 0; j < [children_ count]; j++) {
+            CCSprite *characterSprite;
+            
+            while(!(characterSprite = (CCSprite *)[self getChildByTag:j+skip]))
+                skip++;
+            
+            if (!characterSprite.visible) continue;
+            
+            if (i >= stringLength || i < 0)
+                break;
+            
+            unichar character = [self.string characterAtIndex:i];
+            
+            if (startOfWord == -1)
+                startOfWord = characterSprite.position.x - characterSprite.contentSize.width/2;
+            if (startOfLine == -1)
+                startOfLine = startOfWord;
+            
+            //Character is a line break
+            //Put lastWord on the current line and start a new line
+            //Reset lastWord
+            if ([[NSCharacterSet newlineCharacterSet] characterIsMember:character]) {
+                lastWord = [[lastWord stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] stringByAppendingFormat:@"%C", character];
+                multilineString = [multilineString stringByAppendingString:lastWord];
+                lastWord = @"";
+                startOfWord = -1;
+                line++;
+                startOfLine = -1;
+                i++;
+                
+                //CCLabelBMFont do not have a character for new lines, so do NOT "continue;" in the for loop. Process the next character
+                if (i >= stringLength || i < 0)
+                    break;
+                character = [self.string characterAtIndex:i];
+                
+                if (startOfWord == -1)
+                    startOfWord = characterSprite.position.x - characterSprite.contentSize.width/2;
+                if (startOfLine == -1)
+                    startOfLine = startOfWord;
+            }
+            
+            //Character is a whitespace
+            //Put lastWord on current line and continue on current line
+            //Reset lastWord
+            if ([[NSCharacterSet whitespaceCharacterSet] characterIsMember:character]) {
+                lastWord = [lastWord stringByAppendingFormat:@"%C", character];
+                multilineString = [multilineString stringByAppendingString:lastWord];
+                lastWord = @"";
+                startOfWord = -1;
+                i++;
+                continue;
+            }
+            
+            //Character is out of bounds
+            //Do not put lastWord on current line. Add "\n" to current line to start a new line
+            //Append to lastWord
+            if (characterSprite.position.x + characterSprite.contentSize.width/2 - startOfLine > self.width) {
+                lastWord = [lastWord stringByAppendingFormat:@"%C", character];
+                NSString *trimmedString = [multilineString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+                multilineString = [trimmedString stringByAppendingString:@"\n"];
+                line++;
+                startOfLine = -1;
+                i++;
+                continue;
+            } else {
+                //Character is normal
+                //Append to lastWord
+                lastWord = [lastWord stringByAppendingFormat:@"%C", character];
+                i++;
+                continue;
+            }
+        }
+        
+        multilineString = [multilineString stringByAppendingFormat:@"%@", lastWord];
+        
+        [self setString:multilineString fromUpdate:YES];
+    }
+    
+    //Step 2: Make alignment
+    
+    if (self.alignment != CCTextAlignmentLeft) {
+        
+        int i = 0;
+        //Number of spaces skipped
+        int lineNumber = 0;
+        //Go through line by line
+        for (NSString *lineString in [string_ componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]]) {
+            int lineWidth = 0;
+            
+            //Find index of last character in this line
+            NSInteger index = i + [lineString length] - 1 + lineNumber;
+            if (index < 0)
+                continue;
+            
+            //Find position of last character on the line
+            CCSprite *lastChar = (CCSprite *)[self getChildByTag:index];
+            
+            lineWidth = lastChar.position.x + lastChar.contentSize.width/2;
+            
+            //Figure out how much to shift each character in this line horizontally
+            float shift = 0;
+            switch (self.alignment) {
+                case CCTextAlignmentCenter:
+                    shift = self.contentSize.width/2 - lineWidth/2;
+                    break;
+                case CCTextAlignmentRight:
+                    shift = self.contentSize.width - lineWidth;
+                default:
+                    break;
+            }
+            
+            if (shift != 0) {
+                int j = 0;
+                //For each character, shift it so that the line is center aligned
+                for (j = 0; j < [lineString length]; j++) {
+                    index = i + j + lineNumber;
+                    if (index < 0)
+                        continue;
+                    CCSprite *characterSprite = (CCSprite *)[self getChildByTag:index];
+                    characterSprite.position = ccpAdd(characterSprite.position, ccp(shift, 0));
+                }
+            }
+            i += [lineString length];
+            lineNumber++;
+        }
+    }
 }
 
 #pragma mark LabelBMFont - Atlas generation
@@ -493,7 +667,7 @@ typedef struct _KerningHashElement
 		if(element)
 			ret = element->amount;
 	}
-		
+    
 	return ret;
 }
 
@@ -505,16 +679,16 @@ typedef struct _KerningHashElement
 	NSInteger kerningAmount = 0;
 	
 	CGSize tmpSize = CGSizeZero;
-
+    
 	NSInteger longestLine = 0;
 	NSUInteger totalHeight = 0;
 	
 	NSUInteger quantityOfLines = 1;
-
+    
 	NSUInteger stringLen = [string_ length];
 	if( ! stringLen )
 		return;
-
+    
 	// quantity of lines NEEDS to be calculated before parsing the lines,
 	// since the Y position needs to be calcualted before hand
 	for(NSUInteger i=0; i < stringLen-1;i++) {
@@ -526,7 +700,7 @@ typedef struct _KerningHashElement
 	totalHeight = configuration_->commonHeight_ * quantityOfLines;
 	nextFontPositionY = -(configuration_->commonHeight_ - configuration_->commonHeight_*quantityOfLines);
 	
-	for(NSUInteger i=0; i<stringLen; i++) {
+	for(NSUInteger i = 0; i<stringLen; i++) {
 		unichar c = [string_ characterAtIndex:i];
 		NSAssert( c < kCCBMFontMaxChars, @"LabelBMFont: character outside bounds");
 		
@@ -535,7 +709,7 @@ typedef struct _KerningHashElement
 			nextFontPositionY -= configuration_->commonHeight_;
 			continue;
 		}
-
+        
 		kerningAmount = [self kerningAmountForFirst:prev second:c];
 		
 		ccBMFontDef fontDef = configuration_->BMFontArray_[c];
@@ -560,27 +734,26 @@ typedef struct _KerningHashElement
 		}
 		
 		float yOffset = configuration_->commonHeight_ - fontDef.yOffset;
-		fontChar.positionInPixels = ccp( (float)nextFontPositionX + fontDef.xOffset + fontDef.rect.size.width*0.5f + kerningAmount,
-								(float)nextFontPositionY + yOffset - rect.size.height*0.5f );
+        fontChar.positionInPixels = ccp( (float)nextFontPositionX + fontDef.xOffset + fontDef.rect.size.width*0.5f + kerningAmount, (float)nextFontPositionY + yOffset - rect.size.height*0.5f );
 
 		// update kerning
 		nextFontPositionX += configuration_->BMFontArray_[c].xAdvance + kerningAmount;
 		prev = c;
-
+        
 		// Apply label properties
 		[fontChar setOpacityModifyRGB:opacityModifyRGB_];
 		// Color MUST be set before opacity, since opacity might change color if OpacityModifyRGB is on
 		[fontChar setColor:color_];
-
+        
 		// only apply opacity if it is different than 255 )
 		// to prevent modifying the color too (issue #610)
 		if( opacity_ != 255 )
 			[fontChar setOpacity: opacity_];
-
+        
 		if (longestLine < nextFontPositionX)
 			longestLine = nextFontPositionX;
 	}
-
+    
 	tmpSize.width = longestLine;
 	tmpSize.height = totalHeight;
 
@@ -589,15 +762,28 @@ typedef struct _KerningHashElement
 
 #pragma mark LabelBMFont - CCLabelProtocol protocol
 - (void) setString:(NSString*) newString
+{
+    [self setString:newString fromUpdate:NO];
+}
+
+- (void) setString:(NSString*) newString fromUpdate:(bool)fromUpdate
 {	
-	[string_ release];
-	string_ = [newString copy];
-
-	CCNode *child;
-	CCARRAY_FOREACH(children_, child)
+    if (fromUpdate) {
+        [string_ release];
+        string_ = [newString copy];
+    } else {
+        [initialString_ release];
+        initialString_ = [newString copy];
+    }
+    
+    CCSprite *child;
+    CCARRAY_FOREACH(children_, child)
 		child.visible = NO;
-
+    
 	[self createFontChars];
+    
+    if (!fromUpdate)
+        [self updateLabel];
 }
 
 -(NSString*) string
@@ -618,16 +804,16 @@ typedef struct _KerningHashElement
 	
 	CCSprite *child;
 	CCARRAY_FOREACH(children_, child)
-		[child setColor:color_];
+    [child setColor:color_];
 }
 
 -(void) setOpacity:(GLubyte)opacity
 {
 	opacity_ = opacity;
-
+    
 	id<CCRGBAProtocol> child;
 	CCARRAY_FOREACH(children_, child)
-		[child setOpacity:opacity_];
+    [child setOpacity:opacity_];
 }
 -(void) setOpacityModifyRGB:(BOOL)modify
 {
@@ -635,7 +821,7 @@ typedef struct _KerningHashElement
 	
 	id<CCRGBAProtocol> child;
 	CCARRAY_FOREACH(children_, child)
-		[child setOpacityModifyRGB:modify];
+    [child setOpacityModifyRGB:modify];
 }
 
 -(BOOL) doesOpacityModifyRGB
@@ -652,12 +838,23 @@ typedef struct _KerningHashElement
 	}
 }
 
+#pragma mark LabelBMFont - Alignment
+- (void)setWidth:(float)width {
+    width_ = width;
+    [self updateLabel];
+}
+
+- (void)setAlignment:(CCTextAlignment)alignment {
+    alignment_ = alignment;
+    [self updateLabel];
+}
+
 #pragma mark LabelBMFont - Debug draw
 #if CC_LABELBMFONT_DEBUG_DRAW
 -(void) draw
 {
 	[super draw];
-
+    
 	CGSize s = [self contentSize];
 	CGPoint vertices[4]={
 		ccp(0,0),ccp(s.width,0),


### PR DESCRIPTION
This backport is tested on iPhone 3G and an iPod with retina display using LabelTest from the cocos2d project. Also it works on my current game so hopefully there are no issues. I changed as little as possible.

I also added arm6 to the cocos2d, FontLabel and LabelTest targets, I think arm6 should be added to all targets for 1.x cocos2d versions since only reason to use 1.x cocos2d is to support older handsets.
