### PR TITLE
Issue 1264, flipped tiles can be changed during runtime. 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,6 +40,7 @@ Contributors (alphabetically ordered):
 	Improved ESRenderer layoutSubview
 	Improved Debug Drawing for Sprite batched node	
 	EAGLView destroys and recreates all OpenGL buffers correctly
+	TileMap: flipped tiles can be changed during runtime
 
 * podhrask...@gmail.com
 	TouchDispatcher: correctly handles addition and removal of handlers when being inside a touch handler. patch

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ version 1.1-beta2 xx - 2011
 . [NEW] All: Code is compatible with ARC (issue #1199)
 . [NEW] TileMap: supports in-memory TMX map creation (issue #1239)
 . [NEW] Node: Added onExitTransitionDidStart (issue #792)
+. [NEW] TileMap: Flipped tiles can be changed during runtime (issue #1264)
 . [FIX] Node: orderOfArrival is @synthezied correctly (issue #1273)
 . [FIX] Node & Sprite: Scale before Skew to prevent issues with negatives scales.
 . [FIX] TouchDispatcher: correctly handles addition and removal of handlers when being inside a touch handler (issue #1084, #1139)

--- a/cocos2d/CCTMXLayer.h
+++ b/cocos2d/CCTMXLayer.h
@@ -61,6 +61,10 @@
 	http://www.cocos2d-iphone.org/wiki/doku.php/prog_guide:tiled_maps
  
  @since v0.8.1
+ 
+ Tiles can have tile flags for additional properties. At the moment only flip horizontal and flip vertical are used. These bit flags are defined in CCTMXXMLParser.h.
+ 
+ @since 1.1
  */
 @interface CCTMXLayer : CCSpriteBatchNode
 {
@@ -127,11 +131,26 @@
  */
 -(uint32_t) tileGIDAt:(CGPoint)tileCoordinate;
 
+/** returns the tile gid at a given tile coordinate and includes the tile flags when flag is YES
+ if it returns 0, it means that the tile is empty.
+ This method requires the the tile map has not been previously released (eg. don't call [layer releaseMap])
+ */
+-(uint32_t) tileGIDAt:(CGPoint)pos withFlags:(BOOL) flags;
+
 /** sets the tile gid (gid = tile global id) at a given tile coordinate.
  The Tile GID can be obtained by using the method "tileGIDAt" or by using the TMX editor -> Tileset Mgr +1.
  If a tile is already placed at that position, then it will be removed.
  */
 -(void) setTileGID:(uint32_t)gid at:(CGPoint)tileCoordinate;
+
+/** sets the tile gid (gid = tile global id) at a given tile coordinate.
+ The Tile GID can be obtained by using the method "tileGIDAt" or by using the TMX editor -> Tileset Mgr +1.
+ If a tile is already placed at that position, then it will be removed.
+ 
+ Use withFlags if the tile flags need to be changed as well
+ */
+
+-(void) setTileGID:(uint32_t)gid at:(CGPoint)pos withFlags:(BOOL) flags;
 
 /** removes a tile at given tile coordinate */
 -(void) removeTileAt:(CGPoint)tileCoordinate;

--- a/cocos2d/CCTMXLayer.m
+++ b/cocos2d/CCTMXLayer.m
@@ -130,6 +130,7 @@ int compareInts (const void * a, const void * b);
 
 /* The layer recognizes some special properties, like cc_vertez */
 -(void) parseInternalProperties;
+- (void) setupTileSprite:(CCSprite*) sprite position:(CGPoint)pos withGID:(uint32_t)gid;
 
 -(NSInteger) vertexZForPos:(CGPoint)pos;
 
@@ -332,28 +333,43 @@ int compareInts (const void * a, const void * b);
 
 -(uint32_t) tileGIDAt:(CGPoint)pos
 {
+	return [self tileGIDAt:pos withFlags:NO];
+}
+
+-(uint32_t) tileGIDAt:(CGPoint)pos withFlags:(BOOL) flags
+{
 	NSAssert( pos.x < layerSize_.width && pos.y < layerSize_.height && pos.x >=0 && pos.y >=0, @"TMXLayer: invalid position");
 	NSAssert( tiles_ && atlasIndexArray_, @"TMXLayer: the tiles map has been released");
 	
 	NSInteger idx = pos.x + pos.y * layerSize_.width;
 	
 	// Bits on the far end of the 32-bit global tile ID are used for tile flags
-	return (tiles_[ idx ] & kFlippedMask);
+	// issue1264, flipped tiles can be changed dynamically
+	if (flags) 
+		return (tiles_[ idx ]);
+	else 
+		return (tiles_[ idx ] & kFlippedMask);
 }
 
 #pragma mark CCTMXLayer - adding helper methods
 
-- (void) setupReusedTile:(CGPoint)pos withGID:(uint32_t)gid
+- (void) setupTileSprite:(CCSprite*) sprite position:(CGPoint)pos withGID:(uint32_t)gid
 {
-	[reusedTile_ setPositionInPixels: [self positionAt:pos]];
-	[reusedTile_ setVertexZ: [self vertexZForPos:pos]];
-	reusedTile_.anchorPoint = CGPointZero;
-	[reusedTile_ setOpacity:opacity_];
+	[sprite setPositionInPixels: [self positionAt:pos]];
+	[sprite setVertexZ: [self vertexZForPos:pos]];
+	sprite.anchorPoint = CGPointZero;
+	[sprite setOpacity:opacity_];
 	
+	//issue 1264, flip can be undone as well
 	if (gid & kFlippedHorizontallyFlag)
-		reusedTile_.flipX = YES;
+		sprite.flipX = YES;
+	else 
+		sprite.flipX = NO;
+	
 	if (gid & kFlippedVerticallyFlag)
-		reusedTile_.flipY = YES;
+		sprite.flipY = YES;
+	else
+		sprite.flipY = NO;
 }
 
 -(CCSprite*) insertTileForGID:(uint32_t)gid at:(CGPoint)pos
@@ -367,7 +383,7 @@ int compareInts (const void * a, const void * b);
 	else
 		[reusedTile_ initWithBatchNode:self rectInPixels:rect];
 	
-	[self setupReusedTile:pos withGID:gid];
+	[self setupTileSprite:reusedTile_ position:pos withGID:gid];
 	
 	// get atlas index
 	NSUInteger indexForZ = [self atlasIndexForNewZ:z];
@@ -402,7 +418,7 @@ int compareInts (const void * a, const void * b);
 	else
 		[reusedTile_ initWithBatchNode:self rectInPixels:rect];
 	
-	[self setupReusedTile:pos withGID:gid];
+	[self setupTileSprite:reusedTile_ position:pos withGID:gid];
 	
 	// get atlas index
 	NSUInteger indexForZ = [self atlasIndexForExistantZ:z];
@@ -429,7 +445,7 @@ int compareInts (const void * a, const void * b);
 	else
 		[reusedTile_ initWithBatchNode:self rectInPixels:rect];
 	
-	[self setupReusedTile:pos withGID:gid];
+	[self setupTileSprite:reusedTile_ position:pos withGID:gid];
 	
 	// optimization:
 	// The difference between appendTileForGID and insertTileforGID is that append is faster, since
@@ -478,17 +494,21 @@ int compareInts (const void * a, const void * b)
 }
 
 #pragma mark CCTMXLayer - adding / remove tiles
-
 -(void) setTileGID:(uint32_t)gid at:(CGPoint)pos
+{
+	[self setTileGID:gid at:pos withFlags:NO];	
+}
+
+-(void) setTileGID:(uint32_t)gid at:(CGPoint)pos withFlags:(BOOL) flags
 {
 	NSAssert( pos.x < layerSize_.width && pos.y < layerSize_.height && pos.x >=0 && pos.y >=0, @"TMXLayer: invalid position");
 	NSAssert( tiles_ && atlasIndexArray_, @"TMXLayer: the tiles map has been released");
 	NSAssert( gid == 0 || gid >= tileset_.firstGid, @"TMXLayer: invalid gid" );
 
-	uint32_t currentGID = [self tileGIDAt:pos];
+	uint32_t currentGID = [self tileGIDAt:pos withFlags:flags];
 	
-	if( currentGID != gid ) {
-		
+	if (currentGID != gid) 
+	{
 		// setting gid=0 is equal to remove the tile
 		if( gid == 0 )
 			[self removeTileAt:pos];
@@ -505,6 +525,10 @@ int compareInts (const void * a, const void * b)
 			if( sprite ) {
 				CGRect rect = [tileset_ rectForGID:gid];
 				[sprite setTextureRectInPixels:rect rotated:NO untrimmedSize:rect.size];
+				
+				if (flags) 
+					[self setupTileSprite:sprite position:[sprite position] withGID:gid];
+				
 				tiles_[z] = gid;
 			} else
 				[self updateTileForGID:gid at:pos];

--- a/tests/TileMapTest.h
+++ b/tests/TileMapTest.h
@@ -143,6 +143,10 @@
 {}
 @end
 
+@interface TMXOrthoFlipRunTimeTest : TileDemo
+{}
+@end
+
 @interface TMXOrthoFromXMLTest : TileDemo 
 {}
 @end

--- a/tests/TileMapTest.m
+++ b/tests/TileMapTest.m
@@ -38,6 +38,7 @@ static NSString *transitions[] = {
 	@"TMXIsoMoveLayer",
 	@"TMXOrthoMoveLayer",
 	@"TMXOrthoFlipTest",
+	@"TMXOrthoFlipRunTimeTest",
 	@"TMXOrthoFromXMLTest",
 	@"TMXBug987",
 	@"TMXBug787",
@@ -1394,6 +1395,76 @@ Class restartAction()
 }
 @end
 
+#pragma mark -
+#pragma mark TMXOrthoFlipRunTimeTest
+
+@implementation TMXOrthoFlipRunTimeTest
+-(id) init
+{
+	if( (self=[super init]) ) {		
+		CCTMXTiledMap *map = [CCTMXTiledMap tiledMapWithTMXFile:@"TileMaps/ortho-rotation-test.tmx"];
+		[self addChild:map z:0 tag:kTagTileMap];
+		
+		CGSize s = map.contentSize;
+		NSLog(@"ContentSize: %f, %f", s.width,s.height);
+		
+		for( CCSpriteBatchNode* child in [map children] ) {
+			[[child texture] setAntiAliasTexParameters];
+		}
+		
+		id action = [CCScaleBy actionWithDuration:2 scale:0.5f];
+		[map runAction:action];
+		
+		[self schedule:@selector(flipIt) interval:0.f repeat:0.f delay:2.f]; 
+	}	
+	return self;
+}
+
+-(NSString *) title
+{
+	return @"TMX tile flip run time test";
+}
+
+-(NSString *) subtitle
+{
+	return @"in 2 sec bottom left tiles will flip";
+}
+
+- (void) flipIt 
+{
+	CCTMXTiledMap *map = (CCTMXTiledMap*) [self getChildByTag:kTagTileMap]; 
+	CCTMXLayer *layer = [map layerNamed:@"Layer 0"]; 
+	
+	//blue diamond 
+	CGPoint tileCoord = ccp(1,10);
+	
+	uint32_t GID = [layer tileGIDAt:tileCoord withFlags:NO]; 
+	GID = GID | kFlippedVerticallyFlag;
+	
+	//only the vertical flag is now set
+	[layer setTileGID:GID  at:tileCoord withFlags:YES]; 
+	
+	tileCoord = ccp(2,10);
+	
+	//tile has horizontal flag
+	GID = [layer tileGIDAt:tileCoord withFlags:YES]; 
+	GID = GID | kFlippedVerticallyFlag;
+	
+	//tile has horizontal + vertical flag
+	[layer setTileGID:GID at:tileCoord withFlags:YES]; 
+	
+	//the bug
+	tileCoord = ccp(2,8);
+	
+	//want to reset flip of tile, get original tile gid
+	GID = [layer tileGIDAt:tileCoord withFlags:NO]; 
+	
+	//overwrite the flags by setting withFlags to YES
+	[layer setTileGID:GID  at:tileCoord withFlags:YES]; 
+}
+@end
+
+
 
 #pragma mark -
 #pragma mark TMXOrthoFromXMLTest
@@ -1420,6 +1491,7 @@ Class restartAction()
 		
 		id action = [CCScaleBy actionWithDuration:2 scale:0.5f];
 		[map runAction:action];
+	
 	}	
 	return self;
 }


### PR DESCRIPTION
CCTMXLayer added

-(void) setTileGID:(uint32_t)gid at:(CGPoint)pos withFlags:(BOOL) flags;
-(uint32_t) tileGIDAt:(CGPoint)pos withFlags:(BOOL) flags;
