### PR TITLE
CCProgress Timer Fix #1303

### DIFF
--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -4167,7 +4167,7 @@
 		5012DD4B0FE29A7D00D6DDD1 /* ball.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ball.png; sourceTree = "<group>"; };
 		5012DD4C0FE29A7D00D6DDD1 /* paddle.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = paddle.png; sourceTree = "<group>"; };
 		50150433113300F900A9CA65 /* CCProgressTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CCProgressTimer.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		50150434113300F900A9CA65 /* CCProgressTimer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CCProgressTimer.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		50150434113300F900A9CA65 /* CCProgressTimer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CCProgressTimer.m; sourceTree = "<group>"; };
 		50150435113300F900A9CA65 /* CCActionProgressTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionProgressTimer.h; sourceTree = "<group>"; };
 		50150436113300F900A9CA65 /* CCActionProgressTimer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCActionProgressTimer.m; sourceTree = "<group>"; };
 		501504ED11330E1700A9CA65 /* ActionsProgressTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ActionsProgressTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -9020,7 +9020,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0430;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "cocos2d-ios" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		05CA7AFE10ED674700F12774 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D500B990D5A79CF00DBA0E3 /* QuartzCore.framework */; };
 		05CA7B0010ED674700F12774 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 503092B210447296005F7AFC /* libz.dylib */; };
 		05CA7B0C10ED67CE00F12774 /* ActionsWithBlocks.m in Sources */ = {isa = PBXBuildFile; fileRef = 05CA7B0B10ED67CE00F12774 /* ActionsWithBlocks.m */; };
+		3BB41AD414E43A51006CD0D8 /* zwoptex in Resources */ = {isa = PBXBuildFile; fileRef = E0C5588E11FE4CF100B9E4CB /* zwoptex */; };
 		3BB5C8E911410A4000DD65EF /* blocks.png in Resources */ = {isa = PBXBuildFile; fileRef = AAEA834A0FD5704400F08728 /* blocks.png */; };
 		3BB5C8EF11410A5300DD65EF /* blocks.png in Resources */ = {isa = PBXBuildFile; fileRef = AAEA834A0FD5704400F08728 /* blocks.png */; };
 		495E73FD104B75090012BB52 /* r1.png in Resources */ = {isa = PBXBuildFile; fileRef = 500165990E72DB0E0085673F /* r1.png */; };
@@ -9353,6 +9354,7 @@
 				A0EC4BA41403239E00EC482A /* PositionTextureA8Color.vsh in Resources */,
 				A0EC4BA51403239E00EC482A /* PositionTextureColor.fsh in Resources */,
 				A0EC4BA61403239E00EC482A /* PositionTextureColor.vsh in Resources */,
+				3BB41AD414E43A51006CD0D8 /* zwoptex in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/cocos2d-mac.xcodeproj/project.pbxproj
+++ b/cocos2d-mac.xcodeproj/project.pbxproj
@@ -6015,7 +6015,7 @@
 		E076E66A1225EC7400DE0DA2 /* CCParticleSystem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCParticleSystem.m; sourceTree = "<group>"; };
 		E076E66D1225EC7400DE0DA2 /* CCParticleSystemQuad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCParticleSystemQuad.h; sourceTree = "<group>"; };
 		E076E66E1225EC7400DE0DA2 /* CCParticleSystemQuad.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCParticleSystemQuad.m; sourceTree = "<group>"; };
-		E076E66F1225EC7400DE0DA2 /* CCProgressTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCProgressTimer.h; sourceTree = "<group>"; };
+		E076E66F1225EC7400DE0DA2 /* CCProgressTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCProgressTimer.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		E076E6701225EC7400DE0DA2 /* CCProgressTimer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCProgressTimer.m; sourceTree = "<group>"; };
 		E076E6711225EC7400DE0DA2 /* CCProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCProtocols.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		E076E6721225EC7400DE0DA2 /* CCRenderTexture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCRenderTexture.h; sourceTree = "<group>"; };

--- a/cocos2d/CCProgressTimer.m
+++ b/cocos2d/CCProgressTimer.m
@@ -189,8 +189,11 @@ const char kCCProgressTextureCoords = 0x4b;
 	ccV3F_C4B_T2F_Quad quad = sprite_.quad;
 	CGPoint min = (CGPoint){quad.bl.texCoords.u,quad.bl.texCoords.v};
 	CGPoint max = (CGPoint){quad.tr.texCoords.u,quad.tr.texCoords.v};
-	BOOL texRotated = sprite_.textureRectRotated;
-	return (ccTex2F){min.x * (1.f - alpha.x) + max.x * (texRotated? alpha.y : alpha.x), min.y * (1.f - alpha.y) + max.y * (texRotated? alpha.x : alpha.y)};
+  //  Fix bug #1303 so that progress timer handles sprite frame texture rotation
+  if (sprite_.textureRectRotated) {
+    CC_SWAP(alpha.x, alpha.y);
+  }
+	return (ccTex2F){min.x * (1.f - alpha.x) + max.x * alpha.x, min.y * (1.f - alpha.y) + max.y * alpha.y};
 }
 
 -(ccVertex2F)vertexFromAlphaPoint:(CGPoint) alpha

--- a/cocos2d/CCProgressTimer.m
+++ b/cocos2d/CCProgressTimer.m
@@ -57,6 +57,7 @@ const char kCCProgressTextureCoords = 0x4b;
 @synthesize sprite = sprite_;
 @synthesize type = type_;
 @synthesize reverseDirection = reverseDirection_;
+@synthesize midpoint = midpoint_;
 @synthesize barChangeRate = barChangeRate_;
 @synthesize vertexData = vertexData_;
 @synthesize vertexDataCount = vertexDataCount_;
@@ -65,20 +66,27 @@ const char kCCProgressTextureCoords = 0x4b;
 {
 	return [[[self alloc]initWithSprite:sprite] autorelease];
 }
--(id)initWithSprite:(CCSprite*) sprite
+
+-(id)init
 {
-	if(( self = [super init] )){
-		self.sprite = sprite;
+	if( (self=[super init]) ) {
 		percentage_ = 0.f;
 		vertexData_ = NULL;
 		vertexDataCount_ = 0;
-
 		self.anchorPoint = ccp(0.5f,0.5f);
-		type_ = kCCProgressTimerTypeRadial;
-		reverseDirection_ = NO;
-		midpoint_ = ccp(.5f, .5f);
-		barChangeRate_ = ccp(1,1);
+		self.type = kCCProgressTimerTypeRadial;
+		self.reverseDirection = NO;
+		self.midpoint = ccp(.5f, .5f);
+		self.barChangeRate = ccp(1,1);
+  }
+  return self;
+}
 
+-(id)initWithSprite:(CCSprite*) sprite
+{
+	if(( self = [self init] )){
+		self.sprite = sprite;
+    
 		// shader program
 		self.shaderProgram = [[CCShaderCache sharedShaderCache] programForKey:kCCShader_PositionTextureColor];
 	}
@@ -97,7 +105,7 @@ const char kCCProgressTextureCoords = 0x4b;
 -(void)setPercentage:(float) percentage
 {
 	if(percentage_ != percentage) {
-        percentage_ = clampf( percentage, 0, 100);
+    percentage_ = clampf( percentage, 0, 100);
 		[self updateProgress];
 	}
 }
@@ -108,7 +116,7 @@ const char kCCProgressTextureCoords = 0x4b;
 		[sprite_ release];
 		sprite_ = [newSprite retain];
 		self.contentSize = sprite_.contentSize;
-
+    
 		//	Everytime we set a new sprite, we free the current vertex data
 		if(vertexData_){
 			free(vertexData_);
@@ -121,7 +129,7 @@ const char kCCProgressTextureCoords = 0x4b;
 -(void)setType:(CCProgressTimerType)newType
 {
 	if (newType != type_) {
-
+    
 		//	release all previous information
 		if(vertexData_){
 			free(vertexData_);
@@ -136,7 +144,7 @@ const char kCCProgressTextureCoords = 0x4b;
 {
 	if( reverseDirection_ != reverse ) {
 		reverseDirection_ = reverse;
-
+    
 		//	release all previous information
 		if(vertexData_){
 			free(vertexData_);
@@ -181,7 +189,8 @@ const char kCCProgressTextureCoords = 0x4b;
 	ccV3F_C4B_T2F_Quad quad = sprite_.quad;
 	CGPoint min = (CGPoint){quad.bl.texCoords.u,quad.bl.texCoords.v};
 	CGPoint max = (CGPoint){quad.tr.texCoords.u,quad.tr.texCoords.v};
-	return (ccTex2F){min.x * (1.f - alpha.x) + max.x * alpha.x, min.y * (1.f - alpha.y) + max.y * alpha.y};
+	BOOL texRotated = sprite_.textureRectRotated;
+	return (ccTex2F){min.x * (1.f - alpha.x) + max.x * (texRotated? alpha.y : alpha.x), min.y * (1.f - alpha.y) + max.y * (texRotated? alpha.x : alpha.y)};
 }
 
 -(ccVertex2F)vertexFromAlphaPoint:(CGPoint) alpha
@@ -251,21 +260,21 @@ const char kCCProgressTextureCoords = 0x4b;
 	if (!sprite_) {
 		return;
 	}
-
+  
 	float alpha = percentage_ / 100.f;
-
+  
 	float angle = 2.f*((float)M_PI) * ( reverseDirection_ == YES ? alpha : 1.f - alpha);
-
+  
 	//	We find the vector to do a hit detection based on the percentage
 	//	We know the first vector is the one @ 12 o'clock (top,mid) so we rotate
 	//	from that by the progress angle around the midpoint_ pivot
 	CGPoint topMid = ccp(midpoint_.x, 1.f);
 	CGPoint percentagePt = ccpRotateByAngle(topMid, midpoint_, angle);
-
-
+  
+  
 	int index = 0;
 	CGPoint hit = CGPointZero;
-
+  
 	if (alpha == 0.f) {
 		//	More efficient since we don't always need to check intersection
 		//	If the alpha is zero then the hit point is top mid and the index is 0.
@@ -280,28 +289,28 @@ const char kCCProgressTextureCoords = 0x4b;
 		//	We run a for loop checking the edges of the texture to find the
 		//	intersection point
 		//	We loop through five points since the top is split in half
-
+    
 		float min_t = FLT_MAX;
-
+    
 		for (int i = 0; i <= kProgressTextureCoordsCount; ++i) {
 			int pIndex = (i + (kProgressTextureCoordsCount - 1))%kProgressTextureCoordsCount;
-
+      
 			CGPoint edgePtA = [self boundaryTexCoord:i % kProgressTextureCoordsCount];
 			CGPoint edgePtB = [self boundaryTexCoord:pIndex];
-
+      
 			//	Remember that the top edge is split in half for the 12 o'clock position
 			//	Let's deal with that here by finding the correct endpoints
 			if(i == 0){
-				edgePtB = ccpLerp(edgePtA, edgePtB, .5f);
+				edgePtB = ccpLerp(edgePtA, edgePtB, 1 - midpoint_.x);
 			} else if(i == 4){
-				edgePtA = ccpLerp(edgePtA, edgePtB, .5f);
+				edgePtA = ccpLerp(edgePtA, edgePtB, 1 - midpoint_.x);
 			}
-
+      
 			//	s and t are returned by ccpLineIntersect
 			float s = 0, t = 0;
 			if(ccpLineIntersect(edgePtA, edgePtB, midpoint_, percentagePt, &s, &t))
 			{
-
+        
 				//	Since our hit test is on rays we have to deal with the top edge
 				//	being in split in half so we have to test as a segment
 				if ((i == 0 || i == 4)) {
@@ -322,16 +331,16 @@ const char kCCProgressTextureCoords = 0x4b;
 				}
 			}
 		}
-
+    
 		//	Now that we have the minimum magnitude we can use that to find our intersection
 		hit = ccpAdd(midpoint_, ccpMult(ccpSub(percentagePt, midpoint_),min_t));
-
+    
 	}
-
-
+  
+  
 	//	The size of the vertex data is the index from the hitpoint
 	//	the 3 is for the midpoint_, 12 o'clock point and hitpoint position.
-
+  
 	BOOL sameIndexCount = YES;
 	if(vertexDataCount_ != index + 3){
 		sameIndexCount = NO;
@@ -341,32 +350,32 @@ const char kCCProgressTextureCoords = 0x4b;
 			vertexDataCount_ = 0;
 		}
 	}
-
-
+  
+  
 	if(!vertexData_) {
 		vertexDataCount_ = index + 3;
 		vertexData_ = malloc(vertexDataCount_ * sizeof(ccV2F_C4B_T2F));
 		NSAssert( vertexData_, @"CCProgressTimer. Not enough memory");
 	}
 	[self updateColor];
-
+  
 	if (!sameIndexCount) {
-
+    
 		//	First we populate the array with the midpoint_, then all
 		//	vertices/texcoords/colors of the 12 'o clock start and edges and the hitpoint
 		vertexData_[0].texCoords = [self textureCoordFromAlphaPoint:midpoint_];
 		vertexData_[0].vertices = [self vertexFromAlphaPoint:midpoint_];
-
+    
 		vertexData_[1].texCoords = [self textureCoordFromAlphaPoint:topMid];
 		vertexData_[1].vertices = [self vertexFromAlphaPoint:topMid];
-
+    
 		for(int i = 0; i < index; ++i){
 			CGPoint alphaPoint = [self boundaryTexCoord:i];
 			vertexData_[i+2].texCoords = [self textureCoordFromAlphaPoint:alphaPoint];
 			vertexData_[i+2].vertices = [self vertexFromAlphaPoint:alphaPoint];
 		}
 	}
-
+  
 	//	hitpoint will go last
 	vertexData_[vertexDataCount_ - 1].texCoords = [self textureCoordFromAlphaPoint:hit];
 	vertexData_[vertexDataCount_ - 1].vertices = [self vertexFromAlphaPoint:hit];
@@ -390,28 +399,28 @@ const char kCCProgressTextureCoords = 0x4b;
 	CGPoint alphaOffset = ccpMult(ccp(1.f * (1.f - barChangeRate_.x) + alpha * barChangeRate_.x, 1.f * (1.f - barChangeRate_.y) + alpha * barChangeRate_.y), .5f);
 	CGPoint min = ccpSub(midpoint_, alphaOffset);
 	CGPoint max = ccpAdd(midpoint_, alphaOffset);
-
+  
 	if (min.x < 0.f) {
 		max.x += -min.x;
 		min.x = 0.f;
 	}
-
+  
 	if (max.x > 1.f) {
 		min.x -= max.x - 1.f;
 		max.x = 1.f;
 	}
-
+  
 	if (min.y < 0.f) {
 		max.y += -min.y;
 		min.y = 0.f;
 	}
-
+  
 	if (max.y > 1.f) {
 		min.y -= max.y - 1.f;
 		max.y = 1.f;
 	}
-
-
+  
+  
 	if (!reverseDirection_) {
 		if(!vertexData_) {
 			vertexDataCount_ = 4;
@@ -421,15 +430,15 @@ const char kCCProgressTextureCoords = 0x4b;
 		//	TOPLEFT
 		vertexData_[0].texCoords = [self textureCoordFromAlphaPoint:ccp(min.x,max.y)];
 		vertexData_[0].vertices = [self vertexFromAlphaPoint:ccp(min.x,max.y)];
-
+    
 		//	BOTLEFT
 		vertexData_[1].texCoords = [self textureCoordFromAlphaPoint:ccp(min.x,min.y)];
 		vertexData_[1].vertices = [self vertexFromAlphaPoint:ccp(min.x,min.y)];
-
+    
 		//	TOPRIGHT
 		vertexData_[2].texCoords = [self textureCoordFromAlphaPoint:ccp(max.x,max.y)];
 		vertexData_[2].vertices = [self vertexFromAlphaPoint:ccp(max.x,max.y)];
-
+    
 		//	BOTRIGHT
 		vertexData_[3].texCoords = [self textureCoordFromAlphaPoint:ccp(max.x,min.y)];
 		vertexData_[3].vertices = [self vertexFromAlphaPoint:ccp(max.x,min.y)];
@@ -441,32 +450,32 @@ const char kCCProgressTextureCoords = 0x4b;
 			//	TOPLEFT 1
 			vertexData_[0].texCoords = [self textureCoordFromAlphaPoint:ccp(0,1)];
 			vertexData_[0].vertices = [self vertexFromAlphaPoint:ccp(0,1)];
-
+      
 			//	BOTLEFT 1
 			vertexData_[1].texCoords = [self textureCoordFromAlphaPoint:ccp(0,0)];
 			vertexData_[1].vertices = [self vertexFromAlphaPoint:ccp(0,0)];
-
+      
 			//	TOPRIGHT 2
 			vertexData_[6].texCoords = [self textureCoordFromAlphaPoint:ccp(1,1)];
 			vertexData_[6].vertices = [self vertexFromAlphaPoint:ccp(1,1)];
-
+      
 			//	BOTRIGHT 2
 			vertexData_[7].texCoords = [self textureCoordFromAlphaPoint:ccp(1,0)];
 			vertexData_[7].vertices = [self vertexFromAlphaPoint:ccp(1,0)];
 		}
-
+    
 		//	TOPRIGHT 1
 		vertexData_[2].texCoords = [self textureCoordFromAlphaPoint:ccp(min.x,max.y)];
 		vertexData_[2].vertices = [self vertexFromAlphaPoint:ccp(min.x,max.y)];
-
+    
 		//	BOTRIGHT 1
 		vertexData_[3].texCoords = [self textureCoordFromAlphaPoint:ccp(min.x,min.y)];
 		vertexData_[3].vertices = [self vertexFromAlphaPoint:ccp(min.x,min.y)];
-
+    
 		//	TOPLEFT 2
 		vertexData_[4].texCoords = [self textureCoordFromAlphaPoint:ccp(max.x,max.y)];
 		vertexData_[4].vertices = [self vertexFromAlphaPoint:ccp(max.x,max.y)];
-
+    
 		//	BOTLEFT 2
 		vertexData_[5].texCoords = [self textureCoordFromAlphaPoint:ccp(max.x,min.y)];
 		vertexData_[5].vertices = [self vertexFromAlphaPoint:ccp(max.x,min.y)];
@@ -490,19 +499,19 @@ const char kCCProgressTextureCoords = 0x4b;
 {
 	if( ! vertexData_ || ! sprite_)
 		return;
-
+  
 	CC_NODE_DRAW_SETUP();
-
+  
 	ccGLBlendFunc( sprite_.blendFunc.src, sprite_.blendFunc.dst );
-
+  
 	ccGLEnableVertexAttribs(kCCVertexAttribFlag_PosColorTex );
-
+  
 	ccGLBindTexture2D( sprite_.texture.name );
-
-    glVertexAttribPointer( kCCVertexAttrib_Position, 2, GL_FLOAT, GL_FALSE, sizeof(vertexData_[0]) , &vertexData_[0].vertices);
-    glVertexAttribPointer( kCCVertexAttrib_TexCoords, 2, GL_FLOAT, GL_FALSE, sizeof(vertexData_[0]), &vertexData_[0].texCoords);
-    glVertexAttribPointer( kCCVertexAttrib_Color, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(vertexData_[0]), &vertexData_[0].colors);
-
+  
+  glVertexAttribPointer( kCCVertexAttrib_Position, 2, GL_FLOAT, GL_FALSE, sizeof(vertexData_[0]) , &vertexData_[0].vertices);
+  glVertexAttribPointer( kCCVertexAttrib_TexCoords, 2, GL_FLOAT, GL_FALSE, sizeof(vertexData_[0]), &vertexData_[0].texCoords);
+  glVertexAttribPointer( kCCVertexAttrib_Color, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(vertexData_[0]), &vertexData_[0].colors);
+  
 	if(type_ == kCCProgressTimerTypeRadial)
 	{
 		glDrawArrays(GL_TRIANGLE_FAN, 0, vertexDataCount_);
@@ -523,7 +532,7 @@ const char kCCProgressTextureCoords = 0x4b;
 		}
 	}
 	CC_INCREMENT_GL_DRAWS(1);
-
+  
 }
 
 @end

--- a/tests/ActionsProgressTest.h
+++ b/tests/ActionsProgressTest.h
@@ -23,6 +23,10 @@
 {}
 @end
 
+@interface SpriteProgressToRadialMidpointChanged : SpriteDemo
+{}
+@end
+
 @interface SpriteProgressToHorizontal : SpriteDemo
 {}
 @end
@@ -39,4 +43,6 @@
 {}
 @end
 
-
+@interface SpriteProgressWithSpriteFrame : SpriteDemo
+{}
+@end

--- a/tests/ActionsProgressTest.m
+++ b/tests/ActionsProgressTest.m
@@ -9,10 +9,12 @@
 static int sceneIdx=-1;
 static NSString *transitions[] = {
 	@"SpriteProgressToRadial",
+  @"SpriteProgressToRadialMidpointChanged",
 	@"SpriteProgressToHorizontal",
 	@"SpriteProgressToVertical",
 	@"SpriteProgressBarVarious",
 	@"SpriteProgressBarTintAndFade",
+  @"SpriteProgressWithSpriteFrame",
 
 };
 
@@ -150,6 +152,47 @@ Class restartAction()
 -(NSString *) title
 {
 	return @"ProgressTo Radial";
+}
+@end
+
+@implementation SpriteProgressToRadialMidpointChanged
+-(void) onEnter
+{
+	[super onEnter];
+	
+	CGSize s = [[CCDirector sharedDirector] winSize];
+  
+	CCProgressTo *action = [CCProgressTo actionWithDuration:2 percent:100];
+  
+  /**
+   *  Our image on the left should be a radial progress indicator, clockwise
+   */
+	CCProgressTimer *left = [CCProgressTimer progressWithSprite:[CCSprite spriteWithFile:@"blocks.png"]];
+	left.type = kCCProgressTimerTypeRadial;
+	[self addChild:left];
+  left.midpoint = ccp(.25,.75);
+	[left setPosition:ccp(100, s.height/2)];
+	[left runAction: [CCRepeatForever actionWithAction:[[action copy]autorelease]]];
+	
+  /**
+   *  Our image on the left should be a radial progress indicator, counter clockwise
+   */
+	CCProgressTimer *right = [CCProgressTimer progressWithSprite:[CCSprite spriteWithFile:@"blocks.png"]];
+	right.type = kCCProgressTimerTypeRadial;
+  right.midpoint = ccp(.75,.25);
+  
+  /**
+   *  Note the reverse property (default=NO) is only added to the right image. That's how
+   *  we get a counter clockwise progress.
+   */
+	[self addChild:right];
+	[right setPosition:ccp(s.width-100, s.height/2)];
+	[right runAction: [CCRepeatForever actionWithAction:[[action copy]autorelease]]];
+}
+
+-(NSString *) title
+{
+	return @"Radial w/ Different Midpoints";
 }
 @end
 
@@ -340,6 +383,57 @@ Class restartAction()
 -(NSString *) title
 {
 	return @"ProgressTo Bar Mid";
+}
+@end
+
+@implementation SpriteProgressWithSpriteFrame
+-(void) onEnter
+{
+	[super onEnter];
+  
+	CGSize s = [[CCDirector sharedDirector] winSize];
+  
+	CCProgressTo *to = [CCProgressTo actionWithDuration:6 percent:100];
+  
+  [[CCSpriteFrameCache sharedSpriteFrameCache]addSpriteFramesWithFile:@"zwoptex/grossini.plist"];
+  
+	CCProgressTimer *left = [CCProgressTimer progressWithSprite:[CCSprite spriteWithSpriteFrameName:@"grossini_dance_01.png"]];
+	left.type = kCCProgressTimerTypeBar;
+  
+	//	Setup for a bar starting from the bottom since the midpoint is 0 for the y
+	left.midpoint = ccp(.5f, .5f);
+	//	Setup for a vertical bar since the bar change rate is 0 for x meaning no horizontal change
+	left.barChangeRate = ccp(1,0);
+	[self addChild:left];
+	[left setPosition:ccp(100, s.height/2)];
+	[left runAction:[CCRepeatForever actionWithAction:[[to copy]autorelease]]];
+  
+  
+	CCProgressTimer *middle = [CCProgressTimer progressWithSprite:[CCSprite spriteWithSpriteFrameName:@"grossini_dance_02.png"]];
+	middle.type = kCCProgressTimerTypeBar;
+	//	Setup for a bar starting from the bottom since the midpoint is 0 for the y
+	middle.midpoint = ccp(.5f, .5f);
+	//	Setup for a vertical bar since the bar change rate is 0 for x meaning no horizontal change
+	middle.barChangeRate = ccp(1, 1);
+	[self addChild:middle];
+	[middle setPosition:ccp(s.width/2, s.height/2)];
+	[middle runAction:[CCRepeatForever actionWithAction:[[to copy]autorelease]]];
+  
+  
+	CCProgressTimer *right = [CCProgressTimer progressWithSprite:[CCSprite spriteWithSpriteFrameName:@"grossini_dance_03.png"]];
+	right.type = kCCProgressTimerTypeRadial;
+	//	Setup for a bar starting from the bottom since the midpoint is 0 for the y
+	right.midpoint = ccp(.5f, .5f);
+	//	Setup for a vertical bar since the bar change rate is 0 for x meaning no horizontal change
+	right.barChangeRate = ccp(0, 1);
+	[self addChild:right];
+	[right setPosition:ccp(s.width-100, s.height/2)];
+	[right runAction:[CCRepeatForever actionWithAction:[[to copy]autorelease]]];
+}
+
+-(NSString *) title
+{
+	return @"Progress With Sprite Frame";
 }
 @end
 

--- a/tests/PerformanceTests/cocos2d-ios-PerformanceTests.xcodeproj/project.pbxproj
+++ b/tests/PerformanceTests/cocos2d-ios-PerformanceTests.xcodeproj/project.pbxproj
@@ -807,7 +807,7 @@
 		A037D1E6141510EB0091B5C7 /* vec2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vec2.c; sourceTree = "<group>"; };
 		A037D1E7141510EB0091B5C7 /* vec3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vec3.c; sourceTree = "<group>"; };
 		A037D1E8141510EB0091B5C7 /* vec4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vec4.c; sourceTree = "<group>"; };
-		A08D161214DD17B60036D9CC /* PerformanceTest-Sprite copy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PerformanceTest-Sprite copy.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A08D161214DD17B60036D9CC /* PerformanceTest-Sprite copy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "PerformanceTest-Sprite copy.app"; path = MemoryAllocationTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A08D161714DD186E0036D9CC /* AppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppController.h; sourceTree = "<group>"; };
 		A08D161814DD186E0036D9CC /* AppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppController.m; sourceTree = "<group>"; };
 		A0A3CF0114BBFCDC0079CD11 /* fps_images-hd.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "fps_images-hd.png"; path = "../../Resources/Fonts/fps_images-hd.png"; sourceTree = "<group>"; };
@@ -1898,7 +1898,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0430;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "cocos2d-ios-PerformanceTests" */;
 			compatibilityVersion = "Xcode 3.2";


### PR DESCRIPTION
Fixed bug #1303 Now Progress Timer can handle sprites with rotated sprite frames
http://code.google.com/p/cocos2d-iphone/issues/detail?id=1303&sort=-id&colspec=ID%20Type%20Status%20Priority%20Milestone%20Component%20Owner%20Summary

Fixed graphical bug when midpoint's x is anything but 0.5.

Added in tests to ActionsProgressTest.m to test rotated sprite frames
