### PR TITLE
CCSprite transform order in CCSprite updateTransform

### DIFF
--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -501,13 +501,13 @@ static SEL selSortMethod = NULL;
 				newMatrix = CGAffineTransformTranslate(newMatrix, tv.pos.x, tv.pos.y);
 			if( prevHonor & CC_HONOR_PARENT_TRANSFORM_ROTATE )
 				newMatrix = CGAffineTransformRotate(newMatrix, -CC_DEGREES_TO_RADIANS(tv.rotation));
+			if( prevHonor & CC_HONOR_PARENT_TRANSFORM_SCALE ) {
+				newMatrix = CGAffineTransformScale(newMatrix, tv.scale.x, tv.scale.y);
+			}
 			if ( prevHonor & CC_HONOR_PARENT_TRANSFORM_SKEW ) {
 				CGAffineTransform skew = CGAffineTransformMake(1.0f, tanf(CC_DEGREES_TO_RADIANS(tv.skew.y)), tanf(CC_DEGREES_TO_RADIANS(tv.skew.x)), 1.0f, 0.0f, 0.0f);
 				// apply the skew to the transform
 				newMatrix = CGAffineTransformConcat(skew, newMatrix);
-			}
-			if( prevHonor & CC_HONOR_PARENT_TRANSFORM_SCALE ) {
-				newMatrix = CGAffineTransformScale(newMatrix, tv.scale.x, tv.scale.y);
 			}
 			
 			// 3rd: Translate anchor point

--- a/tests/SpriteTest.h
+++ b/tests/SpriteTest.h
@@ -275,6 +275,10 @@
 {}
 @end
 
+@interface SpriteBatchNodeSkewNegativeScaleChildren : SpriteDemo
+{}
+@end
+
 @interface SpriteNilTexture : SpriteDemo
 {}
 @end

--- a/tests/SpriteTest.m
+++ b/tests/SpriteTest.m
@@ -61,6 +61,7 @@ static NSString *transitions[] = {
 	@"SpriteBatchNodeChildrenScale",
 	@"SpriteChildrenChildren",
 	@"SpriteBatchNodeChildrenChildren",
+	@"SpriteBatchNodeSkewNegativeScaleChildren",
 	@"SpriteNilTexture",
 	@"SpriteSubclass",
 	@"AnimationCache",
@@ -3997,6 +3998,67 @@ Class restartAction()
 -(NSString *) title
 {
 	return @"SpriteBatchNode multiple levels of children";
+}
+@end
+
+#pragma mark -
+#pragma mark Example SpriteBatchNodeSkewNegativeScaleChildren
+
+@implementation SpriteBatchNodeSkewNegativeScaleChildren
+
+-(id) init
+{
+	if( (self=[super init]) ) {
+		
+		CGSize s = [[CCDirector sharedDirector] winSize];		
+		
+		CCSpriteFrameCache *cache = [CCSpriteFrameCache sharedSpriteFrameCache];
+		[cache addSpriteFramesWithFile:@"animations/grossini.plist"];
+		[cache addSpriteFramesWithFile:@"animations/grossini_gray.plist" textureFile:@"animations/grossini_gray.png"];
+		
+		CCSpriteBatchNode *spritebatch = [CCSpriteBatchNode batchNodeWithFile:@"animations/grossini.pvr.gz"];
+		[self addChild:spritebatch];
+		
+		for(int i=0;i<2;i++) {
+			CCSprite *sprite = [CCSprite spriteWithSpriteFrameName:@"grossini_dance_01.png"];
+			sprite.position = ccp( s.width/4*(i+1), s.height/2);
+			
+			// Skew
+			id skewX = [CCSkewBy actionWithDuration:2 skewX:45 skewY:0];
+			id skewX_back = [skewX reverse];
+			id skewY = [CCSkewBy actionWithDuration:2 skewX:0 skewY:45];
+			id skewY_back = [skewY reverse];
+			
+			if(i == 1)
+			{
+				[sprite setScaleX:-1.0f];
+			}
+			
+			id seq_skew = [CCSequence actions:skewX, skewX_back, skewY, skewY_back, nil];
+			[sprite runAction:[CCRepeatForever actionWithAction:seq_skew]];
+			
+			CCSprite *child1 = [CCSprite spriteWithSpriteFrameName:@"grossini_dance_01.png"];
+			[child1 setPosition: ccp(sprite.contentSize.width / 2.0f, sprite.contentSize.height / 2.0f)];
+			
+			[sprite addChild: child1];
+			
+			[spritebatch addChild:sprite z:i];
+		}
+	}
+	return self;
+}
+
+- (void) dealloc
+{
+	CCSpriteFrameCache *cache = [CCSpriteFrameCache sharedSpriteFrameCache];
+	[cache removeSpriteFramesFromFile:@"animations/grossini.plist"];
+	[cache removeSpriteFramesFromFile:@"animations/grossini_gray.plist"];
+	[super dealloc];
+}
+
+-(NSString *) title
+{
+	return @"SpriteBatchNode skew + negative scale with children";
 }
 @end
 


### PR DESCRIPTION
There appears to be an issue with the transform order of CCSprites when the scale of a parent sprite is negative. This commit reorders the transform order so that the scale transform is before the skew transform, mitigating the issue. A test is also attached in  a separate commit.

Thanks.
