### PR TITLE
Fixed PASoundEngine bug with 8 bits PCM sounds

### DIFF
--- a/experimental/sound-engine/PASoundSource.m
+++ b/experimental/sound-engine/PASoundSource.m
@@ -85,7 +85,24 @@ void* MyGetOpenALAudioData(CFURLRef inFileURL, ALsizei *outDataSize, ALenum *out
 		{
 			// success
 			*outDataSize = (ALsizei)dataSize;
-			*outDataFormat = (theFileFormat.mChannelsPerFrame > 1) ? AL_FORMAT_STEREO16 : AL_FORMAT_MONO16;
+            if(theFileFormat.mChannelsPerFrame == 1){
+                // Mono sound
+                if (theFileFormat.mBitsPerChannel == 16) {
+                    *outDataFormat = AL_FORMAT_MONO16;
+                }
+                else {
+                    *outDataFormat = AL_FORMAT_MONO8;
+                }
+            }
+            else {
+                // Stereo sound
+                if (theFileFormat.mBitsPerChannel == 16) {
+                    *outDataFormat = AL_FORMAT_STEREO16;
+                }
+                else {
+                    *outDataFormat = AL_FORMAT_STEREO8;
+                }
+            }
 			*outSampleRate = (ALsizei)theFileFormat.mSampleRate;
 		}
 		else 


### PR DESCRIPTION
PASoundEngine (situated in cocos2d's "experimental" folder) had a bug with 8 bits PCM sounds like WAV sounds.
This changes introduce few lines of code to fix it.
