### PR TITLE
TouchDispatcher has been finally fixed:) See comments for more details.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,13 +6,13 @@ http://www.cocos2d-iphone.org/forum
 
 cocos2d logos by Michael Heald (http://www.fullyillustrated.com)
 
-
-
 cocos2d for iPhone authors for v1.1
 -----------------------------------
 
-Lead Developers:
+Lead Developer:
 	Marco Tillemans (http://www.welcometothefabrik.com/)
+
+Former Lead Developer:
 	Ricardo Quesada (http://www.cocos2d-iphone.org)
 
 
@@ -31,6 +31,7 @@ Contributors (alphabetically ordered):
 	Word Wrap works on LabelTTF on Mac
 	bug fixes for failure to compile on 32-bit mac builds
 	created new drawPrimitives functions, ccDrawRect, ccDrawSolidRect and ccDrawSolidPoly.
+    bug fix for CCTMXXMLParser in release mode
 	
 * Jerrod Putman (http://www.tinytimgames.com)
 	Original author of ARC compatibility code
@@ -65,32 +66,49 @@ Contributors (alphabetically ordered):
 
 * Nicky Weber (https://github.com/nickyEnjoysWoogoo):
 	Added convenience function to create a ccColor4F from color components	
+    
+* Nicolas Barrios (http://wefiends.com)
+    Fix for CCArray for ARC compatibility 
 
 * podhrask...@gmail.com
 	TouchDispatcher: correctly handles addition and removal of handlers when being inside a touch handler. patch
 
 * Ricardo Ruiz:
 	Added support for RGB888 textures
+    
+* Rick Smorawski
+    Added full unicode support to CCLabelBMFont
 
+* Samuel J. Grabski http://www.sg7.com
+	Created a new touchdispatcher implementation
+    New touchdispatcher performance tests
+    
 * Scott Lembcke (AKA slembcke) (http://chipmunk-physics.net/)
 	Improved ARC compatiblity code
 
 * Sergey Tikhonov (AKA haqu) (http://haqu.net)
 	Removed warning in CCMenuItem
 
-* slycrel (http://folderapp.blogspot.com/)
-	TMX Map: fixed crash when multiple layers and tiles were used with rotation
-
 * Shakthi:
 	Added CCNode#onExitTransitionDidStart method
 	Fixed fading background music issue
+    
+* Skyhawk (http://www.hkasoftware.com) 
+    Fix for addFrame method in CCAnimation
 
 * slycrel (http://geopherlite.blogspot.com/)
 	Added support for flipped tiles in TMX maps. Also added test case
 	Added support for in-memory TMX map creation. Also added a test case
+    TMX Map: fixed crash when multiple layers and tiles were used with rotation
+
+* Spencer Ho
+    fixed 3d projection settings for ipad3 
 
 * Stepan Generalov (iPsi) (http://www.itraceur.ru/)
 	FileUtils: Loads -hd resources even if the -sd resource is not present. patch
+
+* Steve Kanter
+    new file extension for ipad retina
 
 
 cocos2d for iPhone authors for v1.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,30 +1,47 @@
-version 1.1-beta2 xx - 2012
+version 1.1-rc0 .. -..-2012
+. [FIX] CCAnimation: bug in addFrames that resulted in incorrect delayPerUnit (issue #1341)
+. [FIX] CCSprite: CCSprite bug in setDisplayFrameWithAnimationName
+
+version 1.1-beta2b 14-Mar-2012
+. [FIX] CCUtils: missing method declaration
+
+version 1.1-beta2 12-Mar-2012
 . [NEW] v2.0 forward ported changes:
 			LabelBMFont: added setFntFile method
 			Animation: Added new animation format that supports delays per frame and notifications per frame
 			Actions: Added ActionTargeted action. Useful to target other nodes from a sequence.
 . [NEW] All: Code is compatible with ARC (issue #1199) 
+. [NEW] CCArray: new sorting methods, replaceObjectAtIndex, isEqualToArray
+. [NEW] ccFileUtiles: new iPad retina file extension (ipadhd)
 . [NEW] DrawPrimitives: Added new functions, ccDrawRect, ccDrawSolidRect, ccDrawSolidPoly
 . [NEW] DrawPrimitives: Added batch drawing of lines, ccDrawLines (issue #1081)
 . [NEW] Node: Added onExitTransitionDidStart (issue #792)
 . [NEW] ParticleSystem: supports animations in new animation format 
 . [NEW] TileMap: supports in-memory TMX map creation (issue #1239)
 . [NEW] TileMap: Flipped tiles can be changed during runtime (issue #1264)
+. [NEW] Touchdispatcher: new implementation, supporting changing dispatchers based on (ranges) of properties, custom sorting and more (full list in online release notes)
 . [NEW] Types: Added convenience function to create a ccColor4F from color components
 . [FIX] Actions: incorrect behavior of CCRepeat
+. [FIX] CCArray: equalilty is tested by isEqual instead of comparing pointer addresses
+. [FIX] CCArray: CCARRAY_FOREACH macro is now ARC compatible
+. [FIX] CCLabelBMFont: full unicode support
+. [FIX] CCTMXXMLParser: removed unused variables in release mode
 . [FIX] ColorLayer: incorrect size in init method
+. [FIX] Director: 3d projection setting for iPad retina
 . [FIX] Denshion: Background music fades ok (issue #1304)
 . [FIX] EAGLView: always destroy and recreate OpenGL buffers completely (issue #1254) 
 . [FIX] MenuItem: removed warning when deleting item
 . [FIX] Node: orderOfArrival is @synthezied correctly (issue #1273)
 . [FIX] Node & Sprite: Scale before Skew to prevent issues with negatives scales.
 . [FIX] ParticleSystem: prevent bursts of particles due to too high emitCounter (issue #1201)
+. [FIX] ParticleSystem: CCParticleExamples on armv6 uses quad particle system by default, so CCParticleBatchNode can be used
 . [FIX] ParticleBatchNode: removeChild error and 'freezing' particles (issue #1316)
 . [FIX] ParticleBatchNode: memoryleak (issue #1306)
 . [FIX] Sprite: fixed possible setColor and opacity
 . [FIX] Sprite: fixed adding premade sprite hierarchy to batchnode (issue #1217)
 . [FIX] TileMap: Fixed a problem with multiple layers and multiple tile sets that could cause TMX maps to not load if rotation is used (issue #1302)
 . [FIX] TouchDispatcher: correctly handles addition and removal of handlers when being inside a touch handler (issue #1084, #1139)
+. [FIX] TouchDispatcher: new implementation fixes multiple issues (issue #1173, #1267)
 . [FIX-MAC] LabelTTF: word wrap works on Mac (issue #1074)
 . [FIX-MAC] fix for failed to compile on 32-bit mac builds.
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,5 @@
-===== cocos2d for iPhone v1.0.1 Release Notes =====
+===== cocos2d for iPhone v1.1-beta2 Release Notes =====
 
 
 Please, see the online document:
-http://www.cocos2d-iphone.org/wiki/doku.php/release_notes:1_0_0
+http://www.cocos2d-iphone.org/wiki/doku.php/release_notes:1_1_0

--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -4700,6 +4700,10 @@
 		50FBB2D8117613F500150761 /* CCActionTween.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionTween.h; sourceTree = "<group>"; };
 		50FBB2D9117613F500150761 /* CCActionTween.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCActionTween.m; sourceTree = "<group>"; };
 		53FE3C7114C835DF006D067D /* Cyber Advance!.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; name = "Cyber Advance!.mp3"; path = "CocosDenshion/TestsAndDemos/FancyRatMeteringDemo/Resources/Cyber Advance!.mp3"; sourceTree = SOURCE_ROOT; };
+		657F114D150BA75D0047F93C /* AppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppController.h; sourceTree = "<group>"; };
+		657F114E150BA75D0047F93C /* AppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppController.m; sourceTree = "<group>"; };
+		657F114F150BA75D0047F93C /* PerformanceDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PerformanceDispatcher.h; sourceTree = "<group>"; };
+		657F1150150BA75D0047F93C /* PerformanceDispatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PerformanceDispatcher.m; sourceTree = "<group>"; };
 		6F305B5D0FB9D2790052E700 /* TransformUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransformUtils.h; sourceTree = "<group>"; };
 		6F305B5E0FB9D2790052E700 /* TransformUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TransformUtils.m; sourceTree = "<group>"; };
 		8E3FC8910F7B8BE900B3E5DE /* trance-loop.ogg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "trance-loop.ogg"; sourceTree = "<group>"; };
@@ -7103,6 +7107,7 @@
 		50B130FC0DFE0923003BAB56 /* tests */ = {
 			isa = PBXGroup;
 			children = (
+				657F114C150BA75D0047F93C /* PerformanceDispatcherTest */,
 				504828C70F45B15700A30CEF /* attachDemo */,
 				05CA7B0910ED679000F12774 /* blocks */,
 				500111EA103B878B0059EC2E /* Box2DTestBed-Cocos2dIntegration */,
@@ -7529,6 +7534,18 @@
 			);
 			name = "cocos2d-artwork";
 			path = "Resources/cocos2d-artwork";
+			sourceTree = "<group>";
+		};
+		657F114C150BA75D0047F93C /* PerformanceDispatcherTest */ = {
+			isa = PBXGroup;
+			children = (
+				657F114D150BA75D0047F93C /* AppController.h */,
+				657F114E150BA75D0047F93C /* AppController.m */,
+				657F114F150BA75D0047F93C /* PerformanceDispatcher.h */,
+				657F1150150BA75D0047F93C /* PerformanceDispatcher.m */,
+			);
+			name = PerformanceDispatcherTest;
+			path = tests/PerformanceTests/PerformanceDispatcherTest;
 			sourceTree = "<group>";
 		};
 		8EDF3E8D0F6BD8CD00F54643 /* sfx */ = {
@@ -9333,8 +9350,8 @@
 				495E73F6104B74E20012BB52 /* RenderTextureTest */,
 				502C66170DFEFCCA00E4107D /* RotateWorldTest */,
 				506C7FF70E041C9300B48100 /* SceneTest */,
-				508CA7AD1193270F003AC397 /* SchedulerTest */,
 				501C7C6D0F91EFFF0024A296 /* SpriteTest */,
+				508CA7AD1193270F003AC397 /* SchedulerTest */,
 				A0240EF6139E3AE50075D13F /* TestCocos2dExtension */,
 				505B62AB0F2E6A0F001B4104 /* Texture2dTest */,
 				503F5C96101FE930002A37E5 /* TileMapTest */,
@@ -14426,6 +14443,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					armv7,
+					"$(ARCHS_STANDARD_32_BIT)",
+				);
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -14450,6 +14472,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					armv7,
+					"$(ARCHS_STANDARD_32_BIT)",
+				);
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -14796,9 +14823,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					"$(ARCHS_STANDARD_32_BIT)",
+				);
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "build all tests";
 			};
 			name = Debug;
@@ -14807,8 +14839,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv6,
+					"$(ARCHS_STANDARD_32_BIT)",
+				);
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = "build all tests";
 				ZERO_LINK = NO;
 			};
@@ -15820,7 +15857,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = (
+					armv6,
+					"$(ARCHS_STANDARD_32_BIT)",
+				);
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COMPRESS_PNG_FILES = YES;
 				EXCLUDED_RECURSIVE_SEARCH_PATH_SUBDIRECTORIES = ".git *.nib *.lproj *.framework *.gch *.xcode* (*) CVS .svn";
@@ -15858,7 +15898,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = (
+					armv6,
+					"$(ARCHS_STANDARD_32_BIT)",
+				);
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COMPRESS_PNG_FILES = YES;
 				EXCLUDED_RECURSIVE_SEARCH_PATH_SUBDIRECTORIES = ".git *.nib *.lproj *.framework *.gch *.xcode* (*) CVS .svn";

--- a/cocos2d-ios.xcodeproj/xcshareddata/xcschemes/ParticleBatchTest.xcscheme
+++ b/cocos2d-ios.xcodeproj/xcshareddata/xcschemes/ParticleBatchTest.xcscheme
@@ -39,12 +39,13 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
       debugDocumentVersioning = "YES"
+      enablesOpenGLESFrameCapture = "YES"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>
          <BuildableReference

--- a/cocos2d-ios.xcodeproj/xcshareddata/xcschemes/SpriteTest.xcscheme
+++ b/cocos2d-ios.xcodeproj/xcshareddata/xcschemes/SpriteTest.xcscheme
@@ -22,8 +22,8 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
       <Testables>
@@ -39,12 +39,13 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
       debugDocumentVersioning = "YES"
+      enablesOpenGLESFrameCapture = "YES"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>
          <BuildableReference

--- a/cocos2d/CCAnimation.m
+++ b/cocos2d/CCAnimation.m
@@ -168,8 +168,9 @@
 
 -(void) addFrame:(CCSpriteFrame*)frame delay:(float) delay
 {
-	if ([frames_ count] == 0)
+	if ([frames_ count] == 0 && delayPerUnit_ == 0)
 	{
+        NSAssert(delay >= 0, @"delay can't be 0 or be negative");
 		delayPerUnit_ = delay; 	
 	}
 	

--- a/cocos2d/CCAtlasNode.m
+++ b/cocos2d/CCAtlasNode.m
@@ -62,8 +62,9 @@
 		
 		// double retain to avoid the autorelease pool
 		// also, using: self.textureAtlas supports re-initialization without leaking
-		self.textureAtlas = [[CCTextureAtlas alloc] initWithFile:tile capacity:c];
-		[textureAtlas_ release];
+        CCTextureAtlas *atlas = [[CCTextureAtlas alloc] initWithFile:tile capacity:c];
+		self.textureAtlas = atlas;
+		[atlas release];
 		
 		if( ! textureAtlas_ ) {
 			CCLOG(@"cocos2d: Could not initialize CCAtlasNode. Invalid Texture");

--- a/cocos2d/CCDrawingPrimitives.h
+++ b/cocos2d/CCDrawingPrimitives.h
@@ -67,13 +67,17 @@ void ccDrawPoints( const CGPoint *points, NSUInteger numberOfPoints );
 /** draws a line given the origin and destination point measured in points. */
 void ccDrawLine( CGPoint origin, CGPoint destination );
 
-/** draws multiple lines in one draw call */
+/** draws multiple lines in one draw call 
+    @since 1.1
+ */
 void ccDrawLines( CGPoint* points, NSUInteger numberOfPoints );	
 
 /** draws a rectangle given the origin and destination point measured in points. */
 void ccDrawRect( CGPoint origin, CGPoint destination );
 
-/** draws a solid rectangle given the origin and destination point measured in points. */
+/** draws a solid rectangle given the origin and destination point measured in points.
+    @since 1.1
+ */
 void ccDrawSolidRect( CGPoint origin, CGPoint destination );
 
 /** draws a poligon given a pointer to CGPoint coordiantes and the number of vertices measured in points.
@@ -83,10 +87,12 @@ void ccDrawPoly( const CGPoint *vertices, NSUInteger numOfVertices, BOOL closePo
 
 /** draws a solid poligon given a pointer to CGPoint coordiantes and the number of vertices measured in points.
  The polygon can be closed or open
+    @since 1.1
  */
 void ccDrawSolidPoly( const CGPoint *vertices, NSUInteger numOfVertices, BOOL closePolygon );
 
-/** draws a circle given the center, radius and number of segments measured in points */
+/** draws a circle given the center, radius and number of segments measured in points 
+ */
 void ccDrawCircle( CGPoint center, float radius, float angle, NSUInteger segments, BOOL drawLineToCenter);
 
 /** draws a quad bezier path measured in points.

--- a/cocos2d/CCDrawingPrimitives.m
+++ b/cocos2d/CCDrawingPrimitives.m
@@ -155,7 +155,7 @@ void ccDrawLines( CGPoint* points, NSUInteger numberOfPoints )
 	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 	glDisableClientState(GL_COLOR_ARRAY);
 	
-	glDrawArrays(GL_LINES, 0, numberOfPoints);
+	glDrawArrays(GL_LINES, 0, (GLsizei) numberOfPoints);
 	
 	// restore default state
 	glEnableClientState(GL_COLOR_ARRAY);
@@ -231,7 +231,7 @@ void ccDrawPoly( const CGPoint *vertices, NSUInteger numberOfPoints, BOOL closeP
 	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 	glEnable(GL_TEXTURE_2D);	
 }
-//const CGPoint *vertices, NSUInteger numOfVertices, BOOL closePolygon
+
 void ccDrawSolidPoly(const CGPoint *vertices, NSUInteger numOfVertices, BOOL closePolygon )
 {
 	ccVertex2F newPoint[numOfVertices];

--- a/cocos2d/CCLabelBMFont.h
+++ b/cocos2d/CCLabelBMFont.h
@@ -52,6 +52,8 @@ typedef struct _BMFontDef {
 	int yOffset;
 	//! The amount to move the current position after drawing the character (in pixels)
 	int xAdvance;
+    // Enable Hash Table
+    UT_hash_handle hh;
 } ccBMFontDef;
 
 /** @struct ccBMFontPadding
@@ -69,11 +71,6 @@ typedef struct _BMFontPadding {
 	int bottom;
 } ccBMFontPadding;
 
-enum {
-	// how many characters are supported
-	kCCBMFontMaxChars = 2048, //256,
-};
-
 /** CCBMFontConfiguration has parsed configuration of the the .fnt file
  @since v0.8
  */
@@ -82,7 +79,7 @@ enum {
     // XXX: Creating a public interface so that the bitmapFontArray[] is accesible
 @public
 	// The characters building up the font
-	ccBMFontDef	BMFontArray_[kCCBMFontMaxChars];
+	ccBMFontDef *BMFontHash_;
 	
 	// FNTConfig: Common Height
 	NSUInteger		commonHeight_;

--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -112,10 +112,20 @@
 										 fontSize:fontSize_];
 
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-	if( CC_CONTENT_SCALE_FACTOR() == 2 )
-		[tex setResolutionType:kCCResolutionRetinaDisplay];
-	else
-		[tex setResolutionType:kCCResolutionStandard];
+    if( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ) {
+        if( CC_CONTENT_SCALE_FACTOR() == 2 )
+            [tex setResolutionType:kCCResolutioniPadRetinaDisplay];
+        else
+            [tex setResolutionType:kCCResolutioniPad];
+    }
+    // iPhone ?
+    else
+    {
+        if( CC_CONTENT_SCALE_FACTOR() == 2 )
+            [tex setResolutionType:kCCResolutioniPhoneRetinaDisplay];
+        else
+            [tex setResolutionType:kCCResolutioniPhone];
+    }
 #endif
 
 	[self setTexture:tex];

--- a/cocos2d/CCParticleExamples.h
+++ b/cocos2d/CCParticleExamples.h
@@ -30,82 +30,68 @@
 #import "CCParticleSystemPoint.h"
 #import "CCParticleSystemQuad.h"
 
-// build each architecture with the optimal particle system
-
-// ARMv7, Mac or Simulator use "Quad" particle
-#if defined(__ARM_NEON__) || defined(__MAC_OS_X_VERSION_MAX_ALLOWED) || TARGET_IPHONE_SIMULATOR
-	#define ARCH_OPTIMAL_PARTICLE_SYSTEM CCParticleSystemQuad
-
-// ARMv6 use "Point" particle
-#elif __arm__
-	#define ARCH_OPTIMAL_PARTICLE_SYSTEM CCParticleSystemPoint
-#else
-	#error(unknown architecture)
-#endif
-
-
 //! A fire particle system
-@interface CCParticleFire: ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleFire: CCParticleSystemQuad
 {
 }
 @end
 
 //! A fireworks particle system
-@interface CCParticleFireworks : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleFireworks : CCParticleSystemQuad
 {
 }
 @end
 
 //! A sun particle system
-@interface CCParticleSun : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleSun : CCParticleSystemQuad
 {
 }
 @end
 
 //! A galaxy particle system
-@interface CCParticleGalaxy : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleGalaxy : CCParticleSystemQuad
 {
 }
 @end
 
 //! A flower particle system
-@interface CCParticleFlower : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleFlower : CCParticleSystemQuad
 {
 }
 @end
 
 //! A meteor particle system
-@interface CCParticleMeteor : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleMeteor : CCParticleSystemQuad
 {
 }
 @end
 
 //! An spiral particle system
-@interface CCParticleSpiral : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleSpiral : CCParticleSystemQuad
 {
 }
 @end
 
 //! An explosion particle system
-@interface CCParticleExplosion : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleExplosion : CCParticleSystemQuad
 {
 }
 @end
 
 //! An smoke particle system
-@interface CCParticleSmoke : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleSmoke : CCParticleSystemQuad
 {
 }
 @end
 
 //! An snow particle system
-@interface CCParticleSnow : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleSnow : CCParticleSystemQuad
 {
 }
 @end
 
 //! A rain particle system
-@interface CCParticleRain : ARCH_OPTIMAL_PARTICLE_SYSTEM
+@interface CCParticleRain : CCParticleSystemQuad
 {
 }
 @end

--- a/cocos2d/CCParticleSystem.m
+++ b/cocos2d/CCParticleSystem.m
@@ -555,7 +555,7 @@
 			[self addParticle];
 			emitCounter -= rate;
 		}
-		CCLOG(@"emitCounter %f",emitCounter);
+	
 		elapsed += dt;
 		if(duration != -1 && duration < elapsed)
 			[self stopSystem];

--- a/cocos2d/CCRenderTexture.h
+++ b/cocos2d/CCRenderTexture.h
@@ -49,6 +49,8 @@ enum
  the render texture to your scene and treat it like any other CocosNode.
  There are also functions for saving the render texture to disk in PNG or JPG format.
  
+ 
+ 
  @since v0.8.1
  */
 @interface CCRenderTexture : CCNode 
@@ -96,9 +98,13 @@ enum
 -(BOOL)saveBuffer:(NSString*)name;
 /** saves the texture into a file. The format can be JPG or PNG */
 -(BOOL)saveBuffer:(NSString*)name format:(int)format;
-/* get buffer as UIImage, can only save a render buffer which has a RGBA8888 pixel format */
+/** get buffer as UIImage, can only save a render buffer which has a RGBA8888 pixel format */
 -(NSData*)getUIImageAsDataFromBuffer:(int) format;
-/* get buffer as UIImage */
+/** get buffer as UIImage 
+ In rare cases getUIImageFromBuffer produces artifacts, a workaround for this is 
+ NSData *imageData = [renderer getUIImageAsDataFromBuffer:kCCImageFormatPNG];
+ UIImage *image = [UIImage imageWithData:imageData];
+ */
 -(UIImage *)getUIImageFromBuffer;
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -974,11 +974,11 @@ static SEL selSortMethod = NULL;
 	
 	NSAssert( a, @"CCSprite#setDisplayFrameWithAnimationName: Frame not found");
 	
-	CCSpriteFrame *frame = [[a frames] objectAtIndex:frameIndex];
+	CCAnimationFrame *frame = [[a frames] objectAtIndex:frameIndex];
 	
 	NSAssert( frame, @"CCSprite#setDisplayFrame. Invalid frame");
 	
-	[self setDisplayFrame:frame];
+	[self setDisplayFrame:[frame spriteFrame]];
 }
 
 

--- a/cocos2d/CCTMXXMLParser.m
+++ b/cocos2d/CCTMXXMLParser.m
@@ -119,7 +119,7 @@
 /* initalises parsing of an XML string, either a tmx (Map) string or tsx (Tileset) string */
 - (void) parseXMLString:(NSString *)xmlString;
 /* handles the work of parsing for parseXMLFile: and parseXMLString: */
-- (NSError*) parseXMLData:(NSData*)data;
+- (void) parseXMLData:(NSData*)data;
 @end
 
 @implementation CCTMXMapInfo
@@ -186,7 +186,7 @@
 	[super dealloc];
 }
 
-- (NSError*) parseXMLData:(NSData*)data
+- (void) parseXMLData:(NSData*)data
 {
 	NSXMLParser *parser = [[[NSXMLParser alloc] initWithData:data] autorelease];
 	
@@ -197,22 +197,21 @@
 	[parser setShouldResolveExternalEntities:NO];
 	[parser parse];
 	
-	return [parser parserError];
+     NSAssert1( ![parser parserError], @"Error parsing TMX data: %@.", [NSString stringWithCharacters:[data bytes] length:[data length]] );
 }
 
 - (void) parseXMLString:(NSString *)xmlString
 {
 	NSData* data = [xmlString dataUsingEncoding:NSUTF8StringEncoding];
-	NSError* err = [self parseXMLData:data];
-	NSAssert1( !err, @"Error parsing TMX data: %@.", [NSString stringWithCharacters:[data bytes] length:[data length]] );
+	[self parseXMLData:data];
+	
 }
 
 - (void) parseXMLFile:(NSString *)xmlFilename
 {
 	NSURL *url = [NSURL fileURLWithPath:[CCFileUtils fullPathFromRelativePath:xmlFilename] ];
 	NSData *data = [NSData dataWithContentsOfURL:url];
-	NSError* err = [self parseXMLData:data];
-	NSAssert3(!err, @"Error parsing TMX file: %@, %@ (%d).", xmlFilename, [err localizedDescription], [err code]);
+	[self parseXMLData:data];
 }
 
 // the XML parser calls here with all the elements

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -209,8 +209,14 @@ CGFloat	__ccContentScaleFactor = 1;
 			glViewport(0, 0, size.width, size.height);
 			glMatrixMode(GL_PROJECTION);
 			glLoadIdentity();
-//			gluPerspective(60, (GLfloat)size.width/size.height, zeye-size.height/2, zeye+size.height/2 );
-			gluPerspective(60, (GLfloat)size.width/size.height, 0.5f, 1500);
+			// accommodate iPad retina while keep backward compatibility
+            if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+                [[UIScreen mainScreen] scale] > 1.0 )
+            {
+                gluPerspective(60, (GLfloat)size.width/size.height, zeye-size.height/2, zeye+size.height/2 );
+            } else {
+                gluPerspective(60, (GLfloat)size.width/size.height, 0.5f, 1500);
+            }
 
 			glMatrixMode(GL_MODELVIEW);	
 			glLoadIdentity();

--- a/cocos2d/Platforms/iOS/CCTouchDispatcher.h
+++ b/cocos2d/Platforms/iOS/CCTouchDispatcher.h
@@ -114,11 +114,11 @@ typedef enum {
 	kCCSwallowsTouches,
 	//	special virtual fields - use it if you understand its purpose
 	kCCPriorityToDo,	// use to prepare change of priority, do the actual sorting by calling 'sortDelegates:' function
-						// useful for compound priority changes
+    // useful for compound priority changes
 	kCCRemoveToDo,		// use to mark delegates for removal, do actual removal by calling 'removeToDoDelegates:' function
-						// useful for compound removals
-						// kCC*ToDo fields are designed to work with 'setField' and 'setDelegatesField' functions
-						//
+    // useful for compound removals
+    // kCC*ToDo fields are designed to work with 'setField' and 'setDelegatesField' functions
+    //
 	kCCNotRemoved,		// do an action only for the delegates which are not marked for removal						
 	kCCNone,			// no field is searched for evaluation
 	kCCDebug,			// prints debug info to console 
@@ -155,12 +155,18 @@ typedef enum{
 	kCCLTOrGT, // two ranges 
 }ccOperators;
 
+typedef enum 
+{
+	kCCAddTargetedHandler,
+	kCCAddStandardHandler,
+}ccHandlersToDoType; 
+
 /** CCTouchDispatcher.
  Singleton that handles all the touch events.
  The dispatcher dispatches events to the registered TouchHandlers.
  There are 2 different type of touch handlers:
-   - Standard Touch Handlers
-   - Targeted Touch Handlers
+ - Standard Touch Handlers
+ - Targeted Touch Handlers
  
  The Standard Touch Handlers work like the CocoaTouch touch handler: a set of touches is passed to the delegate.
  On the other hand, the Targeted Touch Handlers only receive 1 touch at the time, and they can "swallow" touches (avoid the propagation of the event).
@@ -178,7 +184,7 @@ typedef enum{
 	CCArray	*targetedHandlers;
 	CCArray	*standardHandlers;
 	CCArray *handlersToDo;
-
+    
 	BOOL	dispatchEvents;						// default is YES;
 	BOOL	processStandardHandlersFirst;		// default is NO;
 	BOOL	locked;								// do not disturb, executing touch callbacks
@@ -203,7 +209,6 @@ typedef enum{
 
 /** Whether or not the events are going to be dispatched. Default: YES */
 @property (nonatomic,readwrite,assign) BOOL dispatchEvents;
-
 /** Adds a standard touch delegate to the dispatcher's list.
  See StandardTouchDelegate description.
  IMPORTANT: The delegate will be retained.
@@ -222,9 +227,9 @@ typedef enum{
 -(void) removeAllDelegates;
 /** Changes the priority of a previously added delegate. The lower the number,
  the higher the priority
-  @since v1.0 
-  depreciated in v1.1 use:  
-  - (int) setPriority:(int)newValue delegate:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type; 
+ @since v1.0 
+ depreciated in v1.1 use:  
+ - (int) setPriority:(int)newValue delegate:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type; 
  */
 -(void) setPriority:(int) priority forDelegate:(id) delegate;
 
@@ -238,39 +243,39 @@ typedef enum{
 
 /** Adds a standard touch delegate to the dispatcher's list.
  in addition to priority, tag and disabled flag can be specified.
-  'doNotSort' prevents sorting delegates after the addition of a new one. 
+ 'doNotSort' prevents sorting delegates after the addition of a new one. 
  Events will be distributed to the delegates in the same order as delegates were added. 
  See StandardTouchDelegate description.
  IMPORTANT: The delegate will be retained.
-   @since v1.1.0
+ @since v1.1.0
  */
 - (void) addStandardDelegate:(id<CCStandardTouchDelegate>) delegate priority:(int)priority 
-			tag:(int)aTag disable:(int)yesOrNo doNotSort:(int)YN;
+                         tag:(int)aTag disable:(int)yesOrNo doNotSort:(int)YN;
 /** Adds a targeted touch delegate to the dispatcher's list.
  in addition to swallowsTouches or priority, tag and disable flag can be specified.
  'doNoSort' prevents sorting delegates after adding a new one.
  Events will be distributed to the delegates in the same order as delegates were added.
  See TargetedTouchDelegate description.
  IMPORTANT: The delegate will be retained.
-  @since v1.1.0
+ @since v1.1.0
  */
 - (void) addTargetedDelegate:(id<CCTargetedTouchDelegate>) delegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches
-			tag:(int)aTag disable:(int)yesOrNo doNotSort:(int)YN;
+                         tag:(int)aTag disable:(int)yesOrNo doNotSort:(int)YN;
 
 //---------------------------------------------------------------------
 // safe touch call-back getters and setters for internal control fields
 //---------------------------------------------------------------------
- 
+
 /** As per default targeted handlers are executed first 
  If needed this order can be reversed:
-   @since v1.1.0
+ @since v1.1.0
  */
 -(void) setProcessStandardHandlersFirst:(BOOL)yesOrNo;
 
 /** gets - current/requested - order of processing 
-  @return whether or not standard handlers are processed first in the event loop
-  @since v1.1.0
-  */
+ @return whether or not standard handlers are processed first in the event loop
+ @since v1.1.0
+ */
 -(BOOL) processStandardHandlersFirst;
 
 /** get locked state of the dispatcher. It returns YES when called from touch callback function. 
@@ -279,13 +284,13 @@ typedef enum{
 -(BOOL) locked;
 
 /** set sorting algorithm 
-  @since v1.1.0
-*/
+ @since v1.1.0
+ */
 - (void) setSortingAlgorithm:(ccSortingAlgorithm)alg;
 
 /** get - current/requested - sortingAlgorithm
-
-  @since v1.1.0
+ 
+ @since v1.1.0
  */
 - (ccSortingAlgorithm) sortingAlgorithm;
 
@@ -295,7 +300,7 @@ typedef enum{
  */ 
 - (void) setReversePriority:(BOOL)yesNo;
 /** get - current/requested 'reversePriority'
-  @since v1.1.0
+ @since v1.1.0
  */
 - (BOOL) reversePriority;
 
@@ -303,29 +308,14 @@ typedef enum{
  'setUsersComparator' sets new comparator for the sorting algorithms.
  This operation will NOT force resorting. To do sorting use: sortDelegates:(ccDispatcherDelegateType)type;
  'reversePriority' parameter has NO bearing when user supplies his own comparator
-   @since v1.1.0
-  */ 
+ @since v1.1.0
+ */ 
 - (void) setUsersComparator:(int(*)(const void *, const void *))comparator;
 
 /** get - current/requested - usersComparator 
-  @since v1.1.0
+ @since v1.1.0
  */
 - (int(*)(const void *, const void *)) usersComparator;
-
-/** get - zOrderComparator 
-	Built-in zOrderComparator comparator sorts delegates base on the delegate zOrder.
-	If z1>z2>z3 than order is z1,z2,z3,...
-  	'reversePriority' parameter is taken under account and it can reverse above order 
- 
-	If you want your priorities to be z order dependant use 'setUsersComparator' as follows:
-	[[CCTouchDispatcher sharedDispatcher] setUsersComparator:[CCTouchDispatcher sharedDispatcher] zOrderComparator]];
-
-	Notice: If you change the z order of your delegates use
-	sortAllDelegates:(ccDispatcherDelegateType)type; to update the priority order.
-
-  @since v1.1.0
- */
-- (int(*)(const void *, const void *)) zOrderComparator;
 
 //--------------------------------------------
 //		debug
@@ -336,7 +326,7 @@ typedef enum{
  have been processed. In this case the return value is equal to -1.
  If requested outside a touch callback it returns the number of the handlers' objects of the given type.
  It is equal to the count of the printed handlers.
-   @since v1.1.0
+ @since v1.1.0
  */
 - (int) printDebugLog:(int)format afterEvents:(BOOL)after type:(ccDispatcherDelegateType)type;
 
@@ -352,10 +342,10 @@ typedef enum{
  This function is also useful when priority is changed without sorting by the following functions used with kCCPriorityToDo field:
  setField:kCCPriorityToDo ... or/and setDelegatesField:kCCPriorityToDo ...
  Regardless, delegates will be sorted at the end of the callback event processing loop if required. 
-
-   @since v1.1.0
+ 
+ @since v1.1.0
  */
- - (void) sortDelegates:(ccDispatcherDelegateType)type;
+- (void) sortDelegates:(ccDispatcherDelegateType)type;
 //--------------------------------------------
 
 //---------------------------------
@@ -364,7 +354,7 @@ typedef enum{
 
 /** returns number of delegates of the given type
  User's callback safe: delegates in the process of being removed are not counted. 
-   @since v1.1.0
+ @since v1.1.0
  */						
 - (int) countDelegatesUsage:(ccDispatcherDelegateType)type; 
 
@@ -373,7 +363,7 @@ typedef enum{
  User's callback safe: 
  It returns 0 if delegate does not exist or is marked for removal or >0 if delegate is added. 
  If delegate is marked for removal adding the same delegate is safe.  
-   @since v1.1.0
+ @since v1.1.0
  */
 - (int) countDelegateUsage:(id) delegate type:(ccDispatcherDelegateType)type;	
 
@@ -384,20 +374,20 @@ typedef enum{
 
 /** returns number of delegates with the specified priority
  User's callback safe: delegates in the process of being removed are not counted. 
-   @since v1.1.0
+ @since v1.1.0
  */
 - (int) countPriorityUsage:(int)priorityValue type:(ccDispatcherDelegateType)type;
 
 /** returns number of delegates with the specified disable value ((Use: YES or NO)
  User's callback safe: delegates in the process of being removed are not counted. 
-   @since v1.1.0
+ @since v1.1.0
  */
 - (int) countDisableUsage:(int)disableValue type:(ccDispatcherDelegateType)type;
 
 /** returns number of delegates with the specified value for given field 
  User's callback safe: delegates in the process of being removed are not counted. 
  Notice: It is generic functions covering all sugar 'countThisFieldUsage()' functions
-   @since v1.1.0
+ @since v1.1.0
  */
 - (int) countFieldUsage:(ccHandlerFieldName)field fieldValue:(int)value type:(ccDispatcherDelegateType)type;
 
@@ -406,23 +396,23 @@ typedef enum{
 // ---------------------------------
 
 /** returns priority of the delegate or if the delegate does not exist, returns NSNotFound 
-  @since v1.1.0
+ @since v1.1.0
  */
 - (int) retrievePriorityField:(id) delegate type:(ccDispatcherDelegateType)type;
 
 /** returns tag of the delegate or if the delegate does not exist, returns NSNotFound 
-  @since v1.1.0
+ @since v1.1.0
  */
 - (int) retrieveTagField:(id) delegate type:(ccDispatcherDelegateType)type;
 
 /** returns value of the disable field or if the delegate does not exist, returns NSNotFound 
-  @since v1.1.0
+ @since v1.1.0
  */
 -(int) retrieveDisableField:(id) delegate type:(ccDispatcherDelegateType)type;
 
 /** returns value of the field or if the delegate does not exist, returns NSNotFound 
-	Notice: It is generic functions covering all sugar 'retrieve*Field(.)' functions
-   @since v1.1.0
+ Notice: It is generic functions covering all sugar 'retrieve*Field(.)' functions
+ @since v1.1.0
  */
 - (int) retrieveField:(ccHandlerFieldName)field delegate:(id)delegate type:(ccDispatcherDelegateType)type;
 
@@ -431,26 +421,26 @@ typedef enum{
 //--------------------------------
 
 /** disables/enables already added touch delegate 
-  @since v1.1.0
+ @since v1.1.0
  */			
 - (int) disableDelegate:(id) delegate disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
 
 /**  disables/enables all delegates of the given type 
-	returns number of disabled delegates
-   @since v1.1.0
+ returns number of disabled delegates
+ @since v1.1.0
  */
 - (int) disableAllDelegates:(int)yesOrNo type:(ccDispatcherDelegateType)type;
 /** disables/enables already added touch delegates of the given type
-	with specified tag. (That allows for fast and selective disabling/enabling of delegates. 
-	Otherwise, delegates would have to be removed and added again to the list)
-	returns number of disabled delegates
-   @since v1.1.0
+ with specified tag. (That allows for fast and selective disabling/enabling of delegates. 
+ Otherwise, delegates would have to be removed and added again to the list)
+ returns number of disabled delegates
+ @since v1.1.0
  */
- - (int) disableDelegatesWithTag:(int)aTag disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
+- (int) disableDelegatesWithTag:(int)aTag disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
 /** disables/enables already added targeted touch delegates of the given type
-	with specified priority (including those marked for removal).
-	returns number of disabled delegates 
-   @since v1.1.0
+ with specified priority (including those marked for removal).
+ returns number of disabled delegates 
+ @since v1.1.0
  */
 - (int) disableDelegatesWithPriority:(int)aPriority disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
 
@@ -459,16 +449,16 @@ typedef enum{
  Use it inside the touch callback function if you do not want removed delegates to be active
  during event loop.
  returns number of disabled delegates (including those marked for removal)
-   @since v1.1.0
+ @since v1.1.0
  */ 
 - (int) disableRemovedDelegates:(int)yesOrNo type:(ccDispatcherDelegateType)type;
 
 /** generic function to disable/enable delegates when a specific field contains a certain value.  
-  The content of the field is evaluated against arg1 and arg2 using (ccOperators)op.
-  @since v1.1.0
+ The content of the field is evaluated against arg1 and arg2 using (ccOperators)op.
+ @since v1.1.0
  */
 - (int) disableDelegatesWithField:(ccHandlerFieldName)fieldName arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op
-		disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
+disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
 
 //---------------------------------
 // removal of the delegate/s
@@ -476,83 +466,83 @@ typedef enum{
 // Note: removal cannot be undone. If you need an already removed delegate then add it again.
 
 /** Removes the delegate of the given type, releasing the delegate
-	If delay: is set to YES the removal is delayed until removeToDoDelegates:type is called or current/first
-	event loop ends.
-  @since v1.1.0
+ If delay: is set to YES the removal is delayed until removeToDoDelegates:type is called or current/first
+ event loop ends.
+ @since v1.1.0
  */
 - (int) removeDelegate:(id) delegate delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
 
 /** removes all delegates of the given type 
-	returns number of delegates removed
-  @since v1.1.0
+ returns number of delegates removed
+ @since v1.1.0
  */ 
 - (int) removeAllDelegates:(ccDispatcherDelegateType)type;
 
 /** removes all delegates of the given type with specified tag 
-	returns number of delegates removed 
- 	If delay: is set to YES the removal is delayed until removeToDoDelegates:type is called or current/first
-	event loop ends.
-  @since v1.1.0
+ returns number of delegates removed 
+ If delay: is set to YES the removal is delayed until removeToDoDelegates:type is called or current/first
+ event loop ends.
+ @since v1.1.0
  */ 
 - (int) removeDelegatesWithTag:(int)tag delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
 
 /** removes all delegates of the given type with specified priority
-	returns number of delegates removed
-	If delay: is set to YES the removal is delayed until removeToDoDelegates:type is called or current/first
-	event loop ends.
-  @since v1.1.0
+ returns number of delegates removed
+ If delay: is set to YES the removal is delayed until removeToDoDelegates:type is called or current/first
+ event loop ends.
+ @since v1.1.0
  */ 
 - (int) removeDelegatesWithPriority:(int)priority delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
 
 /** removes all delegates of the given type marked for removal by the following functions used with kCCRemoveToDo field:
-	setField:kCCRemoveToDo ... or/and setDelegatesField:kCCRemoveToDo ... or remove* functions with delay:YES
-	If 'removeToDoDelegates' is not used all marked delegates will be removed at the end of the first event processing loop. 
-	returns number of delegates removed.
-	If function is called in the touch callback it returns -1. (Delegates will be removed at the end of the event loop)
+ setField:kCCRemoveToDo ... or/and setDelegatesField:kCCRemoveToDo ... or remove* functions with delay:YES
+ If 'removeToDoDelegates' is not used all marked delegates will be removed at the end of the first event processing loop. 
+ returns number of delegates removed.
+ If function is called in the touch callback it returns -1. (Delegates will be removed at the end of the event loop)
  @since v1.1.0
  */ 
 - (int) removeToDoDelegates:(ccDispatcherDelegateType)type; 
 
 /** power function: covers all 'removeDelegates*' functions. Removes delegates of the given type 
-	for which a given field contains desired value.
-	The value of the field is evaluated against arg1 and arg2 using (ccOperators)op.
-   @since v1.1.0
+ for which a given field contains desired value.
+ The value of the field is evaluated against arg1 and arg2 using (ccOperators)op.
+ @since v1.1.0
  */
 - (int) removeDelegatesWithField:(ccHandlerFieldName)fieldName 
-		arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
+                            arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
 
 //-------------------------------------------------------------------------
 // setting the value of a specific field to a new value for a given delegate
 //-------------------------------------------------------------------------
 
 /** Changes the priority of the previously added delegate.
-	If the new value is different from the old one, it will commence sorting of the delegates.
-	returns the number of delegates which changed priority. Removed delegates are not counted.
-  	If delay: is set to YES, sorting is delayed until 'sortDelegates:type' is called or the current/first
-	event loop ends.
-   @since v1.1.0
+ If the new value is different from the old one, it will commence sorting of the delegates.
+ returns the number of delegates which changed priority. Removed delegates are not counted.
+ If delay: is set to YES, sorting is delayed until 'sortDelegates:type' is called or the current/first
+ event loop ends.
+ @since v1.1.0
  */
 - (int) setPriority:(int)newValue delegate:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type;
- 
- /** setRemove == removeDelegate
- 	If delay: is set to YES then the removal is delayed until removeToDoDelegates:type is called or current/first
-	event loop ends.
-  @since v1.1.0
- */
-  - (int) setRemove:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type;						
 
- /** set a new tag for delegate
-  @since v1.1.0
+/** setRemove == removeDelegate
+ If delay: is set to YES then the removal is delayed until removeToDoDelegates:type is called or current/first
+ event loop ends.
+ @since v1.1.0
  */
-  - (int) setTag:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type; 
+- (int) setRemove:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type;						
+
+/** set a new tag for delegate
+ @since v1.1.0
+ */
+- (int) setTag:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type; 
 /** setDisable == disableDelegate  - disable/enable delegate
-  @since v1.1.0
+ @since v1.1.0
  */
 - (int) setDisable:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type;
- 
- /** generic power function: sets value of the specific field to a new value.
-  @return number of affected delegates. It returns 0 if delegate is not found. It returns less than 0 for an error.  
-  @since v1.1.0
+
+/** generic power function: sets value of the specific field to a new value.
+ @return number of affected delegates. It returns 0 if delegate is not found. It returns less than 0 for an error.  
+ @since v1.1.0
  */
 - (int) setField:(ccHandlerFieldName)field newValue:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type;
 
@@ -560,66 +550,25 @@ typedef enum{
 // setting a new value for a specific field in delegate(s) which is conditional on the value of a certain field in the delegate
 //------------------------------------------------------------------------------------------------
 /** sets new priority for all delegates with the given tag
-	If delay: is set to YES sorting is delayed until sortDelegates:type; is called or the current/first
-	event loop ends.
-  @since v1.1.0
+ If delay: is set to YES sorting is delayed until sortDelegates:type; is called or the current/first
+ event loop ends.
+ @since v1.1.0
  */
 - (int)	setPriorityForTag:(int)tag newPriority:(int)value delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
 /** sets new tag for all delegates with the given priority 
-  @since v1.1.0
-*/
+ @since v1.1.0
+ */
 - (int)	setTagForPriority:(int)priority newTag:(int)value type:(ccDispatcherDelegateType)type;
-			
+
 /** 'Only For Eagles' - generic power function - allows changes for delegates with the specific field value
-	The content of the field is evaluated against arg1 and arg2 using (ccOperators)op.
-	It returns number of affected delegates.
-   @since v1.1.0
+ The content of the field is evaluated against arg1 and arg2 using (ccOperators)op.
+ It returns number of affected delegates.
+ @since v1.1.0
  */
 - (int) setDelegatesField:(ccHandlerFieldName)field newValue:(int)newValue
-		ifField:(ccHandlerFieldName)fieldToSearch arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op
-		   type:(ccDispatcherDelegateType)type;
+                  ifField:(ccHandlerFieldName)fieldToSearch arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op
+type:(ccDispatcherDelegateType)type;
 //-----------------------------------------------------------------------------------------------
-@end
-
-@class CCTouchHandler;
-
-typedef enum 
-{
-	kCCAddTargetedHandler,
-	kCCAddStandardHandler,
-}ccHandlersToDoType; 
-
-/**   @since v1.1.0 */
-@interface CCHandlersToDo : NSObject // treat as private 
-{
-@private
-  ccHandlersToDoType type_;
-  CCTouchHandler *handler_;
-  int arg_; 
-}
-
-@property(nonatomic,readwrite,assign) ccHandlersToDoType type;
-@property(nonatomic,readwrite,retain) CCTouchHandler *handler;
-@property(nonatomic,readwrite,assign) int arg;
-
-@end
-
-/**   @since v1.1.0 */
-@interface  CCArray (Additions)
-
-- (void) replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject;
-- (BOOL) isEqualToArray:(CCArray*)otherArray;
-
-- (void) qsortUsingCFuncComparator:(int(*)(const void *, const void *))comparator;	// c qsort is used for sorting
-- (void) insertionSortUsingCFuncComparator:(int(*)(const void *, const void *))comparator;  // insertion sort 
-- (void) mergesortLUsingCFuncComparator:(int(*)(const void *, const void *))comparator;	// mergesort
-
-- (void) insertionSort:(SEL)selector; // It sorts source array in ascending order
-- (void) sortUsingFunction:(NSInteger (*)(id, id, void *))compare context:(void *)context;
-- (void) forAllObjectsPerformSelectorWithDelegate:(id)delegate selector:(SEL)aSelector; //  for all array objects [delegate aSelector:arrObject]; 
-
-int mergesortL(void *base, size_t nel, size_t width, int (*compar)(const void *, const void *));
-void shuffle(NSMutableArray *array);
 @end
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED

--- a/cocos2d/Platforms/iOS/CCTouchDispatcher.h
+++ b/cocos2d/Platforms/iOS/CCTouchDispatcher.h
@@ -196,12 +196,6 @@ typedef enum
 	
 	// 4, 1 for each type of event
 	struct ccTouchHandlerHelperData handlerHelperData[kCCTouchMax];
-@private
-	unsigned int targetedHandlersCount;
-	unsigned int standardHandlersCount;	
-	BOOL needsMutableSet;	
-	id mutableTouches;	
-	struct ccTouchHandlerHelperData helper;
 }
 
 /** singleton of the CCTouchDispatcher */

--- a/cocos2d/Platforms/iOS/CCTouchDispatcher.h
+++ b/cocos2d/Platforms/iOS/CCTouchDispatcher.h
@@ -2,6 +2,7 @@
  * cocos2d for iPhone: http://www.cocos2d-iphone.org
  *
  * Copyright (c) 2009 Valentin Milea
+ * Copyright (c) 2011 Samuel J. Grabski
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,12 +26,17 @@
 
 // Only compile this code on iOS. These files should NOT be included on your Mac project.
 // But in case they are included, it won't be compiled.
+
 #import <Availability.h>
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 
 #import "CCTouchDelegateProtocol.h"
 #import "EAGLView.h"
+#import "CCArray.h"			// CCArray
+#import "../../ccMacros.h"	// CCLOG
 
+
+#define CC_UNUSED_ARGUMENT			0
 
 typedef enum
 {
@@ -40,7 +46,6 @@ typedef enum
 	kCCTouchSelectorCancelledBit = 1 << 3,
 	kCCTouchSelectorAllBits = ( kCCTouchSelectorBeganBit | kCCTouchSelectorMovedBit | kCCTouchSelectorEndedBit | kCCTouchSelectorCancelledBit),
 } ccTouchSelectorFlag;
-
 
 enum {
 	kCCTouchBegan,
@@ -57,6 +62,99 @@ struct ccTouchHandlerHelperData {
 	ccTouchSelectorFlag  type;
 };
 
+/** typedef enum ccSortingAlgorithm @since v1.1.0 */
+typedef enum{
+	kCCAlgInsertionSort = 0,	// Insertion Sort is the default algorithm used
+	kCCAlgQSort,				// C qsort
+	kCCAlgMergeLSort,			// mergeLSort
+	kCCDoNotSort				// do not sort
+}ccSortingAlgorithm;
+
+/** typedef struct ccActionToDo @since v1.1.0 */
+typedef struct{
+	int	targetedRemoval;
+	int	standardRemoval;
+	//
+	BOOL processStandardHandlersFirstFlag; 
+	BOOL processStandardHandlersFirstArg;	// order of processing
+	//
+	BOOL sortingAlgorithmFlag;
+	ccSortingAlgorithm sortingAlgorithmArg;	// sorting algorithm type
+	//
+	BOOL reversePriorityFlag;
+	BOOL reversePriorityArg;				// reverse priority
+	//
+	BOOL usersComparatorFlag;
+	int(*usersComparatorArg)(const void *, const void *); // new user comparator function 
+	//	
+	int	targetedPriority;
+	int	standardPriority;
+	//
+	BOOL targetedDebugLogFlag;
+	int targetedDebugLogArg;
+	//
+	BOOL standardDebugLogFlag;
+	int standardDebugLogArg;
+}ccActionToDo; // All critical operations should be only done only when event processing is finished
+
+/** typedef enum ccDispatcherDelegateType @since v1.1.0 */
+typedef enum {
+	kCCTargeted,
+	kCCStandard
+}ccDispatcherDelegateType;
+
+/** typedef enum ccHandlerFieldName @since v1.1.0 */
+typedef enum {
+	kCCDelegate = 0,	// use with care
+	// real fields - their values can be accessed using 'retrieveField' function 
+	kCCPriority,		// use to change priorities 
+	kCCTag,				// use to change tag(s)
+	kCCDisable,			// use to disable delegate(s)
+	kCCRemove,			// use to remove delegate(s)
+	kCCSwallowsTouches,
+	//	special virtual fields - use it if you understand its purpose
+	kCCPriorityToDo,	// use to prepare change of priority, do the actual sorting by calling 'sortDelegates:' function
+						// useful for compound priority changes
+	kCCRemoveToDo,		// use to mark delegates for removal, do actual removal by calling 'removeToDoDelegates:' function
+						// useful for compound removals
+						// kCC*ToDo fields are designed to work with 'setField' and 'setDelegatesField' functions
+						//
+	kCCNotRemoved,		// do an action only for the delegates which are not marked for removal						
+	kCCNone,			// no field is searched for evaluation
+	kCCDebug,			// prints debug info to console 
+}ccHandlerFieldName;
+
+/** typedef enum ccOperators @since v1.1.0 */
+typedef enum{
+	kCCFALSE = 0, // always false
+	kCCTRUE, // always true
+	// One argument operators use with arg1; arg2 not used
+	kCCNEQ,//(v != arg1)
+	kCCEQ, //(v == arg1)
+	kCCGE, //(v >= arg1)
+	kCCGT, //(v >  arg1)
+	kCCLE, //(v <= arg1)
+	kCCLT, //(v <  arg1)
+	// And
+	kCCGEAndLE, // very useful (one closed range) (v >= arg1) && (v <= arg2); (arg1 <= arg2)
+	kCCGEAndLT, // one range (arg1 < arg2)
+	kCCGTAndLE, // one range (arg1 < arg2)
+	kCCGTAndLT, // very useful (one open range) (v > arg1) && (v < arg2); (arg1+1 < arg2)
+	kCCLEAndGE, // one inverted endpoints range (v <= arg1) && (v>= arg2); (arg1 >= arg2)
+	kCCLEAndGT, // one inverted endpoints range (arg1 > arg2)
+	kCCLTAndGE, // one inverted endpoints range (arg1 > arg2)
+	kCCLTAndGT, // one inverted endpoints range (arg1 > arg2+1)
+	// Or	
+	kCCGEOrLE, // inverted endpoints values (arg1 > arg2) 
+	kCCGEOrLT, // inverted endpoints values (arg1 > arg2) 
+	kCCGTOrLE, // inverted endpoints values (arg1 > arg2) 
+	kCCGTOrLT, // inverted endpoints values (arg1 > arg2) 
+	kCCLEOrGE, // whole domain if arg1==arg2 (== kTRUE);  two ranges (v <= arg1) && (v>= arg2); (arg1 < arg2) 
+	kCCLEOrGT, // two ranges
+	kCCLTOrGE, // two ranges
+	kCCLTOrGT, // two ranges 
+}ccOperators;
+
 /** CCTouchDispatcher.
  Singleton that handles all the touch events.
  The dispatcher dispatches events to the registered TouchHandlers.
@@ -70,32 +168,41 @@ struct ccTouchHandlerHelperData {
  Firstly, the dispatcher sends the received touches to the targeted touches.
  These touches can be swallowed by the Targeted Touch Handlers. If there are still remaining touches, then the remaining touches will be sent
  to the Standard Touch Handlers.
-
  @since v0.8.0
+ 
+ The above processing order can be reversed by setting 'processStandardHandlersFirst' to YES.  
+ @since v1.1.0
  */
 @interface CCTouchDispatcher : NSObject <EAGLTouchDelegate>
 {
-	NSMutableArray	*targetedHandlers;
-	NSMutableArray	*standardHandlers;
+	CCArray	*targetedHandlers;
+	CCArray	*standardHandlers;
+	CCArray *handlersToDo;
 
-	BOOL			locked;
-	BOOL			toAdd;
-	BOOL			toRemove;
-	NSMutableArray	*handlersToAdd;
-	NSMutableArray	*handlersToRemove;
-	BOOL			toQuit;
-
-	BOOL	dispatchEvents;
+	BOOL	dispatchEvents;						// default is YES;
+	BOOL	processStandardHandlersFirst;		// default is NO;
+	BOOL	locked;								// do not disturb, executing touch callbacks
+	
+	ccActionToDo actionToDo;					// outstanding processing to do 
+	
+	ccSortingAlgorithm sortingAlgorithm;		// default kAlgInsertionSort
+	int(* usersComparator)(const void *, const void *); // user's comparator for sorting default NULL
 	
 	// 4, 1 for each type of event
 	struct ccTouchHandlerHelperData handlerHelperData[kCCTouchMax];
+@private
+	unsigned int targetedHandlersCount;
+	unsigned int standardHandlersCount;	
+	BOOL needsMutableSet;	
+	id mutableTouches;	
+	struct ccTouchHandlerHelperData helper;
 }
 
 /** singleton of the CCTouchDispatcher */
 + (CCTouchDispatcher*)sharedDispatcher;
 
 /** Whether or not the events are going to be dispatched. Default: YES */
-@property (nonatomic,readwrite, assign) BOOL dispatchEvents;
+@property (nonatomic,readwrite,assign) BOOL dispatchEvents;
 
 /** Adds a standard touch delegate to the dispatcher's list.
  See StandardTouchDelegate description.
@@ -114,10 +221,405 @@ struct ccTouchHandlerHelperData {
 /** Removes all touch delegates, releasing all the delegates */
 -(void) removeAllDelegates;
 /** Changes the priority of a previously added delegate. The lower the number,
- the higher the priority */
+ the higher the priority
+  @since v1.0 
+  depreciated in v1.1 use:  
+  - (int) setPriority:(int)newValue delegate:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type; 
+ */
 -(void) setPriority:(int) priority forDelegate:(id) delegate;
 
-NSComparisonResult sortByPriority(id first, id second, void *context);
+// -------------------------------------------------------------------
+//  @since v1.1.0:
+//--------------------------------------------------------------------
+
+//----------------------------------
+// adding delegates with tags
+//----------------------------------
+
+/** Adds a standard touch delegate to the dispatcher's list.
+ in addition to priority, tag and disabled flag can be specified.
+  'doNotSort' prevents sorting delegates after the addition of a new one. 
+ Events will be distributed to the delegates in the same order as delegates were added. 
+ See StandardTouchDelegate description.
+ IMPORTANT: The delegate will be retained.
+   @since v1.1.0
+ */
+- (void) addStandardDelegate:(id<CCStandardTouchDelegate>) delegate priority:(int)priority 
+			tag:(int)aTag disable:(int)yesOrNo doNotSort:(int)YN;
+/** Adds a targeted touch delegate to the dispatcher's list.
+ in addition to swallowsTouches or priority, tag and disable flag can be specified.
+ 'doNoSort' prevents sorting delegates after adding a new one.
+ Events will be distributed to the delegates in the same order as delegates were added.
+ See TargetedTouchDelegate description.
+ IMPORTANT: The delegate will be retained.
+  @since v1.1.0
+ */
+- (void) addTargetedDelegate:(id<CCTargetedTouchDelegate>) delegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches
+			tag:(int)aTag disable:(int)yesOrNo doNotSort:(int)YN;
+
+//---------------------------------------------------------------------
+// safe touch call-back getters and setters for internal control fields
+//---------------------------------------------------------------------
+ 
+/** As per default targeted handlers are executed first 
+ If needed this order can be reversed:
+   @since v1.1.0
+ */
+-(void) setProcessStandardHandlersFirst:(BOOL)yesOrNo;
+
+/** gets - current/requested - order of processing 
+  @return whether or not standard handlers are processed first in the event loop
+  @since v1.1.0
+  */
+-(BOOL) processStandardHandlersFirst;
+
+/** get locked state of the dispatcher. It returns YES when called from touch callback function. 
+ @since v1.1.0
+ */
+-(BOOL) locked;
+
+/** set sorting algorithm 
+  @since v1.1.0
+*/
+- (void) setSortingAlgorithm:(ccSortingAlgorithm)alg;
+
+/** get - current/requested - sortingAlgorithm
+
+  @since v1.1.0
+ */
+- (ccSortingAlgorithm) sortingAlgorithm;
+
+/** set reverse/normal order of priorities 
+ This operation will NOT force resorting
+ Call sorting yourself via: sortDelegates:(ccDispatcherDelegateType)type; 
+ */ 
+- (void) setReversePriority:(BOOL)yesNo;
+/** get - current/requested 'reversePriority'
+  @since v1.1.0
+ */
+- (BOOL) reversePriority;
+
+/** User can sets his own order of handling touches by supplying comparator functions.
+ 'setUsersComparator' sets new comparator for the sorting algorithms.
+ This operation will NOT force resorting. To do sorting use: sortDelegates:(ccDispatcherDelegateType)type;
+ 'reversePriority' parameter has NO bearing when user supplies his own comparator
+   @since v1.1.0
+  */ 
+- (void) setUsersComparator:(int(*)(const void *, const void *))comparator;
+
+/** get - current/requested - usersComparator 
+  @since v1.1.0
+ */
+- (int(*)(const void *, const void *)) usersComparator;
+
+/** get - zOrderComparator 
+	Built-in zOrderComparator comparator sorts delegates base on the delegate zOrder.
+	If z1>z2>z3 than order is z1,z2,z3,...
+  	'reversePriority' parameter is taken under account and it can reverse above order 
+ 
+	If you want your priorities to be z order dependant use 'setUsersComparator' as follows:
+	[[CCTouchDispatcher sharedDispatcher] setUsersComparator:[CCTouchDispatcher sharedDispatcher] zOrderComparator]];
+
+	Notice: If you change the z order of your delegates use
+	sortAllDelegates:(ccDispatcherDelegateType)type; to update the priority order.
+
+  @since v1.1.0
+ */
+- (int(*)(const void *, const void *)) zOrderComparator;
+
+//--------------------------------------------
+//		debug
+//--------------------------------------------
+
+/** prints debug info about handlers. If format = 1, info about delegate is added. 
+ If 'after' = YES, the debug log is printed after all callback requests to the touch dispatcher
+ have been processed. In this case the return value is equal to -1.
+ If requested outside a touch callback it returns the number of the handlers' objects of the given type.
+ It is equal to the count of the printed handlers.
+   @since v1.1.0
+ */
+- (int) printDebugLog:(int)format afterEvents:(BOOL)after type:(ccDispatcherDelegateType)type;
+
+//--------------------------------------------
+//		priority sort
+//--------------------------------------------
+//--------------------------------------------
+/** sorts delegates of the given type according to the following factors:
+ - sortingAlgorithm
+ - reversePriority
+ - comparator 
+ 
+ This function is also useful when priority is changed without sorting by the following functions used with kCCPriorityToDo field:
+ setField:kCCPriorityToDo ... or/and setDelegatesField:kCCPriorityToDo ...
+ Regardless, delegates will be sorted at the end of the callback event processing loop if required. 
+
+   @since v1.1.0
+ */
+ - (void) sortDelegates:(ccDispatcherDelegateType)type;
+//--------------------------------------------
+
+//---------------------------------
+// counting delegates
+//---------------------------------
+
+/** returns number of delegates of the given type
+ User's callback safe: delegates in the process of being removed are not counted. 
+   @since v1.1.0
+ */						
+- (int) countDelegatesUsage:(ccDispatcherDelegateType)type; 
+
+/** checks if the touch delegate is already added to the dispatcher's list of the given type 
+ It may be important since any attempt to add two identical delegates triggers the 'NSAssert'. 
+ User's callback safe: 
+ It returns 0 if delegate does not exist or is marked for removal or >0 if delegate is added. 
+ If delegate is marked for removal adding the same delegate is safe.  
+   @since v1.1.0
+ */
+- (int) countDelegateUsage:(id) delegate type:(ccDispatcherDelegateType)type;	
+
+/** returns number of delegates with the specified tag
+ User's callback safe: delegates in the process of being removed are not counted. 
+ */
+- (int) countTagUsage:(int)tagValue type:(ccDispatcherDelegateType)type; 
+
+/** returns number of delegates with the specified priority
+ User's callback safe: delegates in the process of being removed are not counted. 
+   @since v1.1.0
+ */
+- (int) countPriorityUsage:(int)priorityValue type:(ccDispatcherDelegateType)type;
+
+/** returns number of delegates with the specified disable value ((Use: YES or NO)
+ User's callback safe: delegates in the process of being removed are not counted. 
+   @since v1.1.0
+ */
+- (int) countDisableUsage:(int)disableValue type:(ccDispatcherDelegateType)type;
+
+/** returns number of delegates with the specified value for given field 
+ User's callback safe: delegates in the process of being removed are not counted. 
+ Notice: It is generic functions covering all sugar 'countThisFieldUsage()' functions
+   @since v1.1.0
+ */
+- (int) countFieldUsage:(ccHandlerFieldName)field fieldValue:(int)value type:(ccDispatcherDelegateType)type;
+
+//----------------------------------
+// retrieval of the field value
+// ---------------------------------
+
+/** returns priority of the delegate or if the delegate does not exist, returns NSNotFound 
+  @since v1.1.0
+ */
+- (int) retrievePriorityField:(id) delegate type:(ccDispatcherDelegateType)type;
+
+/** returns tag of the delegate or if the delegate does not exist, returns NSNotFound 
+  @since v1.1.0
+ */
+- (int) retrieveTagField:(id) delegate type:(ccDispatcherDelegateType)type;
+
+/** returns value of the disable field or if the delegate does not exist, returns NSNotFound 
+  @since v1.1.0
+ */
+-(int) retrieveDisableField:(id) delegate type:(ccDispatcherDelegateType)type;
+
+/** returns value of the field or if the delegate does not exist, returns NSNotFound 
+	Notice: It is generic functions covering all sugar 'retrieve*Field(.)' functions
+   @since v1.1.0
+ */
+- (int) retrieveField:(ccHandlerFieldName)field delegate:(id)delegate type:(ccDispatcherDelegateType)type;
+
+//--------------------------------
+// disabling of the delegate(s)
+//--------------------------------
+
+/** disables/enables already added touch delegate 
+  @since v1.1.0
+ */			
+- (int) disableDelegate:(id) delegate disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
+
+/**  disables/enables all delegates of the given type 
+	returns number of disabled delegates
+   @since v1.1.0
+ */
+- (int) disableAllDelegates:(int)yesOrNo type:(ccDispatcherDelegateType)type;
+/** disables/enables already added touch delegates of the given type
+	with specified tag. (That allows for fast and selective disabling/enabling of delegates. 
+	Otherwise, delegates would have to be removed and added again to the list)
+	returns number of disabled delegates
+   @since v1.1.0
+ */
+ - (int) disableDelegatesWithTag:(int)aTag disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
+/** disables/enables already added targeted touch delegates of the given type
+	with specified priority (including those marked for removal).
+	returns number of disabled delegates 
+   @since v1.1.0
+ */
+- (int) disableDelegatesWithPriority:(int)aPriority disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
+
+/** inside the event loop, delegates marked for removal still receive touches (default)
+ 'disableRemovedDelegates' disables/enables delegates marked for removal inside the event loop.
+ Use it inside the touch callback function if you do not want removed delegates to be active
+ during event loop.
+ returns number of disabled delegates (including those marked for removal)
+   @since v1.1.0
+ */ 
+- (int) disableRemovedDelegates:(int)yesOrNo type:(ccDispatcherDelegateType)type;
+
+/** generic function to disable/enable delegates when a specific field contains a certain value.  
+  The content of the field is evaluated against arg1 and arg2 using (ccOperators)op.
+  @since v1.1.0
+ */
+- (int) disableDelegatesWithField:(ccHandlerFieldName)fieldName arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op
+		disable:(int)yesOrNo type:(ccDispatcherDelegateType)type;
+
+//---------------------------------
+// removal of the delegate/s
+//---------------------------------
+// Note: removal cannot be undone. If you need an already removed delegate then add it again.
+
+/** Removes the delegate of the given type, releasing the delegate
+	If delay: is set to YES the removal is delayed until removeToDoDelegates:type is called or current/first
+	event loop ends.
+  @since v1.1.0
+ */
+- (int) removeDelegate:(id) delegate delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
+
+/** removes all delegates of the given type 
+	returns number of delegates removed
+  @since v1.1.0
+ */ 
+- (int) removeAllDelegates:(ccDispatcherDelegateType)type;
+
+/** removes all delegates of the given type with specified tag 
+	returns number of delegates removed 
+ 	If delay: is set to YES the removal is delayed until removeToDoDelegates:type is called or current/first
+	event loop ends.
+  @since v1.1.0
+ */ 
+- (int) removeDelegatesWithTag:(int)tag delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
+
+/** removes all delegates of the given type with specified priority
+	returns number of delegates removed
+	If delay: is set to YES the removal is delayed until removeToDoDelegates:type is called or current/first
+	event loop ends.
+  @since v1.1.0
+ */ 
+- (int) removeDelegatesWithPriority:(int)priority delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
+
+/** removes all delegates of the given type marked for removal by the following functions used with kCCRemoveToDo field:
+	setField:kCCRemoveToDo ... or/and setDelegatesField:kCCRemoveToDo ... or remove* functions with delay:YES
+	If 'removeToDoDelegates' is not used all marked delegates will be removed at the end of the first event processing loop. 
+	returns number of delegates removed.
+	If function is called in the touch callback it returns -1. (Delegates will be removed at the end of the event loop)
+ @since v1.1.0
+ */ 
+- (int) removeToDoDelegates:(ccDispatcherDelegateType)type; 
+
+/** power function: covers all 'removeDelegates*' functions. Removes delegates of the given type 
+	for which a given field contains desired value.
+	The value of the field is evaluated against arg1 and arg2 using (ccOperators)op.
+   @since v1.1.0
+ */
+- (int) removeDelegatesWithField:(ccHandlerFieldName)fieldName 
+		arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
+
+//-------------------------------------------------------------------------
+// setting the value of a specific field to a new value for a given delegate
+//-------------------------------------------------------------------------
+
+/** Changes the priority of the previously added delegate.
+	If the new value is different from the old one, it will commence sorting of the delegates.
+	returns the number of delegates which changed priority. Removed delegates are not counted.
+  	If delay: is set to YES, sorting is delayed until 'sortDelegates:type' is called or the current/first
+	event loop ends.
+   @since v1.1.0
+ */
+- (int) setPriority:(int)newValue delegate:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type;
+ 
+ /** setRemove == removeDelegate
+ 	If delay: is set to YES then the removal is delayed until removeToDoDelegates:type is called or current/first
+	event loop ends.
+  @since v1.1.0
+ */
+  - (int) setRemove:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type;						
+
+ /** set a new tag for delegate
+  @since v1.1.0
+ */
+  - (int) setTag:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type; 
+/** setDisable == disableDelegate  - disable/enable delegate
+  @since v1.1.0
+ */
+- (int) setDisable:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type;
+ 
+ /** generic power function: sets value of the specific field to a new value.
+  @return number of affected delegates. It returns 0 if delegate is not found. It returns less than 0 for an error.  
+  @since v1.1.0
+ */
+- (int) setField:(ccHandlerFieldName)field newValue:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type;
+
+//------------------------------------------------------------------------------------------------
+// setting a new value for a specific field in delegate(s) which is conditional on the value of a certain field in the delegate
+//------------------------------------------------------------------------------------------------
+/** sets new priority for all delegates with the given tag
+	If delay: is set to YES sorting is delayed until sortDelegates:type; is called or the current/first
+	event loop ends.
+  @since v1.1.0
+ */
+- (int)	setPriorityForTag:(int)tag newPriority:(int)value delay:(BOOL)yesOrNO type:(ccDispatcherDelegateType)type;
+/** sets new tag for all delegates with the given priority 
+  @since v1.1.0
+*/
+- (int)	setTagForPriority:(int)priority newTag:(int)value type:(ccDispatcherDelegateType)type;
+			
+/** 'Only For Eagles' - generic power function - allows changes for delegates with the specific field value
+	The content of the field is evaluated against arg1 and arg2 using (ccOperators)op.
+	It returns number of affected delegates.
+   @since v1.1.0
+ */
+- (int) setDelegatesField:(ccHandlerFieldName)field newValue:(int)newValue
+		ifField:(ccHandlerFieldName)fieldToSearch arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op
+		   type:(ccDispatcherDelegateType)type;
+//-----------------------------------------------------------------------------------------------
+@end
+
+@class CCTouchHandler;
+
+typedef enum 
+{
+	kCCAddTargetedHandler,
+	kCCAddStandardHandler,
+}ccHandlersToDoType; 
+
+/**   @since v1.1.0 */
+@interface CCHandlersToDo : NSObject // treat as private 
+{
+@private
+  ccHandlersToDoType type_;
+  CCTouchHandler *handler_;
+  int arg_; 
+}
+
+@property(nonatomic,readwrite,assign) ccHandlersToDoType type;
+@property(nonatomic,readwrite,retain) CCTouchHandler *handler;
+@property(nonatomic,readwrite,assign) int arg;
+
+@end
+
+/**   @since v1.1.0 */
+@interface  CCArray (Additions)
+
+- (void) replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject;
+- (BOOL) isEqualToArray:(CCArray*)otherArray;
+
+- (void) qsortUsingCFuncComparator:(int(*)(const void *, const void *))comparator;	// c qsort is used for sorting
+- (void) insertionSortUsingCFuncComparator:(int(*)(const void *, const void *))comparator;  // insertion sort 
+- (void) mergesortLUsingCFuncComparator:(int(*)(const void *, const void *))comparator;	// mergesort
+
+- (void) insertionSort:(SEL)selector; // It sorts source array in ascending order
+- (void) sortUsingFunction:(NSInteger (*)(id, id, void *))compare context:(void *)context;
+- (void) forAllObjectsPerformSelectorWithDelegate:(id)delegate selector:(SEL)aSelector; //  for all array objects [delegate aSelector:arrObject]; 
+
+int mergesortL(void *base, size_t nel, size_t width, int (*compar)(const void *, const void *));
+void shuffle(NSMutableArray *array);
 @end
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED

--- a/cocos2d/Platforms/iOS/CCTouchDispatcher.m
+++ b/cocos2d/Platforms/iOS/CCTouchDispatcher.m
@@ -2,6 +2,7 @@
  * cocos2d for iPhone: http://www.cocos2d-iphone.org
  *
  * Copyright (c) 2009 Valentin Milea
+ * Copyright (c) 2011 Samuel J. Grabski
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,16 +26,30 @@
 
 // Only compile this code on iOS. These files should NOT be included on your Mac project.
 // But in case they are included, it won't be compiled.
+
 #import <Availability.h>
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 
-
 #import "CCTouchDispatcher.h"
 #import "CCTouchHandler.h"
+#include <stdlib.h> // qsort
+#import "CCNode.h"  // zOrder
+
+static BOOL	reversePriority;			// default is NO;
+
+static NSComparisonResult zOrderComparator(const void * first, const void * second);
+static NSComparisonResult sortByPriority(const void * first, const void * second);
+static BOOL eval(int v, ccOperators op, int arg);
+static ccOperators calcOp1(ccOperators compOp);
+static BOOL isItAnd(ccOperators compOp);
+static ccOperators calcOp3(ccOperators compOp);
+static BOOL evaluate(int v, ccOperators op1, int v1, BOOL useAnd, ccOperators op3, int v2);
 
 @implementation CCTouchDispatcher
 
 @synthesize dispatchEvents;
+
+#define CC_SEARCH_NOT_SUCCESSFUL	NSNotFound 
 
 static CCTouchDispatcher *sharedDispatcher = nil;
 
@@ -59,24 +74,31 @@ static CCTouchDispatcher *sharedDispatcher = nil;
 -(id) init
 {
 	if((self = [super init])) {
-	
-		dispatchEvents = YES;
-		targetedHandlers = [[NSMutableArray alloc] initWithCapacity:8];
-		standardHandlers = [[NSMutableArray alloc] initWithCapacity:4];
-		
-		handlersToAdd = [[NSMutableArray alloc] initWithCapacity:8];
-		handlersToRemove = [[NSMutableArray alloc] initWithCapacity:8];
-		
-		toRemove = NO;
-		toAdd = NO;
-		toQuit = NO;
-		locked = NO;
 
+		locked = NO;	
+		dispatchEvents = YES;			
+		int capacity = 30;				
+		
+		targetedHandlers = [[CCArray alloc] initWithCapacity:capacity];
+		standardHandlers = [[CCArray alloc] initWithCapacity:capacity];		
+		handlersToDo = [[CCArray alloc] initWithCapacity:capacity];
+
+		actionToDo.targetedRemoval = actionToDo.standardRemoval = 0;		
+		actionToDo.processStandardHandlersFirstFlag = NO;
+		actionToDo.processStandardHandlersFirstArg = processStandardHandlersFirst = NO;
+		actionToDo.sortingAlgorithmFlag = NO; 
+		actionToDo.sortingAlgorithmArg = sortingAlgorithm = kCCAlgInsertionSort;
+		actionToDo.reversePriorityFlag = actionToDo.reversePriorityArg = reversePriority = NO;
+		actionToDo.usersComparatorFlag = NO;
+		actionToDo.usersComparatorArg = usersComparator = NULL;
+		actionToDo.targetedPriority = actionToDo.standardPriority = 0;
+		actionToDo.targetedDebugLogFlag = actionToDo.standardDebugLogFlag = NO;
+		actionToDo.targetedDebugLogArg = actionToDo.standardDebugLogArg = 0;		
+		
 		handlerHelperData[kCCTouchBegan] = (struct ccTouchHandlerHelperData) {@selector(ccTouchesBegan:withEvent:),@selector(ccTouchBegan:withEvent:),kCCTouchSelectorBeganBit};
 		handlerHelperData[kCCTouchMoved] = (struct ccTouchHandlerHelperData) {@selector(ccTouchesMoved:withEvent:),@selector(ccTouchMoved:withEvent:),kCCTouchSelectorMovedBit};
 		handlerHelperData[kCCTouchEnded] = (struct ccTouchHandlerHelperData) {@selector(ccTouchesEnded:withEvent:),@selector(ccTouchEnded:withEvent:),kCCTouchSelectorEndedBit};
-		handlerHelperData[kCCTouchCancelled] = (struct ccTouchHandlerHelperData) {@selector(ccTouchesCancelled:withEvent:),@selector(ccTouchCancelled:withEvent:),kCCTouchSelectorCancelledBit};
-		
+		handlerHelperData[kCCTouchCancelled] = (struct ccTouchHandlerHelperData) {@selector(ccTouchesCancelled:withEvent:),@selector(ccTouchCancelled:withEvent:),kCCTouchSelectorCancelledBit};		
 	}
 	
 	return self;
@@ -86,8 +108,7 @@ static CCTouchDispatcher *sharedDispatcher = nil;
 {
 	[targetedHandlers release];
 	[standardHandlers release];
-	[handlersToAdd release];
-	[handlersToRemove release];
+	[handlersToDo release];
 	[super dealloc];
 }
 
@@ -95,173 +116,1317 @@ static CCTouchDispatcher *sharedDispatcher = nil;
 // handlers management
 //
 
-#pragma mark TouchDispatcher - Add Hanlder
+#pragma mark -
+#pragma mark - Changing priority of the added handlers
 
--(void) forceAddHandler:(CCTouchHandler*)handler array:(NSMutableArray*)array
-{
-	NSUInteger i = 0;
+static NSComparisonResult zOrderComparator(const void * first, const void * second)
+{	
+    id fId = ((id *) first)[0];  
+    id sId = ((id *) second)[0]; 	
 	
-	for( CCTouchHandler *h in array ) {
-		if( h.priority < handler.priority )
-			i++;
+	CCTouchHandler *f = (CCTouchHandler*) fId;
+	CCTouchHandler *s = (CCTouchHandler*) sId;
+
+	int fP = [f.delegate zOrder];   // delegate has to descend from CCNode
+	int sP = [s.delegate zOrder];  
+	
+	if (fP == sP) return NSOrderedSame;
+	
+	if (reversePriority){
+		if (fP < sP)   // if z1 < z2 < z3   order:  z1,z2,z3 
+			return NSOrderedAscending;
+		else
+			return NSOrderedDescending;
+	}
+	else{ // default
+		if (fP > sP)   // if z1 > z2 > z3   order:  z1,z2,z3 
+			return NSOrderedAscending;
+		else
+			return NSOrderedDescending;
+	}
+}
+
+static NSComparisonResult sortByPriority(const void * first, const void * second)
+{	
+    id fId = ((id *) first)[0];  // Lord, Have Mercy on Us!
+    id sId = ((id *) second)[0]; // Amen.	
+	
+	CCTouchHandler *f = (CCTouchHandler*) fId;
+	CCTouchHandler *s = (CCTouchHandler*) sId;					
+	
+	int fP = f.priority;
+	int sP = s.priority;
+	
+	if (fP == sP) return NSOrderedSame;	
 		
-		NSAssert( h.delegate != handler.delegate, @"Delegate already added to touch dispatcher.");
+	if (reversePriority){
+		if (fP > sP)	// if p1 > p2 > p3   order:  p1,p2,p3 
+			return NSOrderedAscending;
+		else
+			return NSOrderedDescending;
 	}
-	[array insertObject:handler atIndex:i];		
-}
-
--(void) addStandardDelegate:(id<CCStandardTouchDelegate>) delegate priority:(int)priority
-{
-	CCTouchHandler *handler = [CCStandardTouchHandler handlerWithDelegate:delegate priority:priority];
-	if( ! locked ) {
-		[self forceAddHandler:handler array:standardHandlers];
-	} else {
-		[handlersToAdd addObject:handler];
-		toAdd = YES;
+	else{ // default
+		if (fP < sP)   // if p1 < p2 < p3   order:  p1,p2,p3 
+			return NSOrderedAscending;
+		else 
+			return NSOrderedDescending;
 	}
 }
 
--(void) addTargetedDelegate:(id<CCTargetedTouchDelegate>) delegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches
+-(void) rearrangeHandlers:(CCArray *)array
 {
-	CCTouchHandler *handler = [CCTargetedTouchHandler handlerWithDelegate:delegate priority:priority swallowsTouches:swallowsTouches];
-	if( ! locked ) {
-		[self forceAddHandler:handler array:targetedHandlers];
-	} else {
-		[handlersToAdd addObject:handler];
-		toAdd = YES;
+	if ( usersComparator ){
+		switch (sortingAlgorithm) {
+			default:
+			case kCCAlgInsertionSort:
+				[array insertionSortUsingCFuncComparator:usersComparator];
+			case kCCAlgQSort:	
+				[array qsortUsingCFuncComparator:usersComparator]; 
+				break;
+			case kCCAlgMergeLSort:
+				[array mergesortLUsingCFuncComparator:usersComparator];
+				break;
+			case kCCDoNotSort:
+				break;
+		}									
+	}
+	else{
+		switch (sortingAlgorithm) {
+			default:
+			case kCCAlgInsertionSort:
+				[array insertionSortUsingCFuncComparator:sortByPriority];
+				break;			
+			case kCCAlgQSort:
+				[array qsortUsingCFuncComparator:sortByPriority]; 
+				break;
+			case kCCAlgMergeLSort:
+				[array mergesortLUsingCFuncComparator:sortByPriority];
+				break;
+			case kCCDoNotSort:
+				break;
+		}					
 	}
 }
 
-#pragma mark TouchDispatcher - removeDelegate
-
--(void) forceRemoveDelegate:(id)delegate
-{
-	// XXX: remove it from both handlers ???
-	
-	for( CCTouchHandler *handler in targetedHandlers ) {
-		if( handler.delegate == delegate ) {
-			[targetedHandlers removeObject:handler];
-			break;
-		}
+- (void) forceSetPriority
+{	 
+	if (actionToDo.targetedPriority){
+		[self rearrangeHandlers:targetedHandlers];
+		actionToDo.targetedPriority = 0;
 	}
-	
-	for( CCTouchHandler *handler in standardHandlers ) {
-		if( handler.delegate == delegate ) {
-			[standardHandlers removeObject:handler];
-			break;
-		}
+	if (actionToDo.standardPriority){
+		[self rearrangeHandlers:standardHandlers];
+		actionToDo.standardPriority = 0;	
 	}	
 }
 
--(void) removeDelegate:(id) delegate
+#pragma mark TouchDispatcher - arrayForType
+
+-(CCArray *) arrayForType:(ccDispatcherDelegateType)delegateType
 {
-	if( delegate == nil )
-		return;
+	CCArray *array; 
 	
-	if( ! locked ) {
-		[self forceRemoveDelegate:delegate];
-	} else {
-		[handlersToRemove addObject:delegate];
-		toRemove = YES;
+	switch (delegateType){
+		default:
+		case kCCTargeted:
+			array = targetedHandlers;
+			break;
+		case kCCStandard:
+			array = standardHandlers;
+			break;
+	}
+	return array;
+}
+//-----------------------------------------------------------
+
+//  removes all delegates of the given type 
+-(int) forceRemoveAllObjects:(ccDispatcherDelegateType) delegateType
+{
+	CCArray *array = [self arrayForType:delegateType];
+	int numberOfObjectsRemoved = [array count];
+	
+	[array removeAllObjects];
+	
+	return numberOfObjectsRemoved;
+}
+
+#pragma mark TouchDispatcher - removeAllDelegates
+
+-(int) removeAllDelegates:(ccDispatcherDelegateType) type
+{	
+	if ( locked ) {
+		return ( [self removeDelegatesWithField:kCCNotRemoved arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE delay:YES type:type] );	
+	}
+	else {		
+		return ( [self forceRemoveAllObjects:type] );
 	}
 }
 
 #pragma mark TouchDispatcher  - removeAllDelegates
 
--(void) forceRemoveAllDelegates
-{
-	[standardHandlers removeAllObjects];
-	[targetedHandlers removeAllObjects];
-}
--(void) removeAllDelegates
-{
-	if( ! locked )
-		[self forceRemoveAllDelegates];
-	else
-		toQuit = YES;
+-(void) removeAllDelegates // since: v0.8.0
+{	
+	[self removeAllDelegates:kCCTargeted];
+	[self removeAllDelegates:kCCStandard];	
 }
 
-#pragma mark Changing priority of added handlers
+#pragma mark TouchDispatcher - forceRemoveOfMarkedHandlers
 
--(CCTouchHandler*) findHandler:(id)delegate
+-(void) forceRemoveOfMarkedHandlers:(ccDispatcherDelegateType)delegateType nrOfObjects:(int)nrOfObjects
+{   // fast removal in one pass
+	int counter = 0;
+	CCTouchHandler *handler;
+	
+	CCArray *array = [self arrayForType:delegateType];	
+	ccArray *arrayData = array->data;
+	
+	for (int i = arrayData->num - 1; i>=0; --i) {
+		
+		handler = arrayData->arr[i]; // get handler
+		
+		if (handler.remove){		
+			
+			ccArrayRemoveObjectAtIndex(arrayData,i); // remove it 
+			
+			//--- this works well if there is more smaller removals than the big ones
+			counter++;
+			if (counter >= nrOfObjects) 
+				break;
+			//---	
+		}
+	}				
+}
+
+#pragma mark TouchDispatcher  - forceRemoveMarkedDelegates
+
+-(void) forceRemoveMarkedDelegates
+{	
+	if ( actionToDo.targetedRemoval ) {		
+		[self forceRemoveOfMarkedHandlers:kCCTargeted nrOfObjects:actionToDo.targetedRemoval];
+		actionToDo.targetedRemoval = 0;
+	}	
+	
+	if ( actionToDo.standardRemoval ) {
+		[self forceRemoveOfMarkedHandlers:kCCStandard nrOfObjects:actionToDo.standardRemoval];
+		actionToDo.standardRemoval = 0;	
+	}			
+}
+//---
+#pragma mark TouchDispatcher - toDoAddType
+
+-(ccHandlersToDoType) toDoAddType:(ccDispatcherDelegateType)type
 {
-	for( CCTouchHandler *handler in targetedHandlers ) {
-		if( handler.delegate == delegate ) {
-            return handler;
+    ccHandlersToDoType toDo;
+ 	switch(type) {
+		default:
+		case kCCTargeted:
+			toDo = kCCAddTargetedHandler;
+			break;
+		case kCCStandard:
+			toDo = kCCAddStandardHandler;
+			break;
+	}
+	return toDo;
+}
+
+-(void) debugLog:(ccDispatcherDelegateType)delegateType nr:(int)nr handler:(CCTouchHandler *) h formatType:(int)format
+{
+	switch (delegateType) {
+
+	case kCCTargeted: 		
+		switch (format){
+		case 1:	
+			CCLOG(@"N%3d Trg pri%4d tag%4d dis%2d rem%2d swl%2d eS %02X hF%d rP%d sA%d uC%p %@",
+				  nr, h.priority, h.tag, h.disable, h.remove, ((CCTargetedTouchHandler*)h).swallowsTouches,
+				  ((CCTargetedTouchHandler*)h).enabledSelectors,
+				  processStandardHandlersFirst, reversePriority, sortingAlgorithm, usersComparator,
+				  h.delegate);
+		break;
+		default:		
+		case 0:		
+			CCLOG(@"N%3d Trg pri%4d tag%4d dis%2d rem%2d swl%2d eS %02X hF%d rP%d sA%d uC%p",
+				  nr, h.priority, h.tag, h.disable, h.remove,((CCTargetedTouchHandler*)h).swallowsTouches,
+				  ((CCTargetedTouchHandler*)h).enabledSelectors,
+				  processStandardHandlersFirst, reversePriority, sortingAlgorithm, usersComparator);					
+			break;
+		}
+	break;
+			
+	case kCCStandard:		
+		switch (format){
+		case 1:		
+			CCLOG(@"N%3d Stn pri%4d tag%4d dis%2d rem%2d             hF%d rP%d sA%d uC%p %@",
+				nr, h.priority, h.tag, h.disable, h.remove,
+				processStandardHandlersFirst, reversePriority, sortingAlgorithm, usersComparator, 
+				h.delegate);
+		break;
+		default:		
+		case 0:		
+			CCLOG(@"N%3d Stn pri%4d tag%4d dis%2d rem%2d             hF%d rP%d sA%d uC%p",
+				nr, h.priority, h.tag, h.disable, h.remove,
+				processStandardHandlersFirst, reversePriority, sortingAlgorithm, usersComparator);						
+		break;
+		}
+	break;
+	} // switch (delegateType)
+}
+
+-(void) debugLog:(ccHandlersToDoType)type nr:(int)cnr handlerToDo:(CCHandlersToDo *)h formatType:(int)format
+{	
+	switch (type) {
+				
+	case kCCAddTargetedHandler: 		
+		switch (format) {
+		case 1:	
+			CCLOG(@"C%3d Trg pri%4d tag%4d dis%2d rem%2d swl%2d eS %02X hF%d rP%d sA%d uC%p %@",
+			  cnr, h.handler.priority, h.handler.tag, h.handler.disable, h.handler.remove,
+			  ((CCTargetedTouchHandler *) h.handler).swallowsTouches,
+			  ((CCTargetedTouchHandler *) h.handler).enabledSelectors,
+			  processStandardHandlersFirst,reversePriority, sortingAlgorithm, usersComparator,
+			  h.handler.delegate);
+		break;
+		default:		
+		case 0:			
+			CCLOG(@"C%3d Trg pri%4d tag%4d dis%2d rem%2d swl%2d eS %02X hF%d rP%d sA%d uC%p",
+			cnr, h.handler.priority, h.handler.tag, h.handler.disable, h.handler.remove,
+			((CCTargetedTouchHandler *) h.handler).swallowsTouches,
+			((CCTargetedTouchHandler *) h.handler).enabledSelectors,
+			processStandardHandlersFirst, reversePriority, sortingAlgorithm, usersComparator);			
+		break;						
+		}
+	break;
+			
+	case kCCAddStandardHandler:					
+		switch (format) {
+		case 1:		
+			CCLOG(@"C%3d Stn pri%4d tag%4d dis%2d rem%2d             hF%d rP%d sA%d uC%p %@",
+				  cnr, h.handler.priority, h.handler.tag, h.handler.disable, h.handler.remove,
+				  processStandardHandlersFirst, reversePriority, sortingAlgorithm, usersComparator,
+				  h.handler.delegate);
+		break;
+		default:		
+		case 0:	
+			CCLOG(@"C%3d Stn pri%4d tag%4d dis%2d rem%2d             hF%d rP%d sA%d uC%p",
+				  cnr, h.handler.priority, h.handler.tag, h.handler.disable, h.handler.remove,
+				  processStandardHandlersFirst, reversePriority, sortingAlgorithm, usersComparator);			
+		break;	
+		}
+	break;		
+	} //switch (type) 					
+}
+
+#pragma mark -
+#pragma mark - alterTouchHandler 
+
+-(void)	fieldToAlter:(ccHandlerFieldName)fieldToAlter withValue:(int)v forHandler:(CCTouchHandler *)h type:(ccDispatcherDelegateType)delegateType action:(int *)a
+{
+	switch ( fieldToAlter ) {
+		case kCCDelegate:
+			break;
+		case kCCPriority:
+		case kCCPriorityToDo:			
+			if ( h.priority != v ){
+				if (!h.remove) { // otherwise no need it is gone soon
+					h.priority = v;
+					(*a)++;
+				}
+			}	
+			break;			
+		case kCCTag:
+			h.tag = v;
+			(*a)++;;
+			break;				
+		case kCCDisable:
+			h.disable = v;
+			(*a)++;
+			break;	
+		case kCCRemove:
+		case kCCRemoveToDo:			
+			if (!h.remove) {  // one way only, no undo of course
+				if (v) {		
+					h.remove = YES;
+					(*a)++; 
+				}
+			}
+			break;		
+		case kCCSwallowsTouches: 	
+			if(delegateType == kCCTargeted){
+				((CCTargetedTouchHandler *) h).swallowsTouches = (BOOL)(v!=0);
+				(*a)++;
+			}
+			break;
+		case kCCNotRemoved: 
+			if (!h.remove) 
+				(*a)++;
+			break;			
+		case kCCNone: // just counting all objects
+			(*a)++;
+			break;				
+		case kCCDebug:
+			(*a)++;
+			[self debugLog:delegateType nr:(*a) handler:h formatType:v];
+			break;
+	}	
+}
+
+-(void)	fieldToAlter:(ccHandlerFieldName)fieldToAlter withValue:(int)v forToDoHandler:(CCHandlersToDo *)hToDo action:(int *)c
+{		
+	switch ( fieldToAlter ){
+		case kCCDelegate:
+			break;
+		case kCCPriority:
+		case kCCPriorityToDo:			
+			if (hToDo.handler.priority != v ){			
+				if (!hToDo.handler.remove){
+					hToDo.handler.priority = v;
+					(*c)++;
+				}
+			}
+			break;			
+		case kCCTag:
+			hToDo.handler.tag = v; 
+			(*c)++;
+			break;				
+		case kCCDisable:			
+			hToDo.handler.disable = v;
+			(*c)++;
+			break;
+		case kCCRemove:
+		case kCCRemoveToDo:			
+			if (!hToDo.handler.remove) {			
+				if ( v ) {	// one way only, no undo of course
+					hToDo.handler.remove = YES; 
+					(*c)++;
+				}
+			}
+			break;			
+		case kCCSwallowsTouches: 
+			if (hToDo.type == kCCAddTargetedHandler) {
+				((CCTargetedTouchHandler *) hToDo.handler).swallowsTouches = (BOOL)(v!=0);
+				(*c)++;
+			}
+			break;
+		case kCCNotRemoved: 
+			if (!hToDo.handler.remove)
+				(*c)++;
+			break;				
+		case kCCNone: // counting all objects
+			(*c)++;
+			break;				
+		case kCCDebug:
+			(*c)++;
+			[self debugLog:hToDo.type nr:(*c) handlerToDo:hToDo formatType:v];	
+			break;
+	}
+}
+
+- (void) sortDelegates:(ccDispatcherDelegateType)type; // API
+{	
+	switch(type){	
+		case kCCTargeted: actionToDo.targetedPriority = YES; break;
+		case kCCStandard: actionToDo.standardPriority = YES; break;
+	}
+	
+	if (!locked) { // sorting can be done now  (if not it will be done in the 'processCallbackRequestsToTheDispatcher'
+		[self forceSetPriority];} // priority flags are cleared here	
+}
+
+- (int) removeToDoDelegates:(ccDispatcherDelegateType)type; // API
+{			
+	int ret = -1;
+	
+	if (!locked) { // removal can be done now (if not it will be done in the 'processCallbackRequestsToTheDispatcher'
+				
+		switch ( type ) { 
+			case kCCTargeted:
+				ret = actionToDo.targetedRemoval;
+				[self forceRemoveOfMarkedHandlers:kCCTargeted nrOfObjects:actionToDo.targetedRemoval]; 
+				actionToDo.targetedRemoval = 0;  // removal flags are cleared here
+			break;
+			case kCCStandard:
+				ret = actionToDo.standardRemoval;
+				[self forceRemoveOfMarkedHandlers:kCCStandard nrOfObjects:actionToDo.standardRemoval]; 
+				actionToDo.standardRemoval = 0;	// removal flags are cleared here			
+			break;
+		}						
+	}
+	
+	return ret;
+}
+
+-(void) actionProcessing:(ccHandlerFieldName)fieldToAlter type:(ccDispatcherDelegateType)delegateType action:(int)action
+{
+	switch(fieldToAlter) 
+	{
+		case kCCDelegate:
+			break;
+		case kCCPriority:
+			if (action) { 
+				[self sortDelegates:delegateType];
+			}
+			break;
+		case kCCPriorityToDo:
+			if (action) { 
+				switch( delegateType ){	
+					case kCCTargeted: actionToDo.targetedPriority = YES; break;
+					case kCCStandard: actionToDo.standardPriority = YES; break;
+				}
+			}// sort will be done at the end of all callbacks or when 'sortDelegates' is issued
+			break;
+		case kCCTag:
+			break;
+		case kCCDisable:
+			break;
+		case kCCRemove:
+			if (action) {												
+				switch ( delegateType ) { 
+					case kCCTargeted: actionToDo.targetedRemoval += action; break; // accumulate number of removals
+					case kCCStandard: actionToDo.standardRemoval += action; break; // accumulate number of removals
+				}			 
+				if (!locked) { //removal can be done now; no accumulation from other remove calls
+					[self removeToDoDelegates:delegateType];	// removal flags are cleared here
+				}
+			}	
+			break;
+		case kCCRemoveToDo:
+			if (action) {												
+				switch ( delegateType ) { 
+					case kCCTargeted: actionToDo.targetedRemoval += action; break; // accumulate number of removals
+					case kCCStandard: actionToDo.standardRemoval += action; break; // accumulate number of removals
+				}
+			} // removal will be done at the end of all callbacks or 					 
+			break;
+		case kCCSwallowsTouches:	
+			break;
+		case kCCNotRemoved:
+			break;
+		case kCCNone:
+			break;			
+		case kCCDebug:
+			break;
+	}
+}
+
+static BOOL eval(int v, ccOperators op, int arg)
+{	
+	switch(op){
+		case kCCFALSE: return NO;	 break;
+		case kCCTRUE:  return YES; break;
+		case kCCNEQ: return (v != arg); break;	
+		case kCCEQ:  return (v == arg); break;	
+		case kCCGE:  return (v >= arg); break;
+		case kCCGT:  return (v >  arg); break;
+		case kCCLE:  return (v <= arg); break;
+		case kCCLT:  return (v <  arg); break;
+		default: return NO;	break;
+	}
+}
+
+static ccOperators calcOp1(ccOperators compOp)
+{
+	switch(compOp){ // fast parsing does not depend on the order of 'ccOperators'	
+		case kCCFALSE:case kCCTRUE:case kCCNEQ:case kCCEQ:case kCCGE:case kCCGT:case kCCLE:case kCCLT:return compOp;break;
+		case kCCGEAndLE:case kCCGEAndLT:case kCCGEOrLE:case kCCGEOrLT:return kCCGE;break;	
+		case kCCGTAndLE:case kCCGTAndLT:case kCCGTOrLE:case kCCGTOrLT:return kCCGT;break;
+		case kCCLEAndGE:case kCCLEAndGT:case kCCLEOrGE:case kCCLEOrGT:return kCCLE;break;
+		case kCCLTAndGE:case kCCLTAndGT:case kCCLTOrGE:case kCCLTOrGT:return kCCLT;break;
+		default: return kCCFALSE; break;
+	}
+}
+
+static BOOL isItAnd(ccOperators compOp)
+{
+	switch(compOp){ // fast parsing does not depend on the order of 'ccOperators'	
+		case kCCFALSE:case kCCTRUE:case kCCNEQ:case kCCEQ:case kCCGE:case kCCGT:case kCCLE:case kCCLT:return NO;break;
+		case kCCGEAndLE:case kCCGEAndLT:case kCCGTAndLE:case kCCGTAndLT:
+		case kCCLEAndGE:case kCCLEAndGT:case kCCLTAndGE:case kCCLTAndGT:return YES;break;
+		case kCCGEOrLE:case kCCGEOrLT:case kCCGTOrLE:case kCCGTOrLT:				
+		case kCCLEOrGE:case kCCLEOrGT:case kCCLTOrGE:case kCCLTOrGT:return NO;break;							
+		default:return NO;break;
+	}
+}
+
+static ccOperators calcOp3(ccOperators compOp)
+{
+	switch(compOp){ // fast parsing does not depend on the order of 'ccOperators'	
+		case kCCFALSE:case kCCTRUE:case kCCNEQ:case kCCEQ:case kCCGE:case kCCGT:case kCCLE:case kCCLT:return kCCTRUE;break;
+		case kCCLEAndGE:case kCCLTAndGE:case kCCLEOrGE:case kCCLTOrGE:return kCCGE;break;
+		case kCCLEAndGT:case kCCLTAndGT:case kCCLEOrGT:case kCCLTOrGT:return kCCGT;break;	
+		case kCCGEAndLE:case kCCGTAndLE:case kCCGEOrLE:case kCCGTOrLE:return kCCLE;break;
+		case kCCGEAndLT:case kCCGTAndLT:case kCCGEOrLT:case kCCGTOrLT:return kCCLT;break;
+		default:return kCCTRUE;break;
+	}	
+}
+
+static BOOL evaluate(int v, ccOperators op1, int v1, BOOL useAnd, ccOperators op3, int v2)
+{
+	BOOL result1 = eval(v,op1,v1);
+	if (op3 == kCCTRUE) return result1;
+	
+	BOOL result3 = eval(v,op3,v2);
+	if (useAnd) return (result1 && result3);
+	else return (result1 || result3); // use OR
+}
+
+// magic function:
+-(int) alterTouchHandler:(ccDispatcherDelegateType)dType delegate:(id)delegate
+		   fieldToSearch:(ccHandlerFieldName)searchField
+			   arg1:(int)v1 
+			   arg2:(int)v2 
+				operator:(ccOperators)op 
+			fieldToAlter:(ccHandlerFieldName)fieldToAlter withValue:(int)nV
+{
+	int action = 0; // number of objects affected
+	
+	if ( (searchField == kCCDelegate) && (delegate == nil) ) {
+		return -1; // NSAssert(delegate != nil, @"Got nil touch delegate!");
+	}
+	
+	ccOperators op1 = calcOp1(op);
+	BOOL useAnd = isItAnd(op); // if false use OR operator
+	ccOperators op3 = calcOp3(op);
+	
+	CCArray *array = [self arrayForType:dType]; // array for given handler's type
+	ccHandlersToDoType hToDoType = [self toDoAddType:dType];
+	
+	CCTouchHandler *h;	
+	CCARRAY_FOREACH(array, h) { 
+		switch(searchField) {
+			case kCCDelegate:						
+				if( h.delegate == delegate ) {																			
+					[self fieldToAlter:fieldToAlter withValue:nV forHandler:h type:dType action:&action]; 
+					break; // delegate has been found
+				}						
+				break;
+			case kCCPriority:
+			case kCCPriorityToDo:						
+				if ( evaluate(h.priority, op1, v1, useAnd, op3, v2) ) {
+					[self fieldToAlter:fieldToAlter withValue:nV forHandler:h type:dType action:&action]; 
+				}
+				break;
+			case kCCTag:
+				if ( evaluate(h.tag, op1, v1, useAnd, op3, v2) ) {
+					[self fieldToAlter:fieldToAlter withValue:nV forHandler:h type:dType action:&action]; 
+				}
+				break;
+			case kCCDisable:
+				if ( evaluate(h.disable, op1, v1, useAnd, op3, v2) ) {
+					[self fieldToAlter:fieldToAlter withValue:nV forHandler:h type:dType action:&action]; 
+				}
+				break;
+			case kCCRemove:
+			case kCCRemoveToDo:
+				if ( evaluate(h.remove, op1, v1, useAnd, op3, v2) ) {
+					[self fieldToAlter:fieldToAlter withValue:nV forHandler:h type:dType action:&action]; 
+				}
+				break;			
+			case kCCSwallowsTouches:
+				if ( dType == kCCTargeted ) {
+					if ( evaluate( ((CCTargetedTouchHandler*)h).swallowsTouches, op1, v1, useAnd, op3, v2) ) {
+						[self fieldToAlter:fieldToAlter withValue:nV forHandler:h type:dType action:&action]; 
+					}
+				}
+				break;				
+			case kCCNotRemoved:
+				if (!h.remove)
+					[self fieldToAlter:fieldToAlter withValue:nV forHandler:h type:dType action:&action]; 
+				break;				
+			case kCCNone: // for any value (for all value) no conditions checked 				
+				[self fieldToAlter:fieldToAlter withValue:nV forHandler:h type:dType action:&action]; 
+				break;
+			case kCCDebug:
+				action++; [self debugLog:dType nr:action handler:h formatType:nV];			
+				break;
+			default:
+				CCLOG(@"alterTouchHandler:You must be kidding!");
+				break;					
+				
+		}// search			
+	}//ccarray
+		
+	// handlersToDo array should be empty if we are NOT 'locked'
+	int callback = 0;	// number of object affected in the callback ToDo array 
+	CCHandlersToDo *hToDo;
+	CCARRAY_FOREACH(handlersToDo, hToDo) {
+		if ( hToDo.type != hToDoType )  //   kCCAddTargetedHandler, kCCAddStandardHandler	
+			continue;
+		switch(searchField) {
+			case kCCDelegate:			
+				if( hToDo.handler.delegate == delegate ) { 					
+					[self fieldToAlter:fieldToAlter withValue:nV forToDoHandler:hToDo action:&callback]; 
+				}// notice: all delegates are searched
+				break;
+			case kCCPriority:
+			case kCCPriorityToDo:					
+				if ( evaluate(hToDo.handler.priority, op1, v1, useAnd, op3, v2) ) { 
+					[self fieldToAlter:fieldToAlter withValue:nV forToDoHandler:hToDo action:&callback]; 				
+				}
+				break;
+			case kCCTag:
+				if ( evaluate(hToDo.handler.tag, op1, v1, useAnd, op3, v2) ) { 					
+					[self fieldToAlter:fieldToAlter withValue:nV forToDoHandler:hToDo action:&callback]; 
+				}
+				break;
+			case kCCDisable:
+				if ( evaluate(hToDo.handler.disable, op1, v1, useAnd, op3, v2) ) { 	
+					[self fieldToAlter:fieldToAlter withValue:nV forToDoHandler:hToDo action:&callback];					
+				}
+				break;
+			case kCCRemove:
+			case kCCRemoveToDo:				
+				if ( evaluate(hToDo.handler.remove, op1, v1, useAnd, op3, v2) ) { 	
+					[self fieldToAlter:fieldToAlter withValue:nV forToDoHandler:hToDo action:&callback];				
+				}
+				break;
+			case kCCSwallowsTouches:
+				if ( hToDo.type == kCCAddTargetedHandler ) { 
+					if ( evaluate(((CCTargetedTouchHandler*)hToDo.handler).swallowsTouches, op1, v1, useAnd, op3, v2) ) { 
+						[self fieldToAlter:fieldToAlter withValue:nV forToDoHandler:hToDo action:&callback];					
+					}
+				} 
+				break;
+			case kCCNotRemoved:
+				if (!hToDo.handler.remove)				
+					[self fieldToAlter:fieldToAlter withValue:nV forToDoHandler:hToDo action:&callback];
+				break;
+			case kCCNone: // for any value (for all value) no conditions checked 				
+				[self fieldToAlter:fieldToAlter withValue:nV forToDoHandler:hToDo action:&callback];
+				break;				
+			case kCCDebug:
+				callback++; [self debugLog:hToDoType nr:callback handlerToDo:hToDo formatType:nV];	
+				break;					
+		} // search 
+	}//ccarray
+	
+	[self actionProcessing:fieldToAlter type:dType action:action];
+	
+	return (action + callback);	// number of handlers affected
+}	
+
+#pragma mark -
+#pragma mark - Add Handlers
+
+-(void) forceAddHandler:(CCTouchHandler*)handler doNotSort:(int)doNotSort type:(ccDispatcherDelegateType)delegateType
+{					
+	if (handler.remove) return; // if handler is marked for removal do not add it to the array
+	
+	CCArray *array = [self arrayForType:delegateType];
+	
+	if ( doNotSort ) {
+		NSAssert( [array containsObject:handler] != YES, @"Delegate already added to touch dispatcher!");
+		[array addObject:handler];	// add at the end
+		return;
+	}
+	
+	NSUInteger i = 0;	
+	CCTouchHandler *h;	
+	CCARRAY_FOREACH(array, h){ // search all array 
+			
+		if ( usersComparator ) {
+			if ( usersComparator( & h, & handler ) == NSOrderedAscending ){ 
+				i++;  
+			}
+		}
+		else {
+			if (reversePriority) { // Descending order.  Priority list looks like: 10, 5, 1 - 5, - 10, - 20
+		
+				if ( h.priority > handler.priority ) {			
+					i++; // count elements which have greater priority than given one 
+				}
+			}
+			else{ // DEFAULT:   Ascending order
+				if ( h.priority < handler.priority ) {	// Priority list looks like:  - 20, - 10, -5 ,  1 , 5,  10 
+					i++; // count elements which have lesser priority than given one 
+				}
+			}	
+		}
+						
+		NSAssert( h.delegate != handler.delegate, @"Delegate already added to touch dispatcher.");
+	}
+	
+	[array insertObject:handler atIndex:i];	// insert 	
+}
+
+-(void) safelyAddHandler:(CCTouchHandler*)handler doNotSort:(int)yesOrNo type:(ccDispatcherDelegateType)delegateType
+{		
+	ccHandlersToDoType toDoType = [self toDoAddType:delegateType];
+	
+	CCHandlersToDo *todo = [[CCHandlersToDo alloc] init]; // autorelease could be used
+	
+	todo.type = toDoType;
+	todo.handler = handler;
+	todo.arg = yesOrNo;
+    
+	[handlersToDo addObject:todo];
+	[todo release]; todo = nil; // no need when autorelease done
+}
+
+-(void) add:(id) handler doNotSort:(int)yesOrNo type:(ccDispatcherDelegateType) delegateType
+{	
+	if (handler == nil )
+		return;
+	
+	if ( locked ) {
+		[self safelyAddHandler:handler doNotSort:yesOrNo type:delegateType]; // safe in to do loop
+	}
+	else {						
+		[self forceAddHandler:handler doNotSort:yesOrNo type:delegateType];
+	}
+}
+
+//----------------------
+// adding a delegate
+//----------------------
+
+-(void) addStandardDelegate:(id<CCStandardTouchDelegate>) delegate priority:(int)priority tag:(int)aTag disable:(int)yesOrNo doNotSort:(int)YN
+{	
+	[self add:[CCStandardTouchHandler handlerWithDelegate:delegate priority:priority tag:aTag disable:yesOrNo] doNotSort:YN type:kCCStandard];	
+}
+
+-(void) addStandardDelegate:(id<CCStandardTouchDelegate>) delegate priority:(int)priority
+{
+	[self addStandardDelegate:(id<CCStandardTouchDelegate>) delegate priority:priority tag:0 disable:NO doNotSort:NO];
+}
+
+-(void) addTargetedDelegate:(id<CCTargetedTouchDelegate>) delegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches tag:(int)aTag disable:(int)yesOrNo doNotSort:(int)YN 
+{
+	[self add:[CCTargetedTouchHandler handlerWithDelegate:delegate priority:priority swallowsTouches:swallowsTouches tag:aTag disable:yesOrNo] doNotSort:YN type:kCCTargeted];	
+}
+
+-(void) addTargetedDelegate:(id<CCTargetedTouchDelegate>) delegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches
+{
+	[self addTargetedDelegate:delegate priority:priority swallowsTouches:swallowsTouches tag:0 disable:NO doNotSort:NO];
+}
+
+//----------------------------------------------------------------------
+// safe touch call-back getters and setters for internal control fields
+//----------------------------------------------------------------------
+// API - touch callbacks safe
+
+-(BOOL) locked
+{
+	return locked; 
+}
+
+- (void) setProcessStandardHandlersFirst:(BOOL)yesOrNo
+{
+	if (locked){
+		actionToDo.processStandardHandlersFirstFlag = YES;
+		actionToDo.processStandardHandlersFirstArg = yesOrNo;
+	}
+	else{
+		processStandardHandlersFirst = yesOrNo;
+	}
+}
+/* get - current/requested - order of processing */
+- (BOOL) processStandardHandlersFirst
+{
+	if (locked){
+		if (actionToDo.processStandardHandlersFirstFlag){
+			return actionToDo.processStandardHandlersFirstArg;
+		}
+		else{
+			return processStandardHandlersFirst;
 		}
 	}
-	
-	for( CCTouchHandler *handler in standardHandlers ) {
-		if( handler.delegate == delegate ) {
-            return handler;
-        }
+	return processStandardHandlersFirst;
+}
+//
+- (void) setSortingAlgorithm:(ccSortingAlgorithm)alg
+{
+	if (locked){
+		actionToDo.sortingAlgorithmFlag = YES;
+		actionToDo.sortingAlgorithmArg = alg;
 	}
-    
-    if (toAdd) {
-		for( CCTouchHandler *handler in handlersToAdd ) {
-            if (handler.delegate == delegate) {
-                return handler;
-            }
-        }        
-    }
-    
-    return nil;
+	else{
+		sortingAlgorithm = alg;
+	}
+}
+/* get - current/requested - sortingAlgorithm */
+- (ccSortingAlgorithm) sortingAlgorithm
+{
+	if (locked){
+		if (actionToDo.sortingAlgorithmFlag){
+			return actionToDo.sortingAlgorithmArg;
+		}
+		else{
+			return sortingAlgorithm;
+		}
+	}
+	return sortingAlgorithm;
 }
 
-NSComparisonResult sortByPriority(id first, id second, void *context)
+- (void) setReversePriority:(BOOL)yesNo
 {
-    if (((CCTouchHandler*)first).priority < ((CCTouchHandler*)second).priority)
-        return NSOrderedAscending;
-    else if (((CCTouchHandler*)first).priority > ((CCTouchHandler*)second).priority)
-        return NSOrderedDescending;
-    else 
-        return NSOrderedSame;
+	if (locked){
+		actionToDo.reversePriorityFlag = YES;
+		actionToDo.reversePriorityArg = yesNo;
+	}
+	else{
+		reversePriority = yesNo;
+	}
+}
+/* get - current/requested - reversePriority */
+- (BOOL) reversePriority
+{ //  it is up to user to call the sort at his convenience
+	if (locked){
+		if (actionToDo.reversePriorityFlag){
+			return actionToDo.reversePriorityArg;
+		}
+		else{
+			return reversePriority;
+		}
+	}
+	return reversePriority;
 }
 
--(void) rearrangeHandlers:(NSMutableArray*)array
+- (void) setUsersComparator:(int(*)(const void *, const void *))comparator;	
+{ //  it is up to user to call the sort at his convenience
+	if (locked){
+		actionToDo.usersComparatorFlag = YES;
+		actionToDo.usersComparatorArg = comparator;
+	}
+	else{ 
+		usersComparator = comparator;
+	}
+}
+/* get - current/requested usersComparator */
+- (int(*)(const void *, const void *)) usersComparator
 {
-    [array sortUsingFunction:sortByPriority context:nil];
+	if (locked){
+		if (actionToDo.usersComparatorFlag){
+			return actionToDo.usersComparatorArg;
+		}
+		else{
+			return usersComparator;
+		}
+	}
+	return usersComparator;
 }
 
--(void) setPriority:(int) priority forDelegate:(id) delegate
+- (int(*)(const void *, const void *)) zOrderComparator
 {
+	return zOrderComparator;
+}
+
+#pragma mark TouchDispatcher  - retrieveField
+
+// returns value of the field or NSNotFound when delegate does not exist 
+- (int) retrieveField:(ccHandlerFieldName)field delegate:(id)delegate type:(ccDispatcherDelegateType)delegateType // power function
+{	
 	NSAssert(delegate != nil, @"Got nil touch delegate!");
 	
-	CCTouchHandler *handler = nil;
-    handler = [self findHandler:delegate];
-    
-    NSAssert(handler != nil, @"Delegate not found!");    
-    
-    handler.priority = priority;
-    
-    [self rearrangeHandlers:targetedHandlers];
-    [self rearrangeHandlers:standardHandlers];
+	BOOL notFound = YES; 	
+	int value = CC_SEARCH_NOT_SUCCESSFUL;
+	
+	CCArray *array = [self arrayForType:delegateType];
+	ccHandlersToDoType type = [self toDoAddType:delegateType];
+	
+	CCTouchHandler *handler;	
+	CCARRAY_FOREACH(array, handler) { 
+		
+		if ( handler.delegate == delegate ) {
+			
+			notFound = NO;
+			
+			switch ( field ) {
+				case kCCDelegate:
+					value = YES;
+					break;					
+				case kCCPriority:
+				case kCCPriorityToDo:				
+					value = handler.priority;
+					break;	
+				case kCCTag:
+					value = handler.tag;
+					break;						
+				case kCCDisable:
+					value = handler.disable;
+					break;
+				case kCCRemove:
+				case kCCRemoveToDo:				
+					value = handler.remove;
+				break;						
+				case kCCSwallowsTouches:
+					if(delegateType == kCCTargeted){
+						value = ((CCTargetedTouchHandler *) handler).swallowsTouches;}		
+				break;
+				default:
+				break;
+
+			}	
+			break; // break the loop if delegate had been found
+		}//if
+	}//ccarray
+		
+	CCHandlersToDo *handlerToDo;
+	CCARRAY_FOREACH(handlersToDo, handlerToDo) {
+		
+		if( handlerToDo.handler.delegate == delegate ) { 
+			
+			if ( handlerToDo.type == type ) {
+				
+				notFound = NO;
+				
+				switch ( field ){						
+					case kCCDelegate:
+						value = YES;
+						break;												
+					case kCCPriority:
+					case kCCPriorityToDo:						
+						value = handlerToDo.handler.priority;
+						break;
+					case kCCTag:
+						value = handlerToDo.handler.tag;
+						break;							
+					case kCCDisable:
+						value = handlerToDo.handler.disable;
+						break;
+					case kCCRemove:
+					case kCCRemoveToDo:						
+						value = handlerToDo.handler.remove;
+					break;						
+					case kCCSwallowsTouches:
+						if(type == kCCAddTargetedHandler){
+							value = ((CCTargetedTouchHandler *) handlerToDo.handler).swallowsTouches;}		
+					break;
+					default:
+					break;																			
+				}	
+			}//if
+		}//if 		
+	}//ccarray
+		
+	if (notFound) CCLOG(@"TouchHandler:delegate not found!");	
+	return value;	
 }
 
-//
-// dispatch events
-//
--(void) touches:(NSSet*)touches withEvent:(UIEvent*)event withTouchType:(unsigned int)idx
+//---------------------------------
+// counting delegates
+//---------------------------------
+
+- (int) countDelegatesUsage:(ccDispatcherDelegateType)type
 {
-	NSAssert(idx < 4, @"Invalid idx value");
+	return ([self alterTouchHandler:type delegate:nil
+		fieldToSearch:kCCNone arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:kCCNotRemoved withValue:CC_UNUSED_ARGUMENT]);
+}
 
-	id mutableTouches;
-	locked = YES;
-	
-	// optimization to prevent a mutable copy when it is not necessary
-	unsigned int targetedHandlersCount = [targetedHandlers count];
-	unsigned int standardHandlersCount = [standardHandlers count];	
-	BOOL needsMutableSet = (targetedHandlersCount && standardHandlersCount);
-	
-	mutableTouches = (needsMutableSet ? [touches mutableCopy] : touches);
+-(int) countDelegateUsage:(id)delegate type:(ccDispatcherDelegateType)type
+{	
+	return ([self alterTouchHandler:type delegate:delegate
+		fieldToSearch:kCCDelegate arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:kCCNotRemoved withValue:CC_UNUSED_ARGUMENT]);
+}
 
-	struct ccTouchHandlerHelperData helper = handlerHelperData[idx];
-	//
-	// process the target handlers 1st
-	//
+-(int) countTagUsage:(int)tag type:(ccDispatcherDelegateType)type
+{
+	return ([self alterTouchHandler:type delegate:nil
+		fieldToSearch:kCCTag arg1:tag arg2:tag operator:kCCEQ fieldToAlter:kCCNotRemoved withValue:CC_UNUSED_ARGUMENT]);
+}
+
+- (int) countPriorityUsage:(int)priority type:(ccDispatcherDelegateType)type
+{
+	return ([self alterTouchHandler:type delegate:nil
+		fieldToSearch:kCCPriority arg1:priority arg2:priority operator:kCCEQ fieldToAlter:kCCNotRemoved withValue:CC_UNUSED_ARGUMENT]);
+}		
+
+- (int) countDisableUsage:(int)aDisable type:(ccDispatcherDelegateType)type
+{
+	return ([self alterTouchHandler:type delegate:nil
+		fieldToSearch:kCCDisable arg1:aDisable arg2:aDisable operator:kCCEQ fieldToAlter:kCCNotRemoved withValue:CC_UNUSED_ARGUMENT]);
+}
+
+- (int) countFieldUsage:(ccHandlerFieldName)field fieldValue:(int)value type:(ccDispatcherDelegateType)type // power function
+{
+	return ([self alterTouchHandler:type delegate:nil
+		fieldToSearch:field arg1:value arg2:value operator:kCCEQ fieldToAlter:kCCNotRemoved withValue:CC_UNUSED_ARGUMENT]);
+}
+
+//-------------------------------------------------------------------------------
+// retrieval of the field value
+// Function returns value of the field or NSNotFound when delegate does not exist 
+// ------------------------------------------------------------------------------
+
+// helper functions based on the generic 'retrieveField' function 
+
+-(int) retrievePriorityField:(id)delegate type:(ccDispatcherDelegateType)type
+{
+	return ( [self retrieveField:kCCPriority delegate:delegate type:type] );
+}
+// returns value of the field or NSNotFound when delegate does not exist 
+-(int) retrieveTagField:(id)delegate type:(ccDispatcherDelegateType)type
+{
+	return ( [self retrieveField:kCCTag delegate:delegate type:type] );
+}
+// returns value of the field or NSNotFound when delegate does not exist 
+-(int) retrieveDisableField:(id)delegate type:(ccDispatcherDelegateType)type
+{
+	return ( [self retrieveField:kCCDisable delegate:delegate type:type] );
+}
+
+//--------------------------------
+// disabling of the delegate/s
+//--------------------------------
+
+#pragma mark -
+#pragma mark - disable/enable particular touch delegate or group 
+
+- (int) disableDelegate:(id)delegate disable:(int)yesOrNo type:(ccDispatcherDelegateType)type 
+{
+	return ( [self alterTouchHandler:type delegate:delegate fieldToSearch:kCCDelegate 
+			arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:kCCDisable withValue:yesOrNo] );
+}
+
+-(int) disableAllDelegates:(int)yesOrNo type:(ccDispatcherDelegateType)type
+{
+	return ( [self alterTouchHandler:type delegate:nil fieldToSearch:kCCNone
+			arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:kCCDisable withValue:yesOrNo]);
+}
+
+- (int) disableDelegatesWithTag:(int)tag disable:(int) yesOrNo type:(ccDispatcherDelegateType)type
+{
+	return ( [self alterTouchHandler:type delegate:nil fieldToSearch:kCCTag
+				arg1:tag arg2:tag operator:kCCEQ fieldToAlter:kCCDisable withValue:yesOrNo] );
+}
+
+- (int) disableDelegatesWithPriority:(int) priority disable:(int) yesOrNo type:(ccDispatcherDelegateType)type
+{
+	return ( [self alterTouchHandler:type delegate:nil fieldToSearch:kCCPriority
+				arg1:priority arg2:priority operator:kCCEQ fieldToAlter:kCCDisable withValue:yesOrNo] );
+}
+
+-(int) disableRemovedDelegates:(int)yesOrNo type:(ccDispatcherDelegateType)type
+{
+	return ( [self alterTouchHandler:type delegate:nil fieldToSearch:kCCRemove 
+				arg1:YES arg2:YES operator:kCCEQ fieldToAlter:kCCDisable withValue:yesOrNo] );
+}
+
+- (int) disableDelegatesWithField:(ccHandlerFieldName)fieldName arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op
+				disable:(int)yesOrNo type:(ccDispatcherDelegateType)type
+{
+	return ( [self alterTouchHandler:type delegate:nil fieldToSearch:fieldName 
+						   arg1:leftEndPoint arg2:rightEndPoint operator:op fieldToAlter:kCCDisable withValue:yesOrNo] );
+}
+
+//---------------------------------
+// removal of the delegate/s
+//---------------------------------
+#pragma mark -
+#pragma mark - removeDelegate 
+
+-(void) removeDelegate:(id) delegate // since v0.8.0
+{				
+	[self removeDelegate:delegate delay:NO type:kCCTargeted];
+	[self removeDelegate:delegate delay:NO type:kCCStandard];
+}
+
+-(int) removeDelegate:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)delegateType
+{
+	ccHandlerFieldName r = kCCRemove; if (yesOrNo) r = kCCRemoveToDo; 
+	return ([self alterTouchHandler:delegateType delegate:delegate fieldToSearch:kCCDelegate 
+		arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:r withValue:YES]);
+}
+
+- (int) removeDelegatesWithTag:(int)tag delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)delegateType
+{
+	ccHandlerFieldName r = kCCRemove; if (yesOrNo) r = kCCRemoveToDo; 
+	return ([self alterTouchHandler:delegateType delegate:nil fieldToSearch:kCCTag 
+		arg1:tag arg2:tag operator:kCCEQ fieldToAlter:r withValue:YES]);
+} 
+
+- (int) removeDelegatesWithPriority:(int)priority delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)delegateType
+{
+	ccHandlerFieldName r = kCCRemove; if (yesOrNo) r = kCCRemoveToDo; 
+	return ([self alterTouchHandler:delegateType delegate:nil fieldToSearch:kCCPriority 
+		arg1:priority arg2:priority operator:kCCEQ fieldToAlter:r withValue:YES]);
+}
+
+// Only For Eagles - Power API Function
+- (int) removeDelegatesWithField:(ccHandlerFieldName)fieldToSearch arg1:(int)leftV arg2:(int)rightV operator:(ccOperators)op
+			delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)delegateType 
+{
+	if (fieldToSearch == kCCDelegate) return -1; // user cannot search this field
+	
+	ccHandlerFieldName r = kCCRemove; if (yesOrNo) r = kCCRemoveToDo; 	
+	return ([self alterTouchHandler:delegateType delegate:nil fieldToSearch:fieldToSearch 
+		arg1:leftV arg2:rightV operator:op fieldToAlter:r withValue:YES]);
+}
+
+//------------------------------------
+// setting value for a delegate field
+//------------------------------------
+
+-(void) setPriority:(int)priority forDelegate:(id)delegate /** since v1.0 obsolete */
+{		
+	[self setPriority:priority delegate:delegate delay:NO type:kCCTargeted];
+	[self setPriority:priority delegate:delegate delay:NO type:kCCStandard];	
+}
+
+-(int) setPriority:(int)newValue delegate:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type;
+{	
+	ccHandlerFieldName p = kCCPriority; if (yesOrNo) p = kCCPriorityToDo; 	
+	return [self alterTouchHandler:type delegate:delegate fieldToSearch:kCCDelegate 
+		arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:p withValue:newValue];
+}
+
+- (int) setTag:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type
+{	
+	return [self alterTouchHandler:type delegate:delegate fieldToSearch:kCCDelegate 
+		arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:kCCTag withValue:newValue];	
+}
+
+- (int) setDisable:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type
+{
+	return [self alterTouchHandler:type delegate:delegate fieldToSearch:kCCDelegate 
+		arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:kCCDisable withValue:newValue];
+}
+
+- (int) setRemove:(id)delegate delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)type
+{
+	ccHandlerFieldName r = kCCRemove; if (yesOrNo) r = kCCRemoveToDo; 
+	return [self alterTouchHandler:type delegate:delegate fieldToSearch:kCCDelegate 
+		arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:r withValue:YES];
+}
+
+// generic power function
+- (int) setField:(ccHandlerFieldName)field newValue:(int)newValue delegate:(id)delegate type:(ccDispatcherDelegateType)type
+{
+	return ([self alterTouchHandler:type delegate:delegate fieldToSearch:kCCDelegate
+		arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE fieldToAlter:field withValue:newValue]);
+}
+
+//------------------------------------------------------------------------------------------------
+// setting new value for a delegates specific field conditional on the value of other(same) field
+//------------------------------------------------------------------------------------------------
+- (int)	setTagForPriority:(int)priority newTag:(int)value type:(ccDispatcherDelegateType)delegateType
+{
+	return ([self alterTouchHandler:delegateType delegate:nil
+		fieldToSearch:kCCPriority arg1:priority arg2:priority operator:kCCEQ fieldToAlter:kCCTag withValue:value]);		
+}
+
+- (int)	setPriorityForTag:(int)tag newPriority:(int)value delay:(BOOL)yesOrNo type:(ccDispatcherDelegateType)delegateType
+{
+	ccHandlerFieldName p = kCCPriority; if (yesOrNo) p = kCCPriorityToDo; 	
+	return ([self alterTouchHandler:delegateType delegate:nil
+		fieldToSearch:kCCTag arg1:tag arg2:tag operator:kCCEQ fieldToAlter:p withValue:value]);
+} 
+
+/** Only For Eagles - Power Functions: */
+-(int) setDelegatesField:(ccHandlerFieldName)field newValue:(int)newValue
+				 ifField:(ccHandlerFieldName)fieldToSearch arg1:(int)leftEndPoint arg2:(int)rightEndPoint operator:(ccOperators)op
+					type:(ccDispatcherDelegateType)type
+{
+	return ([self alterTouchHandler:type delegate:nil fieldToSearch:fieldToSearch
+				arg1:leftEndPoint arg2:rightEndPoint operator:op fieldToAlter:field withValue:newValue]);
+}
+//------------------------------------------------------------------------------------------------
+
+- (int)	printDebugLog:(int)format type:(ccDispatcherDelegateType)type // API
+{
+	int count = 0;
+	switch(type){	
+		case kCCTargeted: 
+			count = [self setDelegatesField:kCCDebug newValue:format ifField:kCCNone 
+						arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE type:type];
+		break;
+		case kCCStandard:
+			count = [self setDelegatesField:kCCDebug newValue:format ifField:kCCNone 
+						arg1:CC_UNUSED_ARGUMENT arg2:CC_UNUSED_ARGUMENT operator:kCCTRUE type:type];
+		break;
+	}
+	return count;
+}
+
+- (int) printDebugLog:(int)format afterEvents:(BOOL)after type:(ccDispatcherDelegateType)type; // API
+{	
+	if (!after || !locked) {
+		return ( [self printDebugLog:format type:type] );
+	}				
+	// after && locked	
+	
+	switch(type){	
+		case kCCTargeted: actionToDo.targetedDebugLogFlag = YES; actionToDo.targetedDebugLogArg = format; break;
+		case kCCStandard: actionToDo.standardDebugLogFlag = YES; actionToDo.standardDebugLogArg = format; break;
+	}
+	return -1;
+}
+
+-(void) processCallbackRequestsToTheDispatcher
+{
+	// check if we need to change the order of processing:
+	if (actionToDo.processStandardHandlersFirstFlag) {
+		processStandardHandlersFirst = actionToDo.processStandardHandlersFirstArg;
+		actionToDo.processStandardHandlersFirstFlag = NO;
+	}
+	// check if we need to change the sortingAlgorithm 
+	if (actionToDo.sortingAlgorithmFlag) {
+		sortingAlgorithm = actionToDo.sortingAlgorithmArg;
+		actionToDo.sortingAlgorithmFlag = NO;
+	}
+	// check if we need to change the priority order	
+	if (actionToDo.reversePriorityFlag){
+		reversePriority = actionToDo.reversePriorityArg;
+		actionToDo.reversePriorityFlag = NO;
+	}
+	// check if we need to change the user's 'usersComparator'	
+	if (actionToDo.usersComparatorFlag){
+		usersComparator = actionToDo.usersComparatorArg;
+		actionToDo.usersComparatorFlag = NO;
+	}
+	
+	// -- handle priority change --
+	[self forceSetPriority];
+	//-----------------------------
+	
+	// print debug log
+	if (actionToDo.targetedDebugLogFlag){
+		[self printDebugLog:actionToDo.targetedDebugLogArg type:kCCTargeted]; 
+		actionToDo.targetedDebugLogFlag = NO;
+	}
+	if (actionToDo.standardDebugLogFlag){
+		[self printDebugLog:actionToDo.standardDebugLogArg type:kCCStandard]; 
+		actionToDo.standardDebugLogFlag = NO;
+	}
+}
+
+#pragma mark TouchDispatcher - safeProcessing
+
+-(void) safeProcessing // process messages to the Dispatcher sent by user's touch callbacks
+{
+	// -- remove marked for removal delegates --
+	[self forceRemoveMarkedDelegates];
+	//------------------------------------------
+	
+	CCHandlersToDo *todo;
+	CCARRAY_FOREACH(handlersToDo, todo) {		
+		switch (todo.type) {
+			case kCCAddTargetedHandler:
+				[self forceAddHandler:todo.handler doNotSort:todo.arg type:kCCTargeted];
+				break;
+			case kCCAddStandardHandler:
+				[self forceAddHandler:todo.handler doNotSort:todo.arg type:kCCStandard];
+				break;				
+			default:
+				break;
+		}
+	}
+	[handlersToDo removeAllObjects];  
+	
+	//  -- process deleyed requests from user's touch callbacks --
+	[self processCallbackRequestsToTheDispatcher];
+	//------------------------------------------------------------
+}
+
+#pragma mark -
+#pragma mark TouchDispatcher - Process Targeted Handlers
+
+- (void) processTargetedHandlers:(NSSet*)touches withEvent:(UIEvent*)event withTouchType:(unsigned int)idx
+{	
+	CCTargetedTouchHandler *handler;	
 	if( targetedHandlersCount > 0 ) {
 		for( UITouch *touch in touches ) {
-			for(CCTargetedTouchHandler *handler in targetedHandlers) {
+			CCARRAY_FOREACH(targetedHandlers, handler) { // speed is critical here
+				
+				if ( handler.disable ) continue; // handlers marked for removal are serviced
 				
 				BOOL claimed = NO;
 				if( idx == kCCTouchBegan ) {
@@ -279,7 +1444,7 @@ NSComparisonResult sortByPriority(id first, id second, void *context)
 					if( helper.type & (kCCTouchSelectorCancelledBit | kCCTouchSelectorEndedBit) )
 						[handler.claimedTouches removeObject:touch];
 				}
-					
+				
 				if( claimed && handler.swallowsTouches ) {
 					if( needsMutableSet )
 						[mutableTouches removeObject:touch];
@@ -287,50 +1452,59 @@ NSComparisonResult sortByPriority(id first, id second, void *context)
 				}
 			}
 		}
-	}
-	
-	//
-	// process standard handlers 2nd
-	//
+	}		
+}
+
+#pragma mark TouchDispatcher - Process Standard Handlers
+
+- (void) processStandardHandlers:(UIEvent*)event
+{
+	CCTouchHandler *handler;
 	if( standardHandlersCount > 0 && [mutableTouches count]>0 ) {
-		for( CCTouchHandler *handler in standardHandlers ) {
+		CCARRAY_FOREACH(standardHandlers, handler) { 
+			if ( handler.disable ) continue; // handlers marked for removal are serviced (default)
 			if( handler.enabledSelectors & helper.type )
 				[handler.delegate performSelector:helper.touchesSel withObject:mutableTouches withObject:event];
 		}
+	}		
+}
+
+#pragma mark TouchDispatcher - touches - dispatch events!
+
+-(void) touches:(NSSet*)touches withEvent:(UIEvent*)event withTouchType:(unsigned int)idx
+{
+	NSAssert(idx < 4, @"Invalid idx value");
+	
+	locked = YES; // processing of the touch callbacks is in progress
+	
+	// optimization to prevent a mutable copy when it is not necessary
+	targetedHandlersCount = [targetedHandlers count];
+	standardHandlersCount = [standardHandlers count];	
+	needsMutableSet = (targetedHandlersCount && standardHandlersCount);
+	
+	mutableTouches = (needsMutableSet ? [touches mutableCopy] : touches); // copy is expensive
+
+	helper = handlerHelperData[idx];
+	
+	//
+	// processing touches
+	//
+	if ( processStandardHandlersFirst ) {
+		[self processStandardHandlers:event];
+		[self processTargetedHandlers:touches withEvent:event withTouchType:idx];	
 	}
-	if( needsMutableSet )
+	else{ // this is the default order of the event processing	
+		[self processTargetedHandlers:touches withEvent:event withTouchType:idx];	
+		[self processStandardHandlers:event];
+	}
+	
+	if ( needsMutableSet )
 		[mutableTouches release];
 	
-	//
-	// Optimization. To prevent a [handlers copy] which is expensive
-	// the add/removes/quit is done after the iterations
-	//
-	locked = NO;
+	locked = NO; // processing of the touch callbacks is done
 	
-	//issue 1084, 1139 first add then remove
-	if( toAdd ) {
-		toAdd = NO;
-		Class targetedClass = [CCTargetedTouchHandler class];
-		
-		for( CCTouchHandler *handler in handlersToAdd ) {
-			if( [handler isKindOfClass:targetedClass] )
-				[self forceAddHandler:handler array:targetedHandlers];
-			else
-				[self forceAddHandler:handler array:standardHandlers];
-		}
-		[handlersToAdd removeAllObjects];
-	}
-	
-	if( toRemove ) {
-		toRemove = NO;
-		for( id delegate in handlersToRemove )
-			[self forceRemoveDelegate:delegate];
-		[handlersToRemove removeAllObjects];
-	}
-		if( toQuit ) {
-		toQuit = NO;
-		[self forceRemoveAllDelegates];
-	}
+	// all critical operations are done after touch callback processing loop is finished 
+	[self safeProcessing];
 }
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
@@ -338,6 +1512,7 @@ NSComparisonResult sortByPriority(id first, id second, void *context)
 	if( dispatchEvents )
 		[self touches:touches withEvent:event withTouchType:kCCTouchBegan];
 }
+
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
 {
 	if( dispatchEvents ) 
@@ -354,6 +1529,256 @@ NSComparisonResult sortByPriority(id first, id second, void *context)
 {
 	if( dispatchEvents )
 		[self touches:touches withEvent:event withTouchType:kCCTouchCancelled];
+}
+
+@end
+
+
+#pragma mark -
+#pragma mark CCHandlersToDo
+
+@implementation CCHandlersToDo
+
+@synthesize type = type_;
+@synthesize handler = handler_;
+@synthesize arg = arg_;
+
+-(void) dealloc
+{
+  [handler_ release];
+  [super dealloc];
+}
+@end
+
+
+#pragma mark -
+#pragma mark CCArray (Additions)
+
+@implementation CCArray (Additions)
+
+#pragma mark -
+#pragma mark CCArray replaceObjectAtIndex
+
+- (void) replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject {
+	[self insertObject:anObject atIndex:index];
+	[self removeObjectAtIndex: index+1];
+}
+
+#pragma mark -
+#pragma mark CCArray isEqualToArray
+- (BOOL) isEqualToArray:(CCArray*)otherArray {
+	for (int i = 0; i< [self count]; i++)
+	{
+		if (![[self objectAtIndex:i] isEqual: [otherArray objectAtIndex:i]])
+		{
+			return FALSE;
+		}
+	}
+	return YES;
+}
+
+#pragma mark -
+#pragma mark CCArray insertionSortUsingCFuncComparator
+
+- (void) insertionSortUsingCFuncComparator:(int(*)(const void *, const void *))comparator
+{
+	// It sorts source array in ascending order
+	
+	// adaptive - performance adapts to the initial order of elements
+	// stable - insertion sort retains relative order of the same elements
+	// in-place - requires constant amount of additional space
+	// online - new elements can be added during the sort
+	
+	NSInteger i,j,length = data->num;
+	
+	id * x = data->arr;
+	id temp;	
+
+	// insertion sort
+	for(i=1; i<length; i++)
+	{
+		j = i;
+		//continue moving element downwards while order is descending 
+		while( j>0 && ( comparator(  &x[j-1],  &x[j]  ) == NSOrderedDescending) )
+		{
+			temp = x[j];
+			x[j] = x[j-1];
+			x[j-1] = temp;
+			j--;
+		}
+	}
+}
+
+#pragma mark CCArray qsortUsingCFuncComparator
+
+- (void) qsortUsingCFuncComparator:(int(*)(const void *, const void *))comparator {
+	
+	// stable c qsort is used - cost of sorting:  best n*log(n), average n*log(n)
+	//  qsort(void *, size_t, size_t, int (*)(const void *arg1, const void *arg2));
+	
+    qsort(data->arr, data->num, sizeof (id), comparator);  
+}
+
+#pragma mark CCArray mergesortLUsingCFuncComparator
+
+- (void) mergesortLUsingCFuncComparator:(int(*)(const void *, const void *))comparator
+{
+   mergesortL(data->arr, data->num, sizeof (id), comparator); 
+}
+
+#pragma mark CCArray insertionSort with (SEL)selector
+
+- (void) insertionSort:(SEL)selector // It sorts source array in ascending order
+{
+	NSInteger i,j,length = data->num;
+	
+	id * x = data->arr;
+	id temp;	
+	
+	// insertion sort
+	for(i=1; i<length; i++)
+	{
+		j = i;
+		// continue moving element downwards while order is descending 
+		while( j>0 && ( (int)([x[j-1] performSelector:selector withObject:x[j]]) == NSOrderedDescending) )
+		{
+			temp = x[j];
+			x[j] = x[j-1];
+			x[j-1] = temp;
+			j--;
+		}
+	}
+}
+
+static inline void memswp(void* a, void* b, size_t width)
+{
+	if (width == sizeof(void*)) {
+			// Optimization for pointer sized swap:
+			void* tmp;
+			tmp = *(void**)a;
+			*(void**)a = *(void**)b;
+			*(void**)b = tmp;
+			return;
+        }
+	// default uses memcpy:
+	char tmp[width];
+	memcpy(tmp, a, width);
+	memcpy(a, b, width);
+	memcpy(b, tmp, width);
+}
+
+#pragma mark CCArray iterative mergesort
+// iterative mergesort based on
+//  http://www.inf.fh-flensburg.de/lang/algorithmen/sortieren/merge/mergiter.htm  
+
+int mergesortL(void *base, size_t nel, size_t width, int (*compar)(const void *, const void *))
+{
+	NSInteger h, i, j, k, l, m, n = nel;
+	void* A; // points to an element
+	void* B = NSZoneMalloc(NULL,(n/2 + 1) * width); // points to a temp array
+        
+
+	for (h = 1; h < n; h += h) {
+			for (m = n - 1 - h; m >= 0; m -= h + h) {
+					l = m - h + 1;
+					if (l < 0)
+							l = 0;
+                        
+					// Copy first half of the array into helper B:
+					j = m+1;
+					memcpy(B, base + (l * width), (j-l) * width);
+                        
+					for (i = 0, k = l; k < j && j <= m + h; k++) {
+							A = base + (width * j); // A = [self objectAtIndex:j];
+							if (compar(A, B + (i * width)) > 0) {
+									memswp(base+(k*width), B+(i*width), width); i+=1;
+							} else {
+									memswp(base+(k*width), A, width); j+=1;
+							}
+					}
+                        
+					while (k < j) // This loop could be optimized
+							memswp(base+(k++*width), B+(i++*width), width);
+			}
+	}
+
+	free(B);
+	return 0;
+}
+//---
+static int selectorCompare(id object1,id object2,void *userData){
+   SEL selector=userData;
+
+   return (NSComparisonResult)[object1 performSelector:selector withObject:object2];
+}
+
+-(void)sortUsingSelector:(SEL)selector {
+   [self sortUsingFunction:selectorCompare context:selector];
+}
+
+#pragma mark CCArray sortUsingFunction
+
+// using a comparison function
+-(void)sortUsingFunction:(NSInteger (*)(id, id, void *))compare context:(void *)context
+{
+   NSInteger h, i, j, k, l, m, n = [self count];
+   id  A, *B = NSZoneMalloc(NULL,(n/2 + 1) * sizeof(id));
+
+	// to prevent retain counts from temporarily hitting zero.  
+   for(i=0;i<n;i++)
+	   [[self objectAtIndex:i] retain];
+    
+   for (h = 1; h < n; h += h)
+   {
+      for (m = n - 1 - h; m >= 0; m -= h + h)
+      {
+         l = m - h + 1;
+         if (l < 0)
+            l = 0;
+
+         for (i = 0, j = l; j <= m; i++, j++)
+            B[i] = [self objectAtIndex:j];
+
+         for (i = 0, k = l; k < j && j <= m + h; k++)
+         {
+            A = [self objectAtIndex:j];
+            if (compare(A, B[i], context) == NSOrderedDescending)
+               [self replaceObjectAtIndex:k withObject:B[i++]];
+            else
+            {
+               [self replaceObjectAtIndex:k withObject:A];
+               j++;
+            }
+         }
+
+         while (k < j)
+            [self replaceObjectAtIndex:k++ withObject:B[i++]];
+      }
+   }
+   
+   for(i=0;i<n;i++)
+	   [[self objectAtIndex:i] release];
+    
+   free(B);
+}
+
+void shuffle(NSMutableArray *array) {
+    NSUInteger count = [array count];
+    for (NSUInteger i = 0; i < count; ++i) {
+        // Select a random element between i and end of array to swap with.
+        int nElements = count - i;
+        int n = (arc4random() % nElements) + i;
+        [array exchangeObjectAtIndex:i withObjectAtIndex:n];
+    }
+}
+
+- (void) forAllObjectsPerformSelectorWithDelegate:(id)delegate selector:(SEL)aSelector 
+{		
+	if (delegate && aSelector){
+		for( NSUInteger i = 0; i < data->num; i++){		
+			[delegate performSelector:aSelector withObject:data->arr[i]];
+		}
+	}		
 }
 @end
 

--- a/cocos2d/Platforms/iOS/CCTouchHandler.h
+++ b/cocos2d/Platforms/iOS/CCTouchHandler.h
@@ -2,6 +2,7 @@
  * cocos2d for iPhone: http://www.cocos2d-iphone.org
  *
  * Copyright (c) 2009 Valentin Milea
+ * Copyright (c) 2011 Samuel J. Grabski
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,13 +46,23 @@
 @interface CCTouchHandler : NSObject {
 	id				delegate;
 	int				priority;
+	int 			tag;	// similar to CCNode tag	
+	int			disable;	// allows fast disabling: default NO, enabled 
+	BOOL         remove;    // if (!=0) object marked for removal (allows fast removal)
 	ccTouchSelectorFlag		enabledSelectors_;
 }
 
 /** delegate */
 @property(nonatomic, readwrite, retain) id delegate;
 /** priority */
-@property(nonatomic, readwrite) int priority; // default 0
+@property(nonatomic, readwrite) int priority;	// default 0
+/** tag */
+@property(nonatomic, readwrite) int tag; 		// default 0
+/** disable */
+@property(nonatomic, readwrite) int disable; 	// default 0; NO
+/** remove */
+@property(nonatomic, readwrite) BOOL remove;	// default NO
+
 /** enabled selectors */
 @property(nonatomic,readwrite) ccTouchSelectorFlag enabledSelectors;
 
@@ -59,6 +70,11 @@
 + (id)handlerWithDelegate:(id)aDelegate priority:(int)priority;
 /** initializes a TouchHandler with a delegate and a priority */
 - (id)initWithDelegate:(id)aDelegate priority:(int)priority;
+
+/** allocates a TouchHandler with a delegate, priority, tag and a disable flag */
++ (id)handlerWithDelegate:(id)aDelegate priority:(int)aPriority tag:(int)aTag disable:(int)yesOrNo;
+/** initializes a TouchHandler with a delegate, priority tag and a disable flag */
+- (id)initWithDelegate:(id)aDelegate priority:(int)aPriority tag:(int)aTag disable:(int)yesOrNo;
 @end
 
 /** CCStandardTouchHandler
@@ -83,11 +99,23 @@
 /** MutableSet that contains the claimed touches */
 @property(nonatomic, readonly) NSMutableSet *claimedTouches;
 
-/** allocates a TargetedTouchHandler with a delegate, a priority and whether or not it swallows touches or not */
+/** allocates a TargetedTouchHandler with a delegate, a priority and whether or not it swallows touches or not 
+ tag = 0; disabled = NO
+*/
 + (id)handlerWithDelegate:(id) aDelegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches;
+/** allocates a TargetedTouchHandler with a delegate, a priority and whether or not it swallows touches or not 
+  allows to set tag and disabled flag	
+*/
++ (id)handlerWithDelegate:(id) aDelegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches
+							 tag:(int)aTag disable:(int)yesOrNo;
 /** initializes a TargetedTouchHandler with a delegate, a priority and whether or not it swallows touches or not */
 - (id)initWithDelegate:(id) aDelegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches;
 
+/** initializes a TargetedTouchHandler with a delegate, a priority and whether or not it swallows touches or not 
+	allows to set tag and disabled flag
+*/
+- (id)initWithDelegate:(id) aDelegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches
+							 tag:(int)aTag disable:(int)yesOrNo;
 @end
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED

--- a/cocos2d/Platforms/iOS/CCTouchHandler.h
+++ b/cocos2d/Platforms/iOS/CCTouchHandler.h
@@ -42,7 +42,7 @@
 /**
  CCTouchHandler
  Object than contains the delegate and priority of the event handler.
-*/
+ */
 @interface CCTouchHandler : NSObject {
 	id				delegate;
 	int				priority;
@@ -101,21 +101,21 @@
 
 /** allocates a TargetedTouchHandler with a delegate, a priority and whether or not it swallows touches or not 
  tag = 0; disabled = NO
-*/
+ */
 + (id)handlerWithDelegate:(id) aDelegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches;
 /** allocates a TargetedTouchHandler with a delegate, a priority and whether or not it swallows touches or not 
-  allows to set tag and disabled flag	
-*/
+ allows to set tag and disabled flag	
+ */
 + (id)handlerWithDelegate:(id) aDelegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches
-							 tag:(int)aTag disable:(int)yesOrNo;
+                      tag:(int)aTag disable:(int)yesOrNo;
 /** initializes a TargetedTouchHandler with a delegate, a priority and whether or not it swallows touches or not */
 - (id)initWithDelegate:(id) aDelegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches;
 
 /** initializes a TargetedTouchHandler with a delegate, a priority and whether or not it swallows touches or not 
-	allows to set tag and disabled flag
-*/
+ allows to set tag and disabled flag
+ */
 - (id)initWithDelegate:(id) aDelegate priority:(int)priority swallowsTouches:(BOOL)swallowsTouches
-							 tag:(int)aTag disable:(int)yesOrNo;
+                   tag:(int)aTag disable:(int)yesOrNo;
 @end
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED

--- a/cocos2d/Support/CCArray.h
+++ b/cocos2d/Support/CCArray.h
@@ -39,7 +39,7 @@
 
 #define CCARRAY_FOREACH(__array__, __object__)												\
 if (__array__ && __array__->data->num > 0)													\
-for(CC_ARC_UNSAFE_RETAINED id *__arr__ = __array__->data->arr, *end = __array__->data->arr + __array__->data->num-1;	\
+for(const CC_ARC_UNSAFE_RETAINED id *__arr__ = __array__->data->arr, *end = __array__->data->arr + __array__->data->num-1;	\
 	__arr__ <= end && ((__object__ = *__arr__) != nil || true);										\
 	__arr__++)
 
@@ -69,6 +69,8 @@ for(CC_ARC_UNSAFE_RETAINED id *__arr__ = __array__->data->arr, *end = __array__-
 - (id) randomObject;
 - (id) lastObject;
 - (NSArray*) getNSArray;
+/** @since 1.1 */
+- (BOOL) isEqualToArray:(CCArray*)otherArray;
 
 
 // Adding Objects
@@ -94,13 +96,24 @@ for(CC_ARC_UNSAFE_RETAINED id *__arr__ = __array__->data->arr, *end = __array__-
 
 - (void) exchangeObject:(id)object1 withObject:(id)object2;
 - (void) exchangeObjectAtIndex:(NSUInteger)index1 withObjectAtIndex:(NSUInteger)index2;
+/** @since 1.1 */
+- (void) replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject;
 - (void) reverseObjects;
 - (void) reduceMemoryFootprint;
+
+// Sorting Array 
+/** all since @1.1 */
+- (void) qsortUsingCFuncComparator:(int(*)(const void *, const void *))comparator;	// c qsort is used for sorting
+- (void) insertionSortUsingCFuncComparator:(int(*)(const void *, const void *))comparator;  // insertion sort 
+- (void) mergesortLUsingCFuncComparator:(int(*)(const void *, const void *))comparator;	// mergesort
+- (void) insertionSort:(SEL)selector; // It sorts source array in ascending order
+- (void) sortUsingFunction:(NSInteger (*)(id, id, void *))compare context:(void *)context;
 
 // Sending Messages to Elements
 
 - (void) makeObjectsPerformSelector:(SEL)aSelector;
 - (void) makeObjectsPerformSelector:(SEL)aSelector withObject:(id)object;
-
+/** @since 1.1 */
+- (void) makeObjectPerformSelectorWithArrayObjects:(id)object selector:(SEL)aSelector; 
 
 @end

--- a/cocos2d/Support/CCArray.m
+++ b/cocos2d/Support/CCArray.m
@@ -25,7 +25,6 @@
 #import "CCArray.h"
 #import "../ccMacros.h"
 
-
 @implementation CCArray
 
 + (id) array
@@ -135,6 +134,17 @@
 	return [NSArray arrayWithObjects:data->arr count:data->num];
 }
 
+- (BOOL) isEqualToArray:(CCArray*)otherArray {
+	for (int i = 0; i< [self count]; i++)
+	{
+		if (![[self objectAtIndex:i] isEqual: [otherArray objectAtIndex:i]])
+		{
+			return NO;
+		}
+	}
+	return YES;
+}
+
 
 #pragma mark Adding Objects
 
@@ -218,6 +228,11 @@
 	ccArraySwapObjectsAtIndexes(data, index1, index2);
 }
 
+- (void) replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject {
+    ccArrayInsertObjectAtIndex(data, anObject, index);
+    ccArrayRemoveObjectAtIndex(data, index+1);
+}
+
 - (void) reverseObjects
 {
 	if (data->num > 1)
@@ -251,6 +266,10 @@
 	ccArrayMakeObjectsPerformSelectorWithObject(data, aSelector, object);
 }
 
+- (void) makeObjectPerformSelectorWithArrayObjects:(id)object selector:(SEL)aSelector 
+{		
+	ccArrayMakeObjectPerformSelectorWithArrayObjects(data, aSelector, object);
+}
 
 #pragma mark CCArray - NSFastEnumeration protocol
 
@@ -264,6 +283,113 @@
 	return data->num;
 }
 
+#pragma mark CCArray - sorting 
+
+/** @since 1.1 */ 
+#pragma mark -
+#pragma mark CCArray insertionSortUsingCFuncComparator
+
+- (void) insertionSortUsingCFuncComparator:(int(*)(const void *, const void *))comparator
+{
+    insertionSort(data, comparator);
+}
+
+#pragma mark CCArray qsortUsingCFuncComparator
+
+- (void) qsortUsingCFuncComparator:(int(*)(const void *, const void *))comparator {
+	
+	// stable c qsort is used - cost of sorting:  best n*log(n), average n*log(n)
+	//  qsort(void *, size_t, size_t, int (*)(const void *arg1, const void *arg2));
+	
+    qsort(data->arr, data->num, sizeof (id), comparator);  
+}
+
+#pragma mark CCArray mergesortLUsingCFuncComparator
+
+- (void) mergesortLUsingCFuncComparator:(int(*)(const void *, const void *))comparator
+{
+    mergesortL(data, sizeof (id), comparator); 
+}
+
+#pragma mark CCArray insertionSort with (SEL)selector
+
+- (void) insertionSort:(SEL)selector // It sorts source array in ascending order
+{
+	NSInteger i,j,length = data->num;
+	
+	id * x = data->arr;
+	id temp;	
+	
+	// insertion sort
+	for(i=1; i<length; i++)
+	{
+		j = i;
+		// continue moving element downwards while order is descending 
+		while( j>0 && ( (int)([x[j-1] performSelector:selector withObject:x[j]]) == NSOrderedDescending) )
+		{
+			temp = x[j];
+			x[j] = x[j-1];
+			x[j-1] = temp;
+			j--;
+		}
+	}
+}
+
+static inline NSInteger selectorCompare(id object1,id object2,void *userData){
+    SEL selector=userData;
+    
+    return (NSInteger)[object1 performSelector:selector withObject:object2];
+}
+
+-(void)sortUsingSelector:(SEL)selector {
+    [self sortUsingFunction:selectorCompare context:selector];
+}
+
+#pragma mark CCArray sortUsingFunction
+
+// using a comparison function
+-(void)sortUsingFunction:(NSInteger (*)(id, id, void *))compare context:(void *)context
+{
+    NSInteger h, i, j, k, l, m, n = [self count];
+    id  A, *B = NSZoneMalloc(NULL,(n/2 + 1) * sizeof(id));
+    
+	// to prevent retain counts from temporarily hitting zero.  
+    for(i=0;i<n;i++)
+        [[self objectAtIndex:i] retain];
+    
+    for (h = 1; h < n; h += h)
+    {
+        for (m = n - 1 - h; m >= 0; m -= h + h)
+        {
+            l = m - h + 1;
+            if (l < 0)
+                l = 0;
+            
+            for (i = 0, j = l; j <= m; i++, j++)
+                B[i] = [self objectAtIndex:j];
+            
+            for (i = 0, k = l; k < j && j <= m + h; k++)
+            {
+                A = [self objectAtIndex:j];
+                if (compare(A, B[i], context) == NSOrderedDescending)
+                    [self replaceObjectAtIndex:k withObject:B[i++]];
+                else
+                {
+                    [self replaceObjectAtIndex:k withObject:A];
+                    j++;
+                }
+            }
+            
+            while (k < j)
+                [self replaceObjectAtIndex:k++ withObject:B[i++]];
+        }
+    }
+    
+    for(i=0;i<n;i++)
+        [[self objectAtIndex:i] release];
+    
+    free(B);
+}
 
 #pragma mark CCArray - NSCopying protocol
 

--- a/cocos2d/Support/CCFileUtils.h
+++ b/cocos2d/Support/CCFileUtils.h
@@ -3,17 +3,17 @@
  *
  * Copyright (c) 2008-2010 Ricardo Quesada
  * Copyright (c) 2011 Zynga Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,12 +36,12 @@
 /** Returns the fullpath of an filename.
  
  If in RetinaDisplay mode, and a RetinaDisplay file is found, it will return that path.
- If in iPad mode, and an iPad file is found, it will return that path. 
+ If in iPad mode, and an iPad file is found, it will return that path.
  
  Examples:
-
-  * In iPad mode: "image.png" -> "/full/path/image-ipad.png" (in case the -ipad file exists)
-  * In RetinaDisplay mode: "image.png" -> "/full/path/image-hd.png" (in case the -hd file exists)
+ 
+ * In iPad mode: "image.png" -> "/full/path/image-ipad.png" (in case the -ipad file exists)
+ * In RetinaDisplay mode: "image.png" -> "/full/path/image-hd.png" (in case the -hd file exists)
  
  */
 +(NSString*) fullPathFromRelativePath:(NSString*) relPath;
@@ -50,15 +50,15 @@
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 
 /** Returns the fullpath of an filename including the resolution of the image.
-
+ 
  If in RetinaDisplay mode, and a RetinaDisplay file is found, it will return that path.
- If in iPad mode, and an iPad file is found, it will return that path. 
+ If in iPad mode, and an iPad file is found, it will return that path.
  
  Examples:
  
-	* In iPad mode: "image.png" -> "/full/path/image-ipad.png" (in case the -ipad file exists)
-	* In RetinaDisplay mode: "image.png" -> "/full/path/image-hd.png" (in case the -hd file exists)
-
+ * In iPad mode: "image.png" -> "/full/path/image-ipad.png" (in case the -ipad file exists)
+ * In RetinaDisplay mode: "image.png" -> "/full/path/image-hd.png" (in case the -hd file exists)
+ 
  If an iPad file is found, it will set resolution type to kCCResolutioniPad
  If a RetinaDisplay file is found, it will set resolution type to kCCResolutionRetinaDisplay
  
@@ -76,21 +76,29 @@
  */
 +(NSString *)removeSuffixFromFile:(NSString*) path;
 
-/** Sets the RetinaDisplay suffix to load resources.
+/** Sets the iPhone RetinaDisplay suffix to load resources.
  By default it is "-hd".
  Only valid on iOS. Not valid for OS X.
  
  @since v1.1
  */
-+(void) setRetinaDisplaySuffix:(NSString*)suffix;
++(void) setiPhoneRetinaDisplaySuffix:(NSString*)suffix;
 
 /** Sets the iPad suffix to load resources.
  By default it is "".
  Only valid on iOS. Not valid for OS X.
  
- @since v1.1
+
  */
 +(void) setiPadSuffix:(NSString*)suffix;
+
+/** Sets the iPad Retina Display suffix to load resources.
+ By default it is "-ipadhd".
+ Only valid on iOS. Not valid for OS X.
+ 
+ @since v1.1
+ */
++(void) setiPadRetinaDisplaySuffix:(NSString*)suffix;
 
 /** Returns whether or not a given filename exists with the iPad suffix.
  Only available on iOS. Not supported on OS X.
@@ -98,11 +106,17 @@
  */
 +(BOOL) iPadFileExistsAtPath:(NSString*)filename;
 
-/** Returns whether or not a given path exists with the RetinaDisplay suffix.
+/** Returns whether or not a given filename exists with the iPad RetinaDisplay suffix.
+ Only available on iOS. Not supported on OS X.
+ 
+ */
++(BOOL) iPadRetinaDisplayFileExistsAtPath:(NSString*)filename;
+
+/** Returns whether or not a given path exists with the iPhone RetinaDisplay suffix.
  Only available on iOS. Not supported on OS X.
  @since v1.1
  */
-+(BOOL) retinaDisplayFileExistsAtPath:(NSString*)filename;
++(BOOL) iPhoneRetinaDisplayFileExistsAtPath:(NSString*)filename;
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED
 

--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -3,17 +3,17 @@
  *
  * Copyright (c) 2008-2010 Ricardo Quesada
  * Copyright (c) 2011 Zynga Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,7 +25,6 @@
  */
 
 
-#import <Availability.h>
 #import "CCFileUtils.h"
 #import "../CCConfiguration.h"
 #import "../ccMacros.h"
@@ -34,48 +33,49 @@
 
 static NSFileManager *__localFileManager=nil;
 
-#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+#ifdef  __IPHONE_OS_VERSION_MAX_ALLOWED
 
-static NSString *__suffixRetinaDisplay =@"-hd";
+static NSString *__suffixiPhoneRetinaDisplay =@"-hd";
 static NSString *__suffixiPad =@"-ipad";
+static NSString *__suffixiPadRetinaDisplay =@"-ipadhd";
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED
 
 
 NSString *ccRemoveSuffixFromPath( NSString *suffix, NSString *path);
 
-// 
-NSInteger ccLoadFileIntoMemory(const char *filename, unsigned char **out) 
-{ 
+//
+NSInteger ccLoadFileIntoMemory(const char *filename, unsigned char **out)
+{
 	NSCAssert( out, @"ccLoadFileIntoMemory: invalid 'out' parameter");
 	NSCAssert( &*out, @"ccLoadFileIntoMemory: invalid 'out' parameter");
-
+    
 	size_t size = 0;
 	FILE *f = fopen(filename, "rb");
-	if( !f ) { 
+	if( !f ) {
 		*out = NULL;
 		return -1;
-	} 
-	
+	}
+    
 	fseek(f, 0, SEEK_END);
 	size = ftell(f);
 	fseek(f, 0, SEEK_SET);
-	
+    
 	*out = malloc(size);
 	size_t read = fread(*out, 1, size, f);
-	if( read != size ) { 
+	if( read != size ) {
 		free(*out);
 		*out = NULL;
 		return -1;
 	}
-	
+    
 	fclose(f);
-	
+    
 	return size;
 }
 
 
-#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+#ifdef  __IPHONE_OS_VERSION_MAX_ALLOWED
 @interface CCFileUtils()
 +(NSString *) removeSuffix:(NSString*)suffix fromPath:(NSString*)path;
 +(BOOL) fileExistsAtPath:(NSString*)string withSuffix:(NSString*)suffix;
@@ -95,20 +95,20 @@ NSInteger ccLoadFileIntoMemory(const char *filename, unsigned char **out)
 	// quick return
 	if( ! suffix || [suffix length] == 0 )
 		return path;
-	
+    
 	NSString *pathWithoutExtension = [path stringByDeletingPathExtension];
 	NSString *name = [pathWithoutExtension lastPathComponent];
-	
+    
 	// check if path already has the suffix.
 	if( [name rangeOfString:suffix].location != NSNotFound ) {
-	
-		CCLOG(@"cocos2d: WARNING Filename(%@) already has the suffix %@. Using it.", name, suffix);			
+        
+		CCLOG(@"cocos2d: WARNING Filename(%@) already has the suffix %@. Using it.", name, suffix);
 		return path;
 	}
-
-	
+    
+    
 	NSString *extension = [path pathExtension];
-	
+    
 	if( [extension isEqualToString:@"ccz"] || [extension isEqualToString:@"gz"] )
 	{
 		// All ccz / gz files should be in the format filename.xxx.ccz
@@ -116,77 +116,89 @@ NSInteger ccLoadFileIntoMemory(const char *filename, unsigned char **out)
 		extension = [NSString stringWithFormat:@"%@.%@", [pathWithoutExtension pathExtension], extension];
 		pathWithoutExtension = [pathWithoutExtension stringByDeletingPathExtension];
 	}
-	
-	
+    
+    
 	NSString *newName = [pathWithoutExtension stringByAppendingString:suffix];
 	newName = [newName stringByAppendingPathExtension:extension];
-
+    
 	if( [__localFileManager fileExistsAtPath:newName] )
 		return newName;
-
+    
 	CCLOG(@"cocos2d: CCFileUtils: Warning file not found: %@", [newName lastPathComponent] );
-	
+    
 	return nil;
 }
 
 +(NSString*) fullPathFromRelativePath:(NSString*)relPath resolutionType:(ccResolutionType*)resolutionType
 {
 	NSAssert(relPath != nil, @"CCFileUtils: Invalid path");
-	
+    
 	NSString *fullpath = nil;
-	
+    
 	// only if it is not an absolute path
 	if( ! [relPath isAbsolutePath] ) {
-
+        
 		// pathForResource also searches in .lproj directories. issue #1230
 		NSString *file = [relPath lastPathComponent];
 		NSString *imageDirectory = [relPath stringByDeletingLastPathComponent];
-		
+        
 		fullpath = [[NSBundle mainBundle] pathForResource:file
 												   ofType:nil
 											  inDirectory:imageDirectory];
-
-		
+        
+        
 	}
-	
+    
 	if (fullpath == nil)
 		fullpath = relPath;
-	
-#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-	
+    
+#ifdef  __IPHONE_OS_VERSION_MAX_ALLOWED
+    
 	NSString *ret = nil;
-	
-	// Retina Display ?
-	if( CC_CONTENT_SCALE_FACTOR() == 2 ) {
-		ret = [self getPath:fullpath forSuffix:__suffixRetinaDisplay];
-		*resolutionType = kCCResolutionRetinaDisplay;
+    
+	// iPad?
+	if( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+	{
+		// Retina Display ?
+		if( CC_CONTENT_SCALE_FACTOR() == 2 ) {
+			ret = [self getPath:fullpath forSuffix:__suffixiPadRetinaDisplay];
+			*resolutionType = kCCResolutioniPadRetinaDisplay;
+		}
+		else
+		{
+			ret = [self getPath:fullpath forSuffix:__suffixiPad];
+			*resolutionType = kCCResolutioniPad;
+			
+		}
 	}
-	
-	// iPad ?
-	else if( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-		ret = [self getPath:fullpath forSuffix:__suffixiPad];
-		*resolutionType = kCCResolutioniPad;
-	}
-	
-	// It should be an iPhone in non Retina Display mode. So, do nothing
+	// iPhone ?
 	else
-		*resolutionType = kCCResolutionStandard;
+	{
+		// Retina Display ?
+		if( CC_CONTENT_SCALE_FACTOR() == 2 ) {
+			ret = [self getPath:fullpath forSuffix:__suffixiPhoneRetinaDisplay];
+			*resolutionType = kCCResolutioniPhoneRetinaDisplay;
+		}
+	}
 	
-	if( ! ret ) {
-		*resolutionType = kCCResolutionStandard;
+	// If it is iPhone Non RetinaDisplay, or if the previous "getPath" failed, then use iPhone images.
+	if( ret == nil )
+	{
+		*resolutionType = kCCResolutioniPhone;
 		ret = fullpath;
 	}
-	
+    
 	return ret;
-	
+    
 #elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
-	
-	*resolutionType = kCCResolutionStandard;
-	
-	return fullpath;	
-	
-#endif // __MAC_OS_X_VERSION_MAX_ALLOWED
-
+    
+	*resolutionType = kCCResolutioniPhone;
+    
+	return fullpath;
+    
+#endif // __CC_PLATFORM_MAC
+    
+    return nil;
 }
 
 +(NSString*) fullPathFromRelativePath:(NSString*) relPath
@@ -205,42 +217,49 @@ NSInteger ccLoadFileIntoMemory(const char *filename, unsigned char **out)
 	// quick return
 	if( ! suffix || [suffix length] == 0 )
 		return path;
-	
+    
 	NSString *name = [path lastPathComponent];
-	
+    
 	// check if path already has the suffix.
 	if( [name rangeOfString:suffix].location != NSNotFound ) {
-		
+        
 		CCLOGINFO(@"cocos2d: Filename(%@) contains %@ suffix. Removing it. See cocos2d issue #1040", path, suffix);
-		
+        
 		NSString *newLastname = [name stringByReplacingOccurrencesOfString:suffix withString:@""];
-		
+        
 		NSString *pathWithoutLastname = [path stringByDeletingLastPathComponent];
 		return [pathWithoutLastname stringByAppendingPathComponent:newLastname];
 	}
-	
+    
 	return path;
 }
 
 +(NSString*) removeSuffixFromFile:(NSString*) path
 {
 	NSString *ret = nil;
-	if( CC_CONTENT_SCALE_FACTOR() == 2 )
-		ret = [self removeSuffix:__suffixRetinaDisplay fromPath:path];
-	
-	else if( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
-		ret = [self removeSuffix:__suffixiPad fromPath:path];
-	
-	else 
-		ret = path;
+    
+	if( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad )
+	{
+		if( CC_CONTENT_SCALE_FACTOR() == 2 )
+			ret = [self removeSuffix:__suffixiPadRetinaDisplay fromPath:path];
+		else
+			ret = [self removeSuffix:__suffixiPad fromPath:path];		
+	}
+	else
+	{
+		if( CC_CONTENT_SCALE_FACTOR() == 2 )
+			ret = [self removeSuffix:__suffixiPhoneRetinaDisplay fromPath:path];
+		else
+			ret = path;
+	}
 	
 	return ret;
 }
 
-+(void) setRetinaDisplaySuffix:(NSString*)suffix
++(void) setiPhoneRetinaDisplaySuffix:(NSString*)suffix
 {
-	[__suffixRetinaDisplay release];
-	__suffixRetinaDisplay = [suffix copy];
+	[__suffixiPhoneRetinaDisplay release];
+	__suffixiPhoneRetinaDisplay = [suffix copy];
 }
 
 +(void) setiPadSuffix:(NSString*)suffix
@@ -249,28 +268,39 @@ NSInteger ccLoadFileIntoMemory(const char *filename, unsigned char **out)
 	__suffixiPad = [suffix copy];
 }
 
++(void) setiPadRetinaDisplaySuffix:(NSString*)suffix
+{
+	[__suffixiPadRetinaDisplay release];
+	__suffixiPadRetinaDisplay = [suffix copy];
+}
+
 +(BOOL) fileExistsAtPath:(NSString*)relPath withSuffix:(NSString*)suffix
 {
 	NSString *fullpath = nil;
-
+    
 	// only if it is not an absolute path
 	if( ! [relPath isAbsolutePath] ) {
 		// pathForResource also searches in .lproj directories. issue #1230
 		NSString *file = [relPath lastPathComponent];
 		NSString *imageDirectory = [relPath stringByDeletingLastPathComponent];
-		
+        
 		fullpath = [[NSBundle mainBundle] pathForResource:file
 												   ofType:nil
 											  inDirectory:imageDirectory];
-		
+        
 	}
-	
+    
 	if (fullpath == nil)
 		fullpath = relPath;
-
+    
 	NSString *path = [self getPath:fullpath forSuffix:suffix];
-	
+    
 	return ( path != nil );
+}
+
++(BOOL) iPhoneRetinaDisplayFileExistsAtPath:(NSString*)path
+{
+	return [self fileExistsAtPath:path withSuffix:__suffixiPhoneRetinaDisplay];
 }
 
 +(BOOL) iPadFileExistsAtPath:(NSString*)path
@@ -278,12 +308,13 @@ NSInteger ccLoadFileIntoMemory(const char *filename, unsigned char **out)
 	return [self fileExistsAtPath:path withSuffix:__suffixiPad];
 }
 
-+(BOOL) retinaDisplayFileExistsAtPath:(NSString*)path
++(BOOL) iPadRetinaDisplayFileExistsAtPath:(NSString*)path
 {
-	return [self fileExistsAtPath:path withSuffix:__suffixRetinaDisplay];
+	return [self fileExistsAtPath:path withSuffix:__suffixiPadRetinaDisplay];
 }
 
-#endif // __IPHONE_OS_VERSION_MAX_ALLOWED
+
+#endif //  __IPHONE_OS_VERSION_MAX_ALLOWED
 
 
 @end

--- a/cocos2d/Support/ccCArray.h
+++ b/cocos2d/Support/ccCArray.h
@@ -21,7 +21,7 @@
 
 /** 
  @file
- Based on Chipmunk cpArray.
+ arrd on Chipmunk cpArray.
  ccArray is a faster alternative to NSMutableArray, it does pretty much the
  same thing (stores NSObjects and retains/releases them appropriately). It's
  faster because:
@@ -44,7 +44,6 @@
 #import <string.h>
 
 #import "../ccMacros.h"
-
 
 #pragma mark -
 #pragma mark ccArray for Objects
@@ -291,6 +290,15 @@ static inline void ccArrayMakeObjectsPerformSelectorWithObject(ccArray *arr, SEL
 #pragma clang diagnostic pop
 }
 
+static inline void ccArrayMakeObjectPerformSelectorWithArrayObjects(ccArray *arr, SEL sel, id object)
+{
+	for( NSUInteger i = 0; i < arr->num; i++)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+		[object performSelector:sel withObject:arr->arr[i]];
+#pragma clang diagnostic pop
+}
+
 
 #pragma mark -
 #pragma mark ccCArray for Values (c structures)
@@ -339,7 +347,7 @@ static inline void ccCArrayEnsureExtraCapacity(ccCArray *arr, NSUInteger extra)
 static inline NSUInteger ccCArrayGetIndexOfValue(ccCArray *arr, CCARRAY_ID value)
 {
 	for( NSUInteger i = 0; i < arr->num; i++)
-		if( arr->arr[i] == value ) return i;
+		if( [arr->arr[i] isEqual:value] ) return i;
 	return NSNotFound;
 }
 
@@ -457,4 +465,90 @@ static inline void ccCArrayFullRemoveArray(ccCArray *arr, ccCArray *minusArr)
 	
 	arr->num -= back;
 }
+
+//used by mergesortL
+static inline void pointerswap(void* a, void* b, size_t width)
+{
+    void* tmp;
+    tmp = *(void**)a;
+    *(void**)a = *(void**)b;
+    *(void**)b = tmp;
+}
+
+// iterative mergesort arrd on
+//  http://www.inf.fh-flensburg.de/lang/algorithmen/sortieren/merge/mergiter.htm  
+static inline int mergesortL(ccCArray* array, size_t width, int (*compar)(const void *, const void *))
+{
+    CCARRAY_ID *arr = array->arr; 
+    NSInteger i,j,k,s,m,n= array->num; 
+    
+    CCARRAY_ID *B = (CCARRAY_ID*) malloc((n/2 + 1) * width);
+    for (s = 1; s < n; s += s) 
+    {
+        for (m = n-1-s; m >= 0; m -= s+s)
+        {
+            NSInteger lo = MAX(m-(s+1),0); 
+            NSInteger hi = m+s; 
+            
+            j = lo;
+
+            if (m-j > 0)
+            {
+                memcpy(B, &arr[j], (m-j) * width);
+            }
+            
+            i = 0;
+            j = m;
+            k = lo; 
+            
+            while (k<j  && j <= hi) 
+            {
+                if (compar(&B[i],&arr[j]) <= 0)
+                {    
+                    pointerswap(&arr[k++],&B[i++], width);
+                }
+             
+                else 
+                {    
+                   pointerswap(&arr[k++],&arr[j++], width);
+                }
+            }
+            
+            while (k<j)
+                pointerswap(&arr[k++],&B[i++],width);
+        }
+    }
+   	free(B);
+	return 0;
+}
+
+static inline void insertionSort(ccCArray* arr, int (*comparator)(const void *, const void *))
+{
+    // It sorts source array in ascending order
+	
+	// adaptive - performance adapts to the initial order of elements
+	// stable - insertion sort retains relative order of the same elements
+	// in-place - requires constant amount of additional space
+	// online - new elements can be added during the sort
+	
+	NSInteger i,j,length = arr->num;
+	
+	CCARRAY_ID *x = arr->arr;
+	id temp;	
+    
+	// insertion sort
+	for(i=1; i<length; i++)
+	{
+		j = i;
+		//continue moving element downwards while order is descending 
+		while( j>0 && ( comparator(  &x[j-1],  &x[j]  ) == NSOrderedDescending) )
+		{
+			temp = x[j];
+			x[j] = x[j-1];
+			x[j-1] = temp;
+			j--;
+		}
+	}
+}
+
 #endif // CC_ARRAY_H

--- a/cocos2d/ccTypes.h
+++ b/cocos2d/ccTypes.h
@@ -290,15 +290,17 @@ typedef struct _ccBlendFunc
 //! ccResolutionType
 typedef enum
 {
-	//! Unknonw resolution type
-	kCCResolutionUnknown,
-	//! standard (iphone) resolution type
-	kCCResolutionStandard,
-	//! RetinaDisplay resolution type
-	kCCResolutionRetinaDisplay,
-	//! iPad resolution type
-	kCCResolutioniPad,
-	
+    //! Unknonw resolution type
+    kCCResolutionUnknown,
+    //! iPhone resolution type
+    kCCResolutioniPhone,
+    //! RetinaDisplay resolution type
+    kCCResolutioniPhoneRetinaDisplay,
+    //! iPad resolution type
+    kCCResolutioniPad,
+    //! iPad Retina Display resolution type
+    kCCResolutioniPadRetinaDisplay,
+    
 } ccResolutionType;
 
 //! delta time type

--- a/cocos2d/cocos2d.m
+++ b/cocos2d/cocos2d.m
@@ -26,7 +26,7 @@
 
 #import <Foundation/Foundation.h>
 #import "cocos2d.h"
-static NSString *version = @"cocos2d v1.1.0-pre";
+static NSString *version = @"cocos2d v1.1.0-beta2b";
 
 NSString *cocos2dVersion()
 {	

--- a/cocoslive/CLScoreServerRequest.m
+++ b/cocoslive/CLScoreServerRequest.m
@@ -31,7 +31,7 @@
 // local imports
 #import "CLScoreServerPost.h"
 #import "CLScoreServerRequest.h"
-#import "ccMacros.h"
+#import "../cocos2d/ccMacros.h"
 
 @implementation CLScoreServerRequest
 

--- a/tests/ActionManagerTest.m
+++ b/tests/ActionManagerTest.m
@@ -384,10 +384,11 @@ Class restartAction()
 	if( ! [director enableRetinaDisplay:YES] )
 		CCLOG(@"Retina Display Not supported");
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+    // If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+    [CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"]; // Default on iPhone RetinaDisplay is "-hd"
+    [CCFileUtils setiPadSuffix:@"-ipad"]; // Default on iPad is "" (empty string)
+    [CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"]; // Default on iPad RetinaDisplay is "-ipadhd"
 
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/ActionsTest.m
+++ b/tests/ActionsTest.m
@@ -1212,10 +1212,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/Box2dTest.mm
+++ b/tests/Box2dTest.mm
@@ -278,10 +278,11 @@ enum {
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	// add layer
 	CCScene *scene = [CCScene node];

--- a/tests/ChipmunkAccelTouchTest.m
+++ b/tests/ChipmunkAccelTouchTest.m
@@ -212,10 +212,11 @@ eachShape(void *ptr, void* unused)
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	// add layer
 	CCScene *scene = [CCScene node];

--- a/tests/ClickAndMoveTest.m
+++ b/tests/ClickAndMoveTest.m
@@ -117,10 +117,11 @@ enum
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+    // When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	MainLayer * mainLayer =[MainLayer node];	

--- a/tests/DirectorTest.m
+++ b/tests/DirectorTest.m
@@ -281,11 +281,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
-	
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"	
 	// Assume that PVR images have premultiplied alpha
 	[CCTexture2D PVRImagesHavePremultipliedAlpha:YES];
 	

--- a/tests/EaseActionsTest.m
+++ b/tests/EaseActionsTest.m
@@ -789,10 +789,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];	

--- a/tests/EffectsAdvancedTest.m
+++ b/tests/EffectsAdvancedTest.m
@@ -402,10 +402,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/EffectsTest.m
+++ b/tests/EffectsTest.m
@@ -508,10 +508,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [TextLayer node] z:0 tag:kTagTextLayer];

--- a/tests/FontTest.m
+++ b/tests/FontTest.m
@@ -171,10 +171,11 @@ NSString* restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [FontTest node]];

--- a/tests/HiResTest.m
+++ b/tests/HiResTest.m
@@ -265,10 +265,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];	
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+    // When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	// create the main scene
 	CCScene *scene = [CCScene node];

--- a/tests/IntervalTest.m
+++ b/tests/IntervalTest.m
@@ -159,10 +159,11 @@
 	if( ! [director enableRetinaDisplay:YES] )
 		CCLOG(@"Retina Display Not supported");
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	// Turn on display FPS
 	[director setDisplayFPS:YES];

--- a/tests/LabelTest.m
+++ b/tests/LabelTest.m
@@ -1130,10 +1130,11 @@ Class restartAction()
 	// set FPS at 60
 	[director setAnimationInterval:1.0/60];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	// Turn on display FPS
 	[director setDisplayFPS:YES];

--- a/tests/LayerTest.m
+++ b/tests/LayerTest.m
@@ -408,10 +408,11 @@ Class restartAction()
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	[director runWithScene: scene];
 }

--- a/tests/MenuTest.m
+++ b/tests/MenuTest.m
@@ -503,10 +503,11 @@ enum {
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 
 	CCScene *scene = [CCScene node];
 

--- a/tests/MotionStreakTest.m
+++ b/tests/MotionStreakTest.m
@@ -235,10 +235,11 @@ Class restartAction()
 	if( ! [director enableRetinaDisplay:YES] )
 		CCLOG(@"Retina Display Not supported");
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/ParallaxTest.m
+++ b/tests/ParallaxTest.m
@@ -342,10 +342,11 @@ Class restartAction()
 	if( ! [director enableRetinaDisplay:YES] )
 		CCLOG(@"Retina Display Not supported");
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/ParticleTest.m
+++ b/tests/ParticleTest.m
@@ -1539,10 +1539,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/ParticleTestBatched.m
+++ b/tests/ParticleTestBatched.m
@@ -2093,10 +2093,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/PerformanceTests/PerformanceDispatcherTest/AppController.h
+++ b/tests/PerformanceTests/PerformanceDispatcherTest/AppController.h
@@ -1,0 +1,12 @@
+//
+// cocos2d performance dispatcher test
+// Based on the test by Valentin Milea
+//
+#import <UIKit/UIKit.h>
+
+@interface AppController
+: NSObject <UIApplicationDelegate> {
+    UIWindow *window;
+}
+
+@end

--- a/tests/PerformanceTests/PerformanceDispatcherTest/AppController.m
+++ b/tests/PerformanceTests/PerformanceDispatcherTest/AppController.m
@@ -1,0 +1,98 @@
+//
+// cocos2d performance dispatcher test
+// Based on the test by Valentin Milea
+//
+
+#import "AppController.h"
+#import "cocos2d.h"
+#import "PerformanceDispatcher.h"
+
+@implementation AppController
+
+- (void)applicationDidFinishLaunching:(UIApplication *)application
+{
+	// Init the window
+	window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+	
+	// must be called before any othe call to the director
+	if( ! [CCDirector setDirectorType:kCCDirectorTypeDisplayLink] )
+		[CCDirector setDirectorType:kCCDirectorTypeMainLoop];
+	
+	// get instance of the shared director
+	CCDirector *director = [CCDirector sharedDirector];
+	
+	// before creating any layer, set the landscape mode
+	[director setDeviceOrientation:kCCDeviceOrientationLandscapeLeft];
+	
+	// display FPS (useful when debugging)
+	[director setDisplayFPS:YES];
+	
+	// frames per second
+	[director setAnimationInterval:1.0/60];
+	
+	// create an OpenGL view
+	EAGLView *glView = [EAGLView viewWithFrame:[window bounds]];
+	
+	// connect it to the director
+	[director setOpenGLView:glView];
+	
+	// Enables High Res mode (Retina Display) on iPhone 4 and maintains low res on all other devices
+	if( ! [director enableRetinaDisplay:YES] )
+		CCLOG(@"Retina Display Not supported");
+	
+	// glview is a child of the main window
+	[window addSubview:glView];
+	
+	// Make the window visible
+	[window makeKeyAndVisible];
+	
+	CCScene *scene = [CCScene node];
+	[scene addChild: [nextAction() testWithQuantityOfNodes:kNodesIncrease]];
+	
+	[director runWithScene:scene];
+}
+
+- (void)dealloc {
+	[window release];
+	[super dealloc];
+}
+
+// getting a call, pause the game
+-(void) applicationWillResignActive:(UIApplication *)application
+{
+	[[CCDirector sharedDirector] pause];
+}
+
+// call got rejected
+-(void) applicationDidBecomeActive:(UIApplication *)application
+{
+	[[CCDirector sharedDirector] resume];
+}
+
+-(void) applicationDidEnterBackground:(UIApplication*)application
+{
+	[[CCDirector sharedDirector] stopAnimation];
+}
+
+-(void) applicationWillEnterForeground:(UIApplication*)application
+{
+	[[CCDirector sharedDirector] startAnimation];
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{	
+	[[CCDirector sharedDirector] end];
+}
+
+// purge memory
+- (void)applicationDidReceiveMemoryWarning:(UIApplication *)application {
+	[[CCDirector sharedDirector] purgeCachedData];
+}
+
+// next delta time will be zero
+-(void) applicationSignificantTimeChange:(UIApplication *)application
+{
+	[[CCDirector sharedDirector] setNextDeltaTimeZero:YES];
+}
+
+@end

--- a/tests/PerformanceTests/PerformanceDispatcherTest/PerformanceDispatcher.h
+++ b/tests/PerformanceTests/PerformanceDispatcherTest/PerformanceDispatcher.h
@@ -1,0 +1,201 @@
+//
+// cocos2d performance dispatcher test by 'cocos'
+// Based on the test by Valentin Milea
+// Based on the Children Node Performance by 'araker'
+//
+
+#import "cocos2d.h"
+
+Class nextAction();
+
+@class CCProfilingTimer;
+
+enum {
+	kMaxNodes = 15000,
+	kNodesIncrease = 200,
+};
+
+@interface MainScene : CCScene {
+	int			lastRenderedCount;
+	int			quantityOfNodes;
+	int			currentQuantityOfNodes;
+	
+}
+
++(id) testWithQuantityOfNodes:(unsigned int)nodes;
+-(id) initWithQuantityOfNodes:(unsigned int)nodes;
+-(NSString*) title;
+-(NSString*) subtitle;
+
+-(void) onIncrease:(id) sender;
+-(void) onDecrease:(id) sender;
+
+-(void) updateQuantityLabel;
+-(void) updateQuantityOfNodes;
+
+@end
+
+
+@interface SGSprite : CCSprite <CCTargetedTouchDelegate,CCStandardTouchDelegate> 
+{	
+}
+-(id) init;
+@end
+
+
+//			ONLY OLD API
+
+@interface IterateSpriteSheet : MainScene
+{
+	CCSpriteBatchNode	*batchNode;
+	CCProfilingTimer* _profilingTimer;
+}
+-(NSString*) profilerName;
+@end
+
+@interface AddingDelegatesTypical : IterateSpriteSheet   //0
+{}
+@end
+
+@interface AddingDelegates : IterateSpriteSheet   //1
+{}
+@end
+
+@interface RemovingDelegates : IterateSpriteSheet  //2
+{}
+@end
+
+@interface AddRemoveSpriteSheet : MainScene
+{
+	CCSpriteBatchNode	*batchNode;
+	CCProfilingTimer* _profilingTimer;
+}
+-(NSString*) profilerName;
+@end
+
+@interface AddRandomPriorityDelegates : AddRemoveSpriteSheet //3
+{}
+@end
+
+@interface RemoveDelegatesWithRandomPriority : AddRemoveSpriteSheet //4
+{}
+@end
+
+@interface ReorderDelegates : AddRemoveSpriteSheet //5
+{}
+@end
+
+//				NEW (and old) API
+
+@interface FastAdd : AddRemoveSpriteSheet //1a
+{}
+@end
+
+@interface FastRemoval : AddRemoveSpriteSheet //2a
+{}
+@end
+
+@interface FastCompoundRemoval : AddRemoveSpriteSheet // 2b
+{}
+@end
+
+@interface ReorderingOneByOneQSORT : AddRemoveSpriteSheet  // 5a
+{}
+@end
+
+@interface ReorderingOneByOneMERGESORT : AddRemoveSpriteSheet  // 5b
+{}
+@end
+
+@interface UltraFastReordering : AddRemoveSpriteSheet  // 5c
+{}
+@end
+
+@interface BasicSpriteSheet : MainScene
+{
+	CCSpriteBatchNode	*batchNode;
+	CCProfilingTimer* _profilingTimer;
+}
+-(NSString*) profilerName;
+@end
+
+@interface Various : BasicSpriteSheet  // 6
+{}
+@end
+
+#if 0
+ SUMMARY OF TEST RESULTS FOR iPod 1gen iOS 3.1.3 (in debug mode)
+Test setup: 200 delegates (100 Standard delegates and 100 targeted delegates)
+//  NSArray OLD API
+0-Adding delegates-typical  (0x00222020) : avg time, 41.871648ms
+0-Adding delegates-typical  (0x00222020) : avg time, 42.388987ms
+0-Adding delegates-typical  (0x00222020) : avg time, 42.211356ms
+1-Adding delegates (0x0025a7b0) : avg time, 38.335520ms
+1-Adding delegates (0x0025a7b0) : avg time, 38.474818ms
+1-Adding delegates (0x0025a7b0) : avg time, 38.628836ms
+2-Removing delegates (0x00218160) : avg time, 31.570366ms
+2-Removing delegates (0x00218160) : avg time, 31.573528ms
+2-Removing delegates (0x00218160) : avg time, 31.610793ms
+3- Add delegates with RANDOM priority (0x002399c0) : avg time, 40.152800ms
+3- Add delegates with RANDOM priority (0x002399c0) : avg time, 40.811739ms
+3- Add delegates with RANDOM priority (0x002399c0) : avg time, 40.993834ms
+4 - Delete delegates with RANDOM priority (0x00242ca0) : avg time, 32.034090ms
+4 - Delete delegates with RANDOM priority (0x00242ca0) : avg time, 31.269717ms
+4 - Delete delegates with RANDOM priority (0x00242ca0) : avg time, 31.321482ms
+5 - Reorder delegates NSMutableASort/InsertSort (0x0025a230) : avg time, 223.752753ms
+5 - Reorder delegates NSMutableASort/InsertSort (0x0025a230) : avg time, 221.252547ms
+5 - Reorder delegates NSMutableASort/InsertSort (0x0025a230) : avg time, 222.701722ms
+
+//  CCArray new files servicing OLD API
+0-Adding delegates-typical  (0x00222340) : avg time, 40.552564ms
+0-Adding delegates-typical  (0x00222340) : avg time, 40.209269ms
+0-Adding delegates-typical  (0x00222340) : avg time, 39.789110ms
+// speed gain:		about 5.25%  TYPICAL
+1-Adding delegates (0x0022cb90) : avg time, 39.056501ms
+1-Adding delegates (0x0022cb90) : avg time, 39.337446ms
+1-Adding delegates (0x0022cb90) : avg time, 39.305130ms
+// speed gain		about -1.9% WORST CASE
+2-Removing delegates (0x00222750) : avg time, 19.787355ms
+2-Removing delegates (0x00222750) : avg time, 19.466457ms
+2-Removing delegates (0x00222750) : avg time, 19.690112ms
+// speed gain        62% 
+3- Add delegates with RANDOM priority (0x00237720) : avg time, 40.726427ms
+3- Add delegates with RANDOM priority (0x00237720) : avg time, 41.668953ms
+3- Add delegates with RANDOM priority (0x00237720) : avg time, 40.969164ms
+// speed gain		about -1.4%
+4 - Delete delegates with RANDOM priority (0x00222340) : avg time, 21.059382ms
+4 - Delete delegates with RANDOM priority (0x00222340) : avg time, 20.993250ms
+4 - Delete delegates with RANDOM priority (0x00222340) : avg time, 20.890169ms
+// speed gain         49.6% 
+5 - Reorder delegates NSMutableASort/InsertSort (0x00237720) : avg time, 59.239157ms
+5 - Reorder delegates NSMutableASort/InsertSort (0x00237720) : avg time, 59.061102ms
+5 - Reorder delegates NSMutableASort/InsertSort (0x00237720) : avg time, 59.396493ms
+// speed gain        275%
+
+// ADVENTAGE OF NEW API
+
+1 a - FAST ADD (0x0023cd00) : avg time, 33.023032ms
+1 a - FAST ADD (0x0023cd00) : avg time, 32.198968ms
+1 a - FAST ADD (0x0023cd00) : avg time, 31.350551ms
+//  SPEED GAIN	 > 33.0%
+2a FAST REMOVAL (0x002564c0) : avg time, 1.504204ms
+2a FAST REMOVAL (0x002564c0) : avg time, 1.578540ms
+2a FAST REMOVAL (0x002564c0) : avg time, 1.489650ms
+// SPEED GAIN	 > 1500% 
+2b Fast Compound removal (0x0024c260) : avg time, 1.958303ms
+2b Fast Compound removal (0x0024c260) : avg time, 2.066753ms
+2b Fast Compound removal (0x0024c260) : avg time, 2.045931ms
+// SPEED GAIN	> 1500%
+5a QSort (0x002564c0) : avg time, 134.083539ms
+5a QSort (0x002564c0) : avg time, 134.018829ms
+5a QSort (0x002564c0) : avg time, 134.094870ms
+// SPEED GAIN	> 65%
+5b MSort (0x0023cd00) : avg time, 149.510898ms
+5b MSort (0x0023cd00) : avg time, 149.723841ms
+5b MSort (0x0023cd00) : avg time, 150.293651ms
+// SPEED GAIN	> 45%
+5c UltraFast(delayed)Reordering (0x002222c0) : avg time, 24.026498ms
+5c UltraFast(delayed)Reordering (0x002222c0) : avg time, 23.920655ms
+5c UltraFast(delayed)Reordering (0x002222c0) : avg time, 24.230325ms
+// SPEED GAIN	> 820% 
+#endif

--- a/tests/PerformanceTests/PerformanceDispatcherTest/PerformanceDispatcher.h
+++ b/tests/PerformanceTests/PerformanceDispatcherTest/PerformanceDispatcher.h
@@ -6,13 +6,18 @@
 
 #import "cocos2d.h"
 
-Class nextAction();
+//run this in release mode to see the timings clearly
+
+Class nextAction(void);
+Class backAction(void);
+Class restartAction(void);
+int myComparatorArg(const void * first, const void * second);
 
 @class CCProfilingTimer;
 
 enum {
 	kMaxNodes = 15000,
-	kNodesIncrease = 200,
+	kNodesIncrease = 20,
 };
 
 @interface MainScene : CCScene {
@@ -34,7 +39,6 @@ enum {
 -(void) updateQuantityOfNodes;
 
 @end
-
 
 @interface SGSprite : CCSprite <CCTargetedTouchDelegate,CCStandardTouchDelegate> 
 {	

--- a/tests/PerformanceTests/PerformanceDispatcherTest/PerformanceDispatcher.m
+++ b/tests/PerformanceTests/PerformanceDispatcherTest/PerformanceDispatcher.m
@@ -1,0 +1,1823 @@
+//
+// cocos2d dispatcher performance test - by 'cocos'
+// Based on the Children Node Performance Test by 'araker'
+
+#import "cocos2d.h"
+
+#if ! CC_ENABLE_PROFILERS
+#error CC_ENABLE_PROFILERS must be enabled. Edit ccConfig.h
+#endif
+
+#import "PerformanceDispatcher.h"
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define  COMPILE_FOR_NEW_API                    1	// USE 0 TO COMPILE WITH 4 OLD FILES FOR OLD API
+													// To compare SPEED of NEW AND OLD API 
+													// keep 0 and swap old files for new ones!
+													// files to be swaped: CCTouchDispatcher.m/.h
+													//					   CCTouchHandler.m/.h
+													
+													// USE 1 TO COMPILE WITH 4 NEW FILES FOR NEW API 
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+
+enum {
+	kTagInfoLayer = 1,
+	kTagMainLayer = 2,
+	kTagLabelAtlas = 3,
+	
+	kTagBase = 20000,
+	kTagMenu = 10000,
+};
+
+static int sceneIdx=-1;
+
+
+static NSString *transitions[] = {
+		// ONLY OLD API used:
+		@"AddingDelegatesTypical",	
+		@"AddingDelegates",						// 1 Adding standard/targeted delegates to the touch dispatcher
+		@"RemovingDelegates",					// 2 .Removing delegates from the touch dispatcher 
+		@"AddRandomPriorityDelegates",		    // 3.
+		@"RemoveDelegatesWithRandomPriority",	// 4
+		@"ReorderDelegates",					// 5 - slow one by one via standard sort alg
+		// NEW and OLD API
+#if  COMPILE_FOR_NEW_API 	
+		@"FastAdd",								// 1.a 
+		@"FastRemoval",							// 2.a
+		@"FastCompoundRemoval",					// 2.b
+		@"ReorderingOneByOneQSORT",				// 5a slow old api with new sorting algorithm 
+		@"ReorderingOneByOneMERGESORT",			// 5b slow old api with new sorting algorithm 
+		@"UltraFastReordering",					// 5c new api with new sorting algorithm 
+		@"Various",								// 6	
+#endif	
+};
+
+Class nextAction()
+{	
+	sceneIdx++;
+	sceneIdx = sceneIdx % ( sizeof(transitions) / sizeof(transitions[0]) );
+	NSString *r = transitions[sceneIdx];
+	Class c = NSClassFromString(r);
+	return c;
+}
+
+Class backAction()
+{
+	sceneIdx--;
+	int total = ( sizeof(transitions) / sizeof(transitions[0]) );
+	if( sceneIdx < 0 )
+		sceneIdx += total;	
+	
+	NSString *r = transitions[sceneIdx];
+	Class c = NSClassFromString(r);
+	return c;
+}
+
+Class restartAction()
+{
+	NSString *r = transitions[sceneIdx];
+	Class c = NSClassFromString(r);
+	return c;
+}
+
+#pragma mark SGSprite
+
+@implementation SGSprite
+
+-(id) init
+{
+	if((self=[super init])){		
+	}
+	return self;
+}
+
+- (void) dealloc
+{
+	[super dealloc];
+}
+
+// standard
+// optional
+- (void)ccTouchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
+{
+}
+- (void)ccTouchesMoved:(NSSet *)touches withEvent:(UIEvent *)event{
+}
+- (void)ccTouchesEnded:(NSSet *)touches withEvent:(UIEvent *)event{
+}
+- (void)ccTouchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event{
+}
+// targeted
+- (BOOL)ccTouchBegan:(UITouch *)touch withEvent:(UIEvent *)event{
+	return NO;
+}
+//optional
+- (void)ccTouchMoved:(UITouch *)touch withEvent:(UIEvent *)event{}
+- (void)ccTouchEnded:(UITouch *)touch withEvent:(UIEvent *)event{}
+- (void)ccTouchCancelled:(UITouch *)touch withEvent:(UIEvent *)event{}
+@end
+
+/////
+
+#pragma mark MainScene
+
+@implementation MainScene
+
++(id) testWithQuantityOfNodes:(unsigned int)nodes
+{
+	return [[[self alloc] initWithQuantityOfNodes:nodes] autorelease];
+}
+
+- (id)initWithQuantityOfNodes:(unsigned int)nodes
+{
+	if ((self = [super init])) {
+		
+		srandom(0);
+		
+		CGSize s = [[CCDirector sharedDirector] winSize];
+		
+		// Title
+		CCLabelTTF *label = [CCLabelTTF labelWithString:[self title] fontName:@"Arial" fontSize:30];
+		[self addChild:label z:1];
+		[label setPosition: ccp(s.width/2, s.height-32)];
+		[label setColor:ccc3(255,255,40)];
+		
+		// Subtitle
+		NSString *subtitle = [self subtitle];
+		if( subtitle ) {
+			CCLabelTTF *l = [CCLabelTTF labelWithString:subtitle fontName:@"Thonburi" fontSize:16];
+			[self addChild:l z:1];
+			[l setPosition:ccp(s.width/2, s.height-80)];
+		}
+
+		lastRenderedCount = 0;
+		currentQuantityOfNodes = 0;
+		quantityOfNodes = nodes;
+
+		[CCMenuItemFont setFontSize:65];
+		CCMenuItemFont *decrease = [CCMenuItemFont itemFromString: @" - " target:self selector:@selector(onDecrease:)];
+		[decrease.label setColor:ccc3(0,200,20)];
+		CCMenuItemFont *increase = [CCMenuItemFont itemFromString: @" + " target:self selector:@selector(onIncrease:)];
+		[increase.label setColor:ccc3(0,200,20)];
+		
+		CCMenu *menu = [CCMenu menuWithItems: decrease, increase, nil];
+		[menu alignItemsHorizontally];
+		menu.position = ccp(s.width/2, s.height/2+15);
+		[self addChild:menu z:1	tag:kTagMenu];
+		
+		CCLabelTTF *infoLabel = [CCLabelTTF labelWithString:@"0 handlers" fontName:@"Marker Felt" fontSize:30];
+		[infoLabel setColor:ccc3(0,200,20)];
+		infoLabel.position = ccp(s.width/2, s.height/2-15);
+		[self addChild:infoLabel z:1 tag:kTagInfoLayer];
+		
+		
+		// Next Prev Test
+		CCMenuItemImage *item1 = [CCMenuItemImage itemFromNormalImage:@"b1.png" selectedImage:@"b2.png" target:self selector:@selector(backCallback:)];
+		CCMenuItemImage *item2 = [CCMenuItemImage itemFromNormalImage:@"r1.png" selectedImage:@"r2.png" target:self selector:@selector(restartCallback:)];
+		CCMenuItemImage *item3 = [CCMenuItemImage itemFromNormalImage:@"f1.png" selectedImage:@"f2.png" target:self selector:@selector(nextCallback:)];
+		menu = [CCMenu menuWithItems:item1, item2, item3, nil];
+		[menu alignItemsHorizontally];
+		menu.position = ccp(s.width/2, 30);
+		[self addChild: menu z:1];	
+		
+
+		[self updateQuantityLabel];
+		[self updateQuantityOfNodes];		
+	}
+	
+	return self;
+}
+
+-(NSString*) title
+{
+	return @"No title";
+}
+
+-(NSString*) subtitle
+{
+	return @"No subtitle";
+}
+
+-(void) dealloc
+{
+	[super dealloc];
+}
+
+-(void) restartCallback: (id) sender
+{
+	CCScene *s = [CCScene node];
+	id scene = [restartAction() testWithQuantityOfNodes:quantityOfNodes];
+	[s addChild:scene];
+
+	[[CCDirector sharedDirector] replaceScene: s];
+}
+
+-(void) nextCallback: (id) sender
+{
+	CCScene *s = [CCScene node];
+	id scene = [nextAction() testWithQuantityOfNodes:quantityOfNodes];
+	[s addChild:scene];
+	[[CCDirector sharedDirector] replaceScene: s];
+}
+
+-(void) backCallback: (id) sender
+{
+	CCScene *s = [CCScene node];
+	id scene = [backAction() testWithQuantityOfNodes:quantityOfNodes];
+	[s addChild:scene];
+
+	[[CCDirector sharedDirector] replaceScene: s];
+}
+
+
+-(void) onIncrease:(id) sender
+{
+	quantityOfNodes += kNodesIncrease;
+	if( quantityOfNodes > kMaxNodes )
+		quantityOfNodes = kMaxNodes;
+
+	[self updateQuantityLabel];
+	[self updateQuantityOfNodes];
+}
+
+-(void) onDecrease:(id) sender
+{
+	quantityOfNodes -= kNodesIncrease;
+	if( quantityOfNodes < 0 )
+		quantityOfNodes = 0;
+	
+	[self updateQuantityLabel];
+	[self updateQuantityOfNodes];
+}
+
+- (void)updateQuantityLabel
+{
+	if( quantityOfNodes != lastRenderedCount ) {
+		
+		CCLabelTTF *infoLabel = (CCLabelTTF *) [self getChildByTag:kTagInfoLayer];
+		[infoLabel setString: [NSString stringWithFormat:@"%u handlers", quantityOfNodes] ];
+		
+		lastRenderedCount = quantityOfNodes;
+	}
+}
+
+-(void) updateQuantityOfNodes
+{
+	// override me
+}
+
+@end
+
+////
+
+#pragma mark -
+#pragma mark IterateSpriteSheet
+
+@implementation IterateSpriteSheet
+
+
+
+- (void) testCallback:(id)sender
+{
+	
+   // OLD FILES HAVE PROBLEM - this callback will crash	
+
+	SGSprite *sprite = [SGSprite spriteWithTexture:[batchNode texture] rect:CGRectMake(0, 0, 32, 32)];		
+	
+	CCLOG(@"testing callback - start");
+	
+// Add delegate 
+	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-10];	
+	
+// Change priority	
+	[[CCTouchDispatcher sharedDispatcher] setPriority:10 forDelegate:sprite];	
+	
+// Remove delegate
+	[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];	
+	
+// Add delegate 
+	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-20];	
+		
+// Remove delegate 
+	[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];		
+	
+// Remove delegate 	// legal should be considered NOP
+	[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];		
+	
+// Add delegate 
+	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-30];		
+	
+// Change priority of the delegate 
+	[[CCTouchDispatcher sharedDispatcher] setPriority:20 forDelegate:sprite];	
+	[[CCTouchDispatcher sharedDispatcher] setPriority:30 forDelegate:sprite];
+		
+// remove it 	
+	[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];
+// nothing added as a result.	
+	
+#if  COMPILE_FOR_NEW_API 		
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)]){	
+		//	print all sprite delagates - all should be marked for removed
+		CCLOG(@" Callback Log: all added sprites should be marked for removal");
+		[[CCTouchDispatcher sharedDispatcher] setField:kCCDebug newValue:1 delegate:sprite type:kCCStandard];	
+	}
+#endif	
+	
+	CCLOG(@"testing callback - end");	
+}
+
+- (id)initWithQuantityOfNodes:(unsigned int)nodes
+{
+	batchNode = [CCSpriteBatchNode batchNodeWithFile:@"spritesheet1.png" capacity:200];
+
+	if( ( self=[super initWithQuantityOfNodes:nodes]) ) {
+	
+		_profilingTimer = [[CCProfiler timerWithName:[self profilerName] andInstance:self] retain];
+
+		[self addChild:batchNode];
+		
+		//--- Button to test callback processing -----
+		CGSize s = [[CCDirector sharedDirector] winSize];
+		[CCMenuItemFont setFontSize:25];
+
+		CCMenuItemFont *testCallbackProcessing = [CCMenuItemFont itemFromString:@"CallBack - It should not crash" target:self selector:@selector(testCallback:)];
+		
+		[testCallbackProcessing.label setColor:ccc3(200,0,20)];
+		
+		CCMenu *menu = [CCMenu menuWithItems:testCallbackProcessing,nil];
+		menu.position = ccp(s.width/2, s.height/2-70);
+		[self addChild:menu];
+		//---------------------------------------------
+		
+		
+		[self scheduleUpdate];								
+		
+	}
+	
+	return self;
+}
+
+- (void) dealloc
+{
+	[CCProfiler releaseTimer:_profilingTimer];
+	[super dealloc];
+}
+
+-(void) updateQuantityOfNodes
+{
+	CGSize s = [[CCDirector sharedDirector] winSize];
+	// increase nodes
+	if( currentQuantityOfNodes < quantityOfNodes ) {
+		for(int i=0;i < (quantityOfNodes-currentQuantityOfNodes);i++) {
+			SGSprite *sprite = [SGSprite spriteWithTexture:[batchNode texture] rect:CGRectMake(0, 0, 32, 32)];
+			[batchNode addChild:sprite];
+			[sprite setVisible:NO];
+			[sprite setPosition:ccp( CCRANDOM_0_1()*s.width, CCRANDOM_0_1()*s.height)];
+		}
+	}
+		
+	// decrease nodes
+	else if ( currentQuantityOfNodes > quantityOfNodes ) {
+		for(int i=0;i < (currentQuantityOfNodes-quantityOfNodes);i++) {
+			int index = currentQuantityOfNodes-i-1;
+			[batchNode removeChildAtIndex:index cleanup:YES];
+		}
+
+	}
+	
+	currentQuantityOfNodes = quantityOfNodes;
+}
+
+-(NSString*) title
+{
+	return @"none";
+}
+-(NSString*) profilerName
+{
+	return @"none";
+}
+@end
+
+
+//// 0
+
+@implementation AddingDelegatesTypical
+
+-(void) update:(ccTime)dt
+{	
+	ccArray *array = batchNode.children->data;
+	int count = array->num;
+		
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING ADDING DELEGATES
+	for( int i=0; i < count; i++)
+	{
+		// THE TYPICAL CASE - SAME PRIORITY FOR ALL DELEGATES
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:array->arr[i] priority:0];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:array->arr[i] priority:0 swallowsTouches:YES];
+	}
+	CCProfilingEndTimingBlock(_profilingTimer); //----
+	
+	// remove them 
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];		
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];
+		else
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];
+	}
+}
+
+-(NSString*) title
+{
+	return @"0 - Adding delegates Typical";
+}
+-(NSString*) subtitle
+{
+	return @"Adding standard/targeted delegates. Typical case. See console";
+}
+-(NSString*) profilerName
+{
+	return @"0-Adding delegates-typical ";
+}
+
+@end
+
+
+//// 1
+
+@implementation AddingDelegates
+
+-(void) update:(ccTime)dt
+{	
+	ccArray *array = batchNode.children->data;
+
+	int count = array->num;
+	
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING ADDING DELEGATES
+	for( int i=0; i < count; i++)
+	{
+		// THE WORST CASE FOR CCARRAY (insering at the front of the ccarray)
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:array->arr[i]priority:count-i];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:array->arr[i] priority:count-i swallowsTouches:YES];
+	}
+	CCProfilingEndTimingBlock(_profilingTimer); //----
+	
+	// remove them 
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];		
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];
+		else
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];
+	}
+}
+
+-(NSString*) title
+{
+	return @"1 - Adding delegates";
+}
+-(NSString*) subtitle
+{
+	return @"Adding standard/targeted delegates. Bad case for CCArray. See console";
+}
+-(NSString*) profilerName
+{
+	return @"1-Adding delegates";
+}
+
+@end
+
+//// 2
+
+@implementation  RemovingDelegates
+
+-(void) update:(ccTime)dt
+{
+	ccArray *array = batchNode.children->data;
+
+	int count = array->num;
+	
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:count-i];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:sprite priority:count-i swallowsTouches:NO];
+	}
+	
+	// remove them - profiling removal of delegates
+	CCProfilingBeginTimingBlock(_profilingTimer); //---- PROFILING REMOVING DELEGATES
+	for( int i=0; i < array->num; i++)
+	{
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:array->arr[i]]; // type:kCCStandard
+		else
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:array->arr[i]]; // type:kCCTargeted
+	}
+	CCProfilingEndTimingBlock(_profilingTimer); //----
+}
+
+-(NSString*) title
+{
+	return @"2 - Removing delegates";
+}
+-(NSString*) subtitle
+{
+	return @"Removing delegates: 'removeDelegate:node' See console";
+}
+
+-(NSString*) profilerName
+{
+	return @"2-Removing delegates";
+}
+
+@end
+
+
+///
+
+#pragma mark -
+#pragma mark AddRemoveSpriteSheet
+
+@implementation AddRemoveSpriteSheet
+
+- (id)initWithQuantityOfNodes:(unsigned int)nodes
+{
+	batchNode = [CCSpriteBatchNode batchNodeWithFile:@"spritesheet1.png" capacity:200];
+	
+	if( ( self=[super initWithQuantityOfNodes:nodes]) ) {
+		
+		_profilingTimer = [[CCProfiler timerWithName:[self profilerName] andInstance:self] retain];
+		
+		[self addChild:batchNode];		
+		[self scheduleUpdate];
+	}
+	
+	return self;
+}
+
+- (void) dealloc
+{
+	[CCProfiler releaseTimer:_profilingTimer];
+	[super dealloc];
+}
+
+-(void) updateQuantityOfNodes
+{
+	CGSize s = [[CCDirector sharedDirector] winSize];
+	// increase nodes
+	if( currentQuantityOfNodes < quantityOfNodes ) {
+		for(int i=0;i < (quantityOfNodes-currentQuantityOfNodes);i++) {
+			SGSprite *sprite = [SGSprite spriteWithTexture:[batchNode texture] rect:CGRectMake(0, 0, 32, 32)];
+			[batchNode addChild:sprite];
+			[sprite setPosition:ccp( CCRANDOM_0_1()*s.width, CCRANDOM_0_1()*s.height)];
+			[sprite setVisible:NO];
+		}
+	}
+	
+	// decrease nodes
+	else if ( currentQuantityOfNodes > quantityOfNodes ) {
+		for(int i=0;i < (currentQuantityOfNodes-quantityOfNodes);i++) {
+			int index = currentQuantityOfNodes-i-1;
+			[batchNode removeChildAtIndex:index cleanup:YES];
+		}
+		
+	}
+	
+	currentQuantityOfNodes = quantityOfNodes;
+}
+
+-(NSString*) title
+{
+	return @"none";
+}
+-(NSString*) profilerName
+{
+	return @"none";
+}
+@end
+
+//// 3
+
+@implementation AddRandomPriorityDelegates
+
+-(void) update:(ccTime)dt
+{
+	// reset seed
+	srandom(0);
+	
+	ccArray *array = batchNode.children->data;
+	
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING ADDING DELEGATES
+	for( int i=0; i < array->num; i++)
+	{
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:array->arr[i] priority:/*array->num-i+*/ CCRANDOM_MINUS1_1() * 50];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:array->arr[i] priority:/*array->num-i+*/ CCRANDOM_MINUS1_1() * 50 swallowsTouches:YES];							
+	}
+	CCProfilingEndTimingBlock(_profilingTimer); //----
+	
+	// remove them 
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];
+		else
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];
+	}
+}
+
+-(NSString*) title
+{
+	return @"3. Add with RANDOM priority";
+}
+-(NSString*) subtitle
+{
+	return @"Adds sprites with random priority. See console";
+}
+-(NSString*) profilerName
+{
+	return @"3- Add delegates with RANDOM priority";
+}
+@end
+
+
+//// 4
+@implementation RemoveDelegatesWithRandomPriority
+-(void) update:(ccTime)dt
+{
+	// reset seed
+	srandom(0);
+		
+	ccArray *array = batchNode.children->data;
+		
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50 ];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50  swallowsTouches:YES];
+	}
+	
+	// remove them 
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING ADDING DELEGATES	
+	for( int i=0; i < array->num; i++)
+	{
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:array->arr[i]];
+		else
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:array->arr[i]];		
+	}	
+	CCProfilingEndTimingBlock(_profilingTimer); //----			
+}
+
+-(NSString*) title
+{
+	return @"4 - Delete (random priority)";
+}
+-(NSString*) subtitle
+{
+	return @"Remove sprites added with random priority. See console";
+}
+-(NSString*) profilerName
+{
+	return @"4 - Delete delegates with RANDOM priority";
+}
+@end
+
+
+
+//// 5
+@implementation ReorderDelegates
+-(void) update:(ccTime)dt
+{
+	// reset seed
+	srandom(0);
+	
+	ccArray *array = batchNode.children->data;
+	
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		[sprite setVisible:NO];
+		
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50 ];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50 swallowsTouches:YES];
+	}
+	
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING REORDERING DELEGATES		
+	for( int i=0;i < array->num;i++)
+	{		
+		[[CCTouchDispatcher sharedDispatcher] setPriority:array->num-i+CCRANDOM_MINUS1_1() * 200 forDelegate:array->arr[i]];						
+	}
+	CCProfilingEndTimingBlock(_profilingTimer);	//--------------------------------------
+	
+	// remove them 
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];	
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];
+		else
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite];		
+	}	
+}
+
+-(NSString*) title
+{
+	return @"5 - Reorder priorities ";
+}
+-(NSString*) subtitle
+{
+	return @"Reorder %100 of delegates via default algorithm. See console";
+}
+-(NSString*) profilerName
+{
+	return @"5 - Reorder delegates NSMutableASort/InsertSort";
+}
+@end
+
+
+#if  COMPILE_FOR_NEW_API 	
+ 
+//// 1 a)
+@implementation FastAdd
+-(void) update:(ccTime)dt
+{	
+   if ( ![[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+	return;
+
+	// reset seed
+	srandom(0);
+		
+	ccArray *array = batchNode.children->data;
+	
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING ADDING DELEGATES -  FAST ADD 
+	for( int i=0; i < array->num; i++)
+	{
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:array->arr[i] priority:array->num-i + CCRANDOM_MINUS1_1() * 50 tag:i disable:NO doNotSort:YES];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:array->arr[i] priority:array->num-i + CCRANDOM_MINUS1_1() * 50 swallowsTouches:NO tag:i disable:NO doNotSort:YES];						
+	}
+	// sorting is done here:
+	[[CCTouchDispatcher sharedDispatcher] sortDelegates:kCCTargeted];
+	[[CCTouchDispatcher sharedDispatcher] sortDelegates:kCCStandard];
+	CCProfilingEndTimingBlock(_profilingTimer); //------------
+	
+	// remove them (fast removal)
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite delay:YES type:kCCStandard];
+		else
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite delay:YES type:kCCTargeted];							
+	}		
+	[[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCTargeted];
+	[[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCStandard];
+}
+
+-(NSString*) title
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return @"1a - Fast Add of delegates";
+	else
+		return @"1a - Fast Add - new API required";	
+}
+-(NSString*) subtitle
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+	return @"1a Fast Add of delegates. Add first sort later. See console";
+		else
+	return @"1a - new API required for this test";
+}
+-(NSString*) profilerName
+{
+	return @"1 a - FAST ADD";
+}
+@end
+
+//// 2 a
+@implementation FastRemoval
+-(void) update:(ccTime)dt
+{
+   if ( ![[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return;
+	
+	// reset seed
+	srandom(0);
+	
+	ccArray *array = batchNode.children->data;
+
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		[sprite setVisible:NO];
+		
+		// the worst case:		
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50 tag:kTagBase+i disable:NO doNotSort:YES];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50 swallowsTouches:NO tag:kTagBase+i disable:NO doNotSort:YES];						
+	}
+	
+	[[CCTouchDispatcher sharedDispatcher]  sortDelegates:kCCTargeted];
+	[[CCTouchDispatcher sharedDispatcher]  sortDelegates:kCCStandard];	
+	
+	// remove them 	
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING FAST REMOVAL 	
+
+	[[CCTouchDispatcher sharedDispatcher] removeDelegatesWithField:kCCTag arg1:kTagBase arg2:CC_UNUSED_ARGUMENT operator:kCCGE delay:NO type:kCCStandard];
+	[[CCTouchDispatcher sharedDispatcher] removeDelegatesWithField:kCCTag arg1:kTagBase arg2:CC_UNUSED_ARGUMENT operator:kCCGE delay:NO type:kCCTargeted];
+	
+	CCProfilingEndTimingBlock(_profilingTimer); //----	
+}
+
+-(NSString*) title
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return @"2a - Fast Removal";
+	else	
+		return @"2a-Fast Removal:new API required!";
+}
+	
+-(NSString*) subtitle
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return @"Fast Removal. See console";
+   else
+		return @"FAST REMOVAL - new API required for this test";	
+}
+-(NSString*) profilerName
+{
+	return @"2a FAST REMOVAL";
+}
+@end
+
+//// 2b
+@implementation FastCompoundRemoval
+-(void) update:(ccTime)dt
+{
+   if ( ![[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return;
+		
+	// reset seed
+	srandom(0);
+	
+	ccArray *array = batchNode.children->data;
+	
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		[sprite setVisible:NO];
+		
+		// the worst case:		
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50 tag:kTagBase+i disable:NO doNotSort:YES];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50 swallowsTouches:NO tag:kTagBase+i disable:NO doNotSort:YES];						
+	}
+	
+	[[CCTouchDispatcher sharedDispatcher]  sortDelegates:kCCTargeted];
+	[[CCTouchDispatcher sharedDispatcher]  sortDelegates:kCCStandard];	
+	
+	// remove them 	
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING COMPOUND FAST REMOVAL - removal delayed	
+	// 
+	[[CCTouchDispatcher sharedDispatcher] setDelegatesField:kCCRemoveToDo newValue:YES ifField:kCCTag arg1:kTagBase+52 arg2:CC_UNUSED_ARGUMENT operator:kCCEQ type:kCCStandard];	
+	[[CCTouchDispatcher sharedDispatcher] setDelegatesField:kCCRemoveToDo newValue:YES ifField:kCCTag arg1:kTagBase arg2:kTagBase+52 operator:kCCGEAndLT type:kCCStandard];
+	[[CCTouchDispatcher sharedDispatcher] setDelegatesField:kCCRemoveToDo newValue:YES ifField:kCCTag arg1:kTagBase+52 arg2:CC_UNUSED_ARGUMENT operator:kCCGT type:kCCStandard];
+	
+	
+	[[CCTouchDispatcher sharedDispatcher] setDelegatesField:kCCRemoveToDo newValue:YES ifField:kCCTag arg1:kTagBase+51 arg2:CC_UNUSED_ARGUMENT operator:kCCEQ type:kCCTargeted];
+	[[CCTouchDispatcher sharedDispatcher] setDelegatesField:kCCRemoveToDo newValue:YES ifField:kCCTag arg1:kTagBase    arg2:kTagBase+51 operator:kCCGEAndLT type:kCCTargeted];	
+	[[CCTouchDispatcher sharedDispatcher] setDelegatesField:kCCRemoveToDo newValue:YES ifField:kCCTag arg1:kTagBase+51 arg2:CC_UNUSED_ARGUMENT operator:kCCGT type:kCCTargeted];		
+	
+	[[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCStandard];
+	[[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCTargeted];	
+	
+	CCProfilingEndTimingBlock(_profilingTimer); //----	
+}
+
+-(NSString*) title
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return @"2b Fast Compound removal";
+	else
+		return @"2b-Fast Compound:new API required!";	
+}
+-(NSString*) subtitle
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return @"Fast Compound removal - removal in one pass. See console";
+	else
+		return @"2b-Fast Compound:new API required!";	
+}
+-(NSString*) profilerName
+{
+	return @"2b Fast Compound removal";
+}
+@end
+
+
+//// 5 a
+@implementation ReorderingOneByOneQSORT
+-(void) update:(ccTime)dt
+{
+   if ( ![[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return;
+		
+	// reset seed
+	srandom(0);
+	
+	ccArray *array = batchNode.children->data;
+	
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50 ];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50   swallowsTouches:YES];
+	}
+		
+	[[CCTouchDispatcher sharedDispatcher] setSortingAlgorithm:kCCAlgQSort];
+	
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING REORDERING QSORT DELEGATES		
+	for( int i=0;i < array->num;i++)
+	{		
+		[[CCTouchDispatcher sharedDispatcher] setPriority:array->num-i+CCRANDOM_MINUS1_1() * 200 forDelegate:array->arr[i]];						
+	}
+	CCProfilingEndTimingBlock(_profilingTimer);	
+	
+	// remove them
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite delay:YES type:kCCStandard];
+		else
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite delay:YES type:kCCTargeted];							
+		
+	}	
+	
+	[[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCTargeted];
+	[[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCStandard];
+}
+
+-(NSString*) title
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+	return @"5a Changing priority - QSort";
+		else
+	return @"5a-QSort:new API required!";	
+}
+-(NSString*) subtitle
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return @"Slow Sort one by one. See console";
+	else
+		return @"5a-QSort:new API required!";	
+}
+-(NSString*) profilerName
+{
+	return @"5a QSort";
+}
+@end
+
+//// 5 b
+@implementation ReorderingOneByOneMERGESORT
+-(void) update:(ccTime)dt
+{
+   if ( ![[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return;
+	
+	// reset seed
+	srandom(0);
+	
+	ccArray *array = batchNode.children->data;
+	
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		[sprite setVisible:NO];
+		
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50 ];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 50   swallowsTouches:YES];
+	}
+	
+	[[CCTouchDispatcher sharedDispatcher] setSortingAlgorithm:kCCAlgMergeLSort];
+	
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  PROFILING REORDERING by LMERGESORT		
+	for( int i=0;i < array->num;i++)
+	{				
+		[[CCTouchDispatcher sharedDispatcher] setPriority:array->num-i+CCRANDOM_MINUS1_1() * 200 forDelegate:array->arr[i]];						
+	}
+	CCProfilingEndTimingBlock(_profilingTimer);	//--------------------------------------------
+		
+	// remove them
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite delay:YES type:kCCStandard];
+		else
+			[[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite delay:YES type:kCCTargeted];							
+	}	
+	
+	[[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCTargeted];
+	[[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCStandard];
+}
+
+-(NSString*) title
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+	return @"5b Changing priority - LMerge";
+		else
+	return @"5b-LMerge:new API required!";
+}
+-(NSString*) subtitle
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return @"Slow Sort one by one. See console";
+	else
+		return @"5b-LMerge:new API required!";
+}
+-(NSString*) profilerName
+{
+	return @"5b MSort";
+}
+@end
+
+
+
+//// 5 c
+@implementation UltraFastReordering
+-(void) update:(ccTime)dt
+{
+   if ( ![[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return;
+	
+	// reset seed
+	srandom(0);
+	
+	ccArray *array = batchNode.children->data;
+	
+	for( int i=0; i < array->num; i++)
+	{
+		SGSprite *sprite = array->arr[i];
+		// the worst case:		
+		if (i%2)
+			[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 200 tag:kTagBase+i disable:NO doNotSort:YES];
+		else
+			[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:sprite priority:array->num-i + CCRANDOM_MINUS1_1() * 200 swallowsTouches:NO tag:kTagBase+i disable:NO doNotSort:YES];										
+	}
+	[[CCTouchDispatcher sharedDispatcher] setSortingAlgorithm:kCCAlgInsertionSort];
+	[[CCTouchDispatcher sharedDispatcher]  sortDelegates:kCCTargeted];
+	[[CCTouchDispatcher sharedDispatcher]  sortDelegates:kCCStandard];	
+		
+	
+	CCProfilingBeginTimingBlock(_profilingTimer); //----  ULTRA FAST REORDERING	- change priority first, sort later	
+	for( int i=0;i < array->num;i++) // via priorityToDd
+	{				
+		if (i%2)	
+			[[CCTouchDispatcher sharedDispatcher] setField:kCCPriorityToDo newValue:array->num-i+CCRANDOM_MINUS1_1() * 200 delegate:array->arr[i] type:kCCStandard];	
+		else
+			[[CCTouchDispatcher sharedDispatcher] setField:kCCPriorityToDo newValue:array->num-i+CCRANDOM_MINUS1_1() * 200 delegate:array->arr[i] type:kCCTargeted];	
+	}
+	// actual sorting: 
+	[[CCTouchDispatcher sharedDispatcher]  sortDelegates:kCCTargeted];
+	[[CCTouchDispatcher sharedDispatcher]  sortDelegates:kCCStandard];	
+	CCProfilingEndTimingBlock(_profilingTimer);	//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+		
+	// remove them via fast removal
+	[[CCTouchDispatcher sharedDispatcher] removeDelegatesWithField:kCCTag arg1:kTagBase arg2:CC_UNUSED_ARGUMENT operator:kCCGE delay:NO type:kCCStandard];
+	[[CCTouchDispatcher sharedDispatcher] removeDelegatesWithField:kCCTag arg1:kTagBase arg2:CC_UNUSED_ARGUMENT operator:kCCGE delay:NO type:kCCTargeted];
+}
+
+-(NSString*) title
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+	return @"5c UltraFast(delayed)Reordering!";
+		else
+	return @"5c-InsertionSort:new API required!";	
+}
+-(NSString*) subtitle
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+	return @"UltraFastReordering - InsertionSort: See console";
+		else
+	return @"5c-InsertionSort:new API required!";
+}
+-(NSString*) profilerName
+{
+	return @"5c UltraFast(delayed)Reordering";
+}
+@end
+
+
+#pragma mark -
+#pragma mark BasicSpriteSheet
+
+@implementation BasicSpriteSheet
+
+-(void) updateQuantityOfNodes
+{
+	CGSize s = [[CCDirector sharedDirector] winSize];
+	// increase nodes
+	if( currentQuantityOfNodes < quantityOfNodes ) {
+		for(int i=0;i < (quantityOfNodes-currentQuantityOfNodes);i++) {
+			SGSprite *sprite = [SGSprite spriteWithTexture:[batchNode texture] rect:CGRectMake(0, 0, 32, 32)];
+			[batchNode addChild:sprite z:i tag:i]; // to trace it
+								
+			[sprite setPosition:ccp( CCRANDOM_0_1()*s.width, CCRANDOM_0_1()*s.height)];
+			[sprite setVisible:NO];
+		}
+	}
+		
+	// decrease nodes
+	else if ( currentQuantityOfNodes > quantityOfNodes ) {
+		for(int i=0;i < (currentQuantityOfNodes-quantityOfNodes);i++) {
+			int index = currentQuantityOfNodes-i-1;
+			[batchNode removeChildAtIndex:index cleanup:YES];
+		}
+		
+	}
+	
+	currentQuantityOfNodes = quantityOfNodes;
+	[self scheduleOnce:@selector(update:) delay:1.0f]; 
+}
+
+-(NSString*) title
+{
+	return @"none";
+}
+-(NSString*) profilerName
+{
+	return @"none";
+}
+@end
+
+
+
+@implementation Various
+
+int myComparatorArg(const void * first, const void * second)
+{
+	// arrange according to tags.
+	// if tags are equal take under consideration the priority 	
+			
+    id fId = ((id *) first)[0];  
+    id sId = ((id *) second)[0]; 	
+	
+	CCTouchHandler *f = (CCTouchHandler*) fId;
+	CCTouchHandler *s = (CCTouchHandler*) sId;
+	
+	// sprite tag
+	//int fT = [f.delegate tag];   // delegate has to descend from CCNode
+	//int sT = [s.delegate tag];  
+
+	// delegate tag
+	int fT = f.tag;
+	int sT = s.tag;  
+
+	int fP = f.priority;
+	int sP = s.priority;	
+	
+	
+	if (fT == sT) { 		
+			if (fP == sP) {
+				return NSOrderedSame;
+			}
+			else{
+				if (fP < sP)   //  if fT == sT  than  p1 < p2 < p3  order:  p1,p2,p3 
+					return NSOrderedAscending;
+				else 
+					return NSOrderedDescending;											
+			}				
+	}
+							
+	if (fT < sT)   // if t1 < t2 < t3   order:  t1,t2,t3 
+		return NSOrderedAscending;
+	else 
+		return NSOrderedDescending;
+}
+
+-(void) variousTests
+{
+   if ( ![[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return;
+		
+    BOOL nl = ![[CCTouchDispatcher sharedDispatcher] locked];	
+
+	
+	if (nl){ 
+	
+		CCLOG(@"----------------------------------");
+		CCLOG(@" 6 Various...	START			  ");
+		CCLOG(@"----------------------------------");
+			
+	}
+	else {
+		CCLOG(@"----------------------------------");
+		CCLOG(@" 6 Various...	START (CALLBACK)  ");
+		CCLOG(@"----------------------------------");								
+	}
+
+	
+	if (currentQuantityOfNodes == 0){
+		
+		CCLOG(@" 6 Various... no sprites ");
+		return;		
+	}
+
+	// reset seed
+	srandom(0);
+	
+	ccArray *array = batchNode.children->data;
+	SGSprite *sprite;
+	int result;
+	
+	
+	CCLOG(@"--------------------------------------");	
+	CCLOG(@" 6 Various...	ADDING DELEGATES standard way");
+	CCLOG(@"--------------------------------------");
+		
+    sprite = array->arr[0]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-5  tag: 0  disable:NO  doNotSort:NO];		
+	sprite = array->arr[1];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 1  tag: 1  disable:YES doNotSort:NO];			
+    sprite = array->arr[2]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 0  disable:NO  doNotSort:NO];					
+    sprite = array->arr[3];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:NO];		
+    sprite = array->arr[4];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-1  tag: 1  disable:NO  doNotSort:NO];			
+	sprite = array->arr[5];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag:-3  disable:YES doNotSort:NO];		
+	sprite = array->arr[6];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 5  tag: 0  disable:YES doNotSort:NO];		
+	sprite = array->arr[7];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag: 5  disable:YES doNotSort:NO];	
+	sprite = array->arr[8];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 1  tag: 1  disable:YES doNotSort:NO];		
+	sprite = array->arr[9]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag: 8  disable:YES doNotSort:NO];		
+	sprite = array->arr[10];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:NO];
+	sprite = array->arr[11];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 0  disable:YES doNotSort:NO];
+	sprite = array->arr[12];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 2  tag: 1  disable:YES doNotSort:NO];	
+	sprite = array->arr[13];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 2  tag: 0  disable:YES doNotSort:NO];	
+	sprite = array->arr[14];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:NO];	
+	
+	if(nl)
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];
+	
+	result = [[CCTouchDispatcher sharedDispatcher] removeAllDelegates:kCCStandard];	
+	CCLOG(@" 6 Various... removeAllDelegates:kCCStandard]; number of removals = %d, expected 15",result);
+	
+	
+	
+	CCLOG(@"--------------------------------------");	
+	CCLOG(@" 6 Various...	ADDING DELEGATES in reverse order");
+	CCLOG(@"--------------------------------------");	
+	
+	[[CCTouchDispatcher sharedDispatcher] setReversePriority:YES];	 // reverse sorting	
+	
+    sprite = array->arr[0]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-5  tag: 0  disable:NO  doNotSort:NO];		
+	sprite = array->arr[1];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 1  tag: 1  disable:YES doNotSort:NO];			
+    sprite = array->arr[2]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 0  disable:NO  doNotSort:NO];					
+    sprite = array->arr[3];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:NO];		
+    sprite = array->arr[4];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-1  tag: 1  disable:NO  doNotSort:NO];			
+	sprite = array->arr[5];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag:-3  disable:YES doNotSort:NO];		
+	sprite = array->arr[6];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 5  tag: 0  disable:YES doNotSort:NO];		
+	sprite = array->arr[7];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag: 5  disable:YES doNotSort:NO];	
+	sprite = array->arr[8];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 1  tag: 1  disable:YES doNotSort:NO];		
+	sprite = array->arr[9]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag: 8  disable:YES doNotSort:NO];		
+	sprite = array->arr[10];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:NO];
+	sprite = array->arr[11];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 0  disable:YES doNotSort:NO];
+	sprite = array->arr[12];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 2  tag: 1  disable:YES doNotSort:NO];	
+	sprite = array->arr[13];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 2  tag: 0  disable:YES doNotSort:NO];	
+	sprite = array->arr[14];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:NO];	
+	
+	if(nl)	
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];
+	
+	result = [[CCTouchDispatcher sharedDispatcher] removeAllDelegates:kCCStandard];	
+	CCLOG(@" 6 Various... removeAllDelegates:kCCStandard]; number of removals = %d, expected 15",result);	
+	
+	
+	CCLOG(@"--------------------------------------");	
+	CCLOG(@" 6 Various...	ADDING DELEGATES custom order ");
+	CCLOG(@"--------------------------------------");	
+	
+	[[CCTouchDispatcher sharedDispatcher] setUsersComparator:myComparatorArg];	// change sorting comparator
+	
+
+	sprite = array->arr[11];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 0  disable:YES doNotSort:NO];
+	sprite = array->arr[12];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 2  tag: 1  disable:YES doNotSort:NO];	
+	sprite = array->arr[13];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 2  tag: 0  disable:YES doNotSort:NO];	
+	sprite = array->arr[14];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:NO];	
+    sprite = array->arr[1]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-5  tag: 0  disable:NO  doNotSort:NO];		
+	sprite = array->arr[0];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 1  tag: 1  disable:YES doNotSort:NO];			
+    sprite = array->arr[3]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 0  disable:NO  doNotSort:NO];					
+    sprite = array->arr[2];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:NO];		
+    sprite = array->arr[5];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-1  tag: 1  disable:NO  doNotSort:NO];			
+	sprite = array->arr[4];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag:-3  disable:YES doNotSort:NO];		
+	sprite = array->arr[7];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 5  tag: 0  disable:YES doNotSort:NO];		
+	sprite = array->arr[6];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag: 5  disable:YES doNotSort:NO];	
+	sprite = array->arr[8];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 1  tag: 1  disable:YES doNotSort:NO];		
+	sprite = array->arr[9]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag: 8  disable:YES doNotSort:NO];		
+	sprite = array->arr[10];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:NO];
+	
+	if(nl)	
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];
+	
+	result = [[CCTouchDispatcher sharedDispatcher] removeAllDelegates:kCCStandard];	
+	CCLOG(@" 6 Various... removeAllDelegates:kCCStandard]; number of removals = %d, expected 15",result);		
+				
+	
+	CCLOG(@"--------------------------------------");	
+	CCLOG(@" 6 Various...	ADDING DELEGATES in the order of being added");
+	CCLOG(@"--------------------------------------");				
+	
+			
+    sprite = array->arr[0]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-5  tag: 0  disable:NO  doNotSort:YES];		
+	sprite = array->arr[1];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 1  tag: 1  disable:YES doNotSort:YES];			
+    sprite = array->arr[2]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 0  disable:NO  doNotSort:YES];					
+    sprite = array->arr[3];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:YES];		
+    sprite = array->arr[4];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-1  tag: 1  disable:NO  doNotSort:YES];			
+	sprite = array->arr[5];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag:-3  disable:YES doNotSort:YES];		
+	sprite = array->arr[6];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 5  tag: 0  disable:YES doNotSort:YES];		
+	sprite = array->arr[7];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag: 5  disable:YES doNotSort:YES];	
+	sprite = array->arr[8];	[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 1  tag: 1  disable:YES doNotSort:YES];		
+	sprite = array->arr[9]; [[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority:-3  tag: 8  disable:YES doNotSort:YES];		
+	sprite = array->arr[10];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:YES];
+	sprite = array->arr[11];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 0  disable:YES doNotSort:YES];
+	sprite = array->arr[12];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 2  tag: 1  disable:YES doNotSort:YES];	
+	sprite = array->arr[13];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 2  tag: 0  disable:YES doNotSort:YES];	
+	sprite = array->arr[14];[[CCTouchDispatcher sharedDispatcher] addStandardDelegate:sprite priority: 0  tag: 1  disable:YES doNotSort:YES];
+		
+	if(nl){		
+		CCLOG(@" 6 Various... before sort:");
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];
+	}		
+
+	//--------------------------------------------
+	//		SORTING
+	//--------------------------------------------
+	
+	
+	CCLOG(@"----------------------------------");	
+	CCLOG(@" 6 Various...	SORTING");
+	CCLOG(@"----------------------------------");	
+	
+	[[CCTouchDispatcher sharedDispatcher] setReversePriority:NO];		// default	
+		[[CCTouchDispatcher sharedDispatcher] setUsersComparator:NULL];	// default
+	if(nl)	
+		CCLOG(@" 6 Various... after standard CCAlgInsertionSort sort:");
+	[[CCTouchDispatcher sharedDispatcher] sortDelegates:kCCStandard];
+	if(nl)		
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];
+
+	if(nl)	
+		CCLOG(@" 6 Various... after custom sort tag && priority:");
+	[[CCTouchDispatcher sharedDispatcher] setUsersComparator:myComparatorArg];	// change sorting comparator
+	[[CCTouchDispatcher sharedDispatcher] sortDelegates:kCCStandard];
+	if(nl)		
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];
+
+	if(nl)	
+		CCLOG(@" 6 Various... after no custom, reverse priority with kCCAlgQSort");
+	[[CCTouchDispatcher sharedDispatcher] setReversePriority:YES];	 // reverse sorting
+	[[CCTouchDispatcher sharedDispatcher] setUsersComparator:NULL]; // change sorting comparator
+	[[CCTouchDispatcher sharedDispatcher] setSortingAlgorithm:kCCAlgQSort];	
+	[[CCTouchDispatcher sharedDispatcher] sortDelegates:kCCStandard];
+	if(nl)		
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];	
+	
+	if(nl)		
+		CCLOG(@" 6 Various... sort with kCCAlgMergeLSort zOrderComparator Notice: zOrder(==spriteTag) ");	
+	[[CCTouchDispatcher sharedDispatcher] setReversePriority:NO];	 // reverse sorting	
+	[[CCTouchDispatcher sharedDispatcher] setUsersComparator: [[CCTouchDispatcher sharedDispatcher] zOrderComparator]  ]; // change sorting comparator
+	[[CCTouchDispatcher sharedDispatcher] setSortingAlgorithm:kCCAlgMergeLSort];	
+	[[CCTouchDispatcher sharedDispatcher] sortDelegates:kCCStandard];
+	if(nl)		
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];	
+	
+	
+	//---------------------------------
+	// counting delegates
+	//---------------------------------
+	
+	/* return number of delegates of the given type
+	 User's callback safe: delegates in the process of being removed are not counted. 
+	 @since v1.1.0
+	 */		
+
+	
+	CCLOG(@"----------------------------------");	
+	CCLOG(@" 6 Various... COUNTING DELEGATES");
+	CCLOG(@"----------------------------------");
+	
+	result = [[CCTouchDispatcher sharedDispatcher] countDelegatesUsage:kCCStandard];
+	CCLOG(@" 6 Various... countDelegatesUsage %d should be 15 ",result);
+	
+	/* checks if the touch delegate is already added to the dispatcher's list of the given type 
+	 It may be important since any attempt to add two identical delegates triggers the 'NSAssert'. 
+	 User's callback safe: 
+	 It returns 0 if delegate does not exist or is marked for removal or >0 if delegate is added. 
+	 If delegate is marked for removal adding the same delegate is safe.  
+	 @since v1.1.0
+	 */
+	result = [[CCTouchDispatcher sharedDispatcher]  countDelegateUsage:sprite type:kCCStandard];
+	CCLOG(@" 6 Various... countDelegateUsage %d should be 1 ",result);
+	
+	/* returns number of delegates with the specified tag
+	 User's callback safe: delegates in the process of being removed are not counted. 
+	 */
+	result = [[CCTouchDispatcher sharedDispatcher]  countTagUsage:1 type:kCCStandard];
+	CCLOG(@" 6 Various... countTagUsage %d should be 7 ",result);
+	
+	/* returns number of delegates with the specified priority
+	 User's callback safe: delegates in the process of being removed are not counted. 
+	 @since v1.1.0
+	 */
+	result = [[CCTouchDispatcher sharedDispatcher]  countPriorityUsage:-3 type:kCCStandard];
+	CCLOG(@" 6 Various... countPriorityUsage %d should be 3 ",result);
+	
+	/* returns number of delegates with the specified disable value ((Use: YES or NO)
+	 User's callback safe: delegates in the process of being removed are not counted. 
+	 @since v1.1.0
+	 */
+	result = [[CCTouchDispatcher sharedDispatcher]  countDisableUsage:NO type:kCCStandard];
+		CCLOG(@" 6 Various... countDisableUsage %d should be 3 ",result);
+	
+	/* returns number of delegates with the specified value for given field 
+	 User's callback safe: delegates in the process of being removed are not counted. 
+	 Notice: It is generic functions covering all sugar 'countThisFieldUsage()' functions
+	 @since v1.1.0
+	 */
+	result = [[CCTouchDispatcher sharedDispatcher]  countFieldUsage:kCCDisable fieldValue:YES type:kCCStandard];
+	CCLOG(@" 6 Various... countFieldUsage:kCCDisable %d should be 12 ",result);
+	
+
+	CCLOG(@"---------------------------------------------");
+	CCLOG(@" 6 Various... RETRIEVE FIELD OF THE DELEGATE ");
+	CCLOG(@"---------------------------------------------");	
+	
+	//----------------------------------
+	// retrieval of the field value
+	// ---------------------------------
+	/* returns priority of the delegate or NSNotFound when delegate does not exist 
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher]  retrievePriorityField:sprite type:kCCStandard];
+	CCLOG(@" 6 Various... retrievePriorityField %d - should be 0 ",result);
+
+	/* returns tag of the delegate or NSNotFound when delegate does not exist 
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] retrieveTagField:sprite type:kCCStandard];
+	CCLOG(@" 6 Various... retrieveTagField %d - should be 1 ",result);
+
+	/* returns value of the disable field or NSNotFound when delegate does not exist 
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] retrieveDisableField:sprite type:kCCStandard];
+	CCLOG(@" 6 Various... retrieveDisableField %d - should be 1 ",result);
+
+	/* returns value of the field or NSNotFound when delegate does not exist 
+	Notice: It is generic functions covering all sugar 'retrieve*Field(.)' functions
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] retrieveField:kCCRemove delegate:sprite type:kCCStandard];
+	CCLOG(@" 6 Various... retrieveField:kCCRemove %d - should be 0 ",result);	
+	
+	//--------------------------------
+	// disabling of the delegate/s
+	//--------------------------------
+	
+	CCLOG(@"-----------------------------------------");
+	CCLOG(@" 6 Various... DISABLING OF THE DELEGATE/S");
+	CCLOG(@"-----------------------------------------");	
+	
+
+	/* disables/enables already added touch delegate 
+	@since v1.1.0
+	*/			
+	result = [[CCTouchDispatcher sharedDispatcher] disableDelegate:sprite disable:NO type:kCCStandard];
+	CCLOG(@" 6 Various... Nr of obj affected by disableDelegate:sprite disable:NO type:kCCStandard]; disable=%d,  should be 0;  result = %d",
+	[[CCTouchDispatcher sharedDispatcher] retrieveDisableField:sprite type:kCCStandard], result );	
+
+	/*  disables/enables all delegates of the given type 
+	returns number of disabled delegates
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] disableAllDelegates:NO type:kCCStandard];
+	CCLOG(@" 6 Various... Nr of obj affected by disableAllDelegates:NO type:kCCStandard]; = %d,  should be 15 (60 in callback)", result);	
+	
+	/* disables/enables already added touch delegates of the given type
+	with specified tag. (That allows fast selective disabling without removing and adding to the list)
+	returns number of disabled delegates
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] disableDelegatesWithTag:1 disable:YES type:kCCStandard];
+	CCLOG(@" 6 Various... Nr of obj affected by disableDelegatesWithTag:1 disable:YES type:kCCStandard]; = %d,   should be 7 (28 in callback)", result);
+	
+	/* disables/enables already added targeted touch delegates of the given type
+	with specified priority (including marked for removal).
+	returns number of disabled delegates 
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] disableDelegatesWithPriority:-3 disable:YES type:kCCStandard];
+	CCLOG(@" 6 Various... Nr of obj affected by disableDelegatesWithPriority:-3 disable:YES type:kCCStandard]; = %d,   should be 3 (12 in callback)", result);
+
+	/* inside the event loop delegates marked for removal still receive touches (default)
+	'disableRemovedDelegates' disables/enables delegates marked for removal inside the event loop.
+	Use it inside the touch callback function if you do not want removed delegates to be active
+	during event loop.
+	returns number of disabled delegates (including marked for removal)
+	@since v1.1.0
+	*/ 
+	
+	result = [[CCTouchDispatcher sharedDispatcher] disableRemovedDelegates:YES type:kCCStandard];
+	CCLOG(@" 6 Various... Nr of obj affected by disableRemovedDelegates:YES type:kCCStandard]; = %d,   should be 0 (45 in callback)", result);
+
+	/* generic function to disable/enable delagates when a specific field contains certain value.  
+	The content of the field is evaluated against ar1 and arg2 using (ccOperators)op.
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] disableDelegatesWithField:kCCTag arg1:1 arg2:CC_UNUSED_ARGUMENT operator:kCCEQ disable:YES type:kCCStandard];
+	CCLOG(@" 6 Various... Nr of obj affected by disableDelegatesWithField:kCCTag arg1:1 arg2:CC_UNUSED_ARGUMENT operator:kCCEQ disable:YES type:kCCStandard]; = %d, should be 7 (28 in callback)", result);
+
+	
+	//-------------------------------------------------------------------------
+	// setting value of the specific field to a new value for the given delegate
+	//-------------------------------------------------------------------------
+	
+	CCLOG(@"-----------------------------------------");
+	CCLOG(@" 6 Various... SETTING FIELDS TO NEW VALUES");
+	CCLOG(@"-----------------------------------------");		
+	
+	
+
+	CCLOG(@" 6 Various... debug log for the specific sprite before changing its fields:\n");
+	result = [[CCTouchDispatcher sharedDispatcher] setField:kCCDebug newValue:1 delegate:sprite type:kCCStandard];
+	
+	/* Changes the priority of the previously added delegate.
+	It will force new sort only if new value is different from the old one.
+	returns the number of affected delegates. Removed delegates are not considered.
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] setPriority:-77 delegate:sprite delay:NO type:kCCStandard];
+	CCLOG(@" 6 Various... seting tag field to -77, result=%d", result);
+	/* set a new tag for delegate
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] setTag:66 delegate:sprite type:kCCStandard];
+	CCLOG(@" 6 Various... seting pri field to 66, result=%d", result);
+	/* setDisable == disableDelegate  - disable/enable delegate
+	@since v1.1.0
+	*/
+	result = [[CCTouchDispatcher sharedDispatcher] setDisable:NO delegate:sprite type:kCCStandard];
+	CCLOG(@" 6 Various... seting disable field to NO, result=%d", result);		
+
+	/* generic power function: sets value of the specific field to a new value.
+	Return number of affected delegates. It returns 0 if delegate is not found. Less than 0 for an error.  
+	@since v1.1.0
+	*/
+	
+	result = [[CCTouchDispatcher sharedDispatcher] setField:kCCRemoveToDo newValue:1 delegate:sprite type:kCCStandard];
+	CCLOG(@" 6 Various... marking sprite for removal, result=%d", result);	
+	
+	/* debug */
+	CCLOG(@" 6 Various... debug log after changes:\n");	
+	result = [[CCTouchDispatcher sharedDispatcher] setField:kCCDebug newValue:1 delegate:sprite type:kCCStandard];
+
+	result = [[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCStandard];					
+	CCLOG(@" 6 Various... removing marked for removal delegates, number of removals = %d",result);	
+	
+	/* Removes the delegate of the given type, releasing the delegate 
+	 @since v1.1.0
+	 */	
+	result = [[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCStandard];					
+	CCLOG(@" 6 Various... repeating removing marked for removal delegates, number of removals = %d",result);	
+		
+	result = [[CCTouchDispatcher sharedDispatcher] removeDelegate:sprite delay:NO type:kCCStandard];
+	CCLOG(@" 6 Various... removing same delegate removeDelegate:sprite type:kCCStandard]; number of removals = %d",result);			
+	/* setRemove == removeDelegate - remove delegate 
+	 @since v1.1.0
+	 */
+	result = [[CCTouchDispatcher sharedDispatcher] setRemove:sprite delay:NO type:kCCStandard];	
+	CCLOG(@" 6 Various... removing same delegate setRemove:sprite type:kCCStandard]; number of removals = %d",result);	
+		
+	result = [[CCTouchDispatcher sharedDispatcher] retrieveField:kCCRemove delegate:sprite type:kCCStandard];
+	CCLOG(@" 6 Various... retrieveField:kCCRemove=%d, should be NSNotFound=NSIntegerMax e.g:(2147483647)",result);		
+	
+	
+	//------------------------------------------------------------------------------------------------
+	// setting new value for a delegates specific field conditional on the value of other(same) field
+	//------------------------------------------------------------------------------------------------
+	/** sets new priority for all delegates with the given tag
+	 @since v1.1.0
+	 */
+		
+	
+	if(nl)	{
+		CCLOG(@" 6 Various... Printing log before: setting delegates with tag==0 to have priority= -33");
+		CCLOG(@" 6 Various...                 setting all delegates with priority==-33 to have tag= 22");
+		CCLOG(@" 6 Various...                 setting all delegates with priority==-33 to be disabled!");			  
+			  
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];	
+	}	
+			  
+	result = [[CCTouchDispatcher sharedDispatcher] setPriorityForTag:0 newPriority:-33 delay:NO type:kCCStandard];
+			  
+	/** sets new tag for all delegates with the given priority 
+	 @since v1.1.0
+	 */
+	result = [[CCTouchDispatcher sharedDispatcher] setTagForPriority:-33 newTag:22 type:kCCStandard];
+			  
+				  			
+	/** 'Only For Eagles' - generic power function - allows changes for delegates with the specific field value
+	 The content of the field is evaluated against arg1 and arg2 using (ccOperators)op.
+	 It returns number of affected delegates.
+	 @since v1.1.0
+	 */
+	result = [[CCTouchDispatcher sharedDispatcher] setDelegatesField:kCCDisable newValue:0
+		ifField:kCCPriority arg1:-33 arg2:CC_UNUSED_ARGUMENT operator:kCCEQ type:kCCStandard];	
+
+	if(nl)	{
+		CCLOG(@" 6 Various... results: NOTICE: since the current algorithm sorts according to z value order was not changed!");	
+		[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];		
+	}
+
+	//---------------------------------
+	// removal of the delegate/s
+	//---------------------------------	
+	
+	
+	CCLOG(@"----------------------------------");
+	CCLOG(@" 6 Various... REMOVING DELEGATE/S");
+	CCLOG(@"----------------------------------");		
+		
+	
+	// Note: removal cannot be undone. If you need already removed delegate than add it again.
+		
+	/* removes all delegates of the given type with specified tag 
+	 returns number of delegates removed 
+	 @since v1.1.0
+	 */ 
+	result = [[CCTouchDispatcher sharedDispatcher] removeDelegatesWithTag:22 delay:NO type:kCCStandard];			
+	CCLOG(@" 6 Various... removeDelegatesWithTag:22 type:kCCStandard]; number of removals = %d,  expected 5",result);			
+	
+	
+	/* removes all delegates of the given type with specified priority
+	 returns number of delegates removed
+	 @since v1.1.0
+	 */ 
+	result = [[CCTouchDispatcher sharedDispatcher] removeDelegatesWithPriority:-3 delay:NO type:kCCStandard];	
+	CCLOG(@" 6 Various... removeDelegatesWithPriority:-3 type:kCCStandard]; number of removals = %d,  expected 3",result);	
+	
+	
+	/* power function: covers all 'removeDelegates*' functions. Removes delegates of the given type 
+	 for which a given field contains desired value.
+	 The value of the field is evaluated against arg1 and arg2 using (ccOperators)op.
+	 @since v1.1.0
+	 */
+	result = [[CCTouchDispatcher sharedDispatcher] removeDelegatesWithField:kCCPriority arg1:1 arg2:CC_UNUSED_ARGUMENT operator:kCCEQ delay:NO type:kCCStandard];			
+
+		CCLOG(@" 6 Various... removeDelegatesWithField:kCCPriority arg1:1 arg2:CC_UNUSED_ARGUMENT operator:kCCEQ type:kCCStandard]; number of removals = %d,  expected 2",result);
+	
+	
+	/* removes all delegates of the given type marked for removal by the following functions used with kCCRemoveToDo field:
+	 setField:kCCRemoveToDo ... or/and setDelegatesField:kCCRemoveToDo ...
+	 Used that way they mark delegates to be removed at the later time. 
+	 At latest delegates will be removed at the end of the callback event processing loop. 
+	 returns number of delegates removed.
+	 if function is called in the touch callback it returns -1. Delegates will be removed at the end of callback anyway.
+	 @since v1.1.0
+	 */ 
+	result = [[CCTouchDispatcher sharedDispatcher] removeToDoDelegates:kCCStandard];
+	CCLOG(@" 6 Various... removeToDoDelegates:kCCStandard]; number of removals = %d, expected 0 (-1 in callback)",result);	
+	
+			
+	/* removes all delegates of the given type 
+		returns number of delegates removed
+		@since v1.1.0
+	*/ 
+		
+	// END cleanup:	
+	result = [[CCTouchDispatcher sharedDispatcher] removeAllDelegates:kCCStandard];	
+	CCLOG(@" 6 Various... removeAllDelegates:kCCStandard]; number of removals = %d, expected 4",result);	
+	
+	// FINAL LOG
+	CCLOG(@" 6 Various...  STANDARD HANDLERS container outside callback should be empty but it should have 60 handlers in the callback!");	
+	[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:NO type:kCCStandard];		
+
+	CCLOG(@" 6 Various...  STANDARD HANDLERS container at the end of event loop should be empty!");	
+	[[CCTouchDispatcher sharedDispatcher] printDebugLog:1 afterEvents:YES type:kCCStandard];		
+	
+	
+	if (nl){ 			
+		CCLOG(@"----------------------------------");
+		CCLOG(@" 6 Various...	END			  ");
+		CCLOG(@"----------------------------------");
+		CCLOG(@"\n\r");		
+		
+	}
+	else {
+		CCLOG(@"----------------------------------");
+		CCLOG(@" 6 Various...	END (CALLBACK)  ");
+		CCLOG(@"----------------------------------");	
+		CCLOG(@"\n\r");		
+	}			
+}
+
+-(void) update:(ccTime)dt
+{
+  [self variousTests];
+}
+
+
+- (void) testCallback:(id)sender
+{	
+	[self variousTests];	
+}
+
+- (id)initWithQuantityOfNodes:(unsigned int)nodes
+{
+	batchNode = [CCSpriteBatchNode batchNodeWithFile:@"spritesheet1.png" capacity:200];
+	
+	if( ( self=[super initWithQuantityOfNodes:nodes]) ) {
+		
+		//_profilingTimer = [[CCProfiler timerWithName:[self profilerName] andInstance:self] retain];
+		
+		[self addChild:batchNode];		
+		//[self scheduleUpdate];
+		//[self schedule: @selector(update:) interval:5.0f];
+		
+		
+		CCNode *menu1 = [self getChildByTag:kTagMenu];
+		if (menu1)		
+			[self removeChild:menu1 cleanup:YES];		
+		CCNode *infoLabel = [self getChildByTag:kTagInfoLayer];
+		if (infoLabel)
+			[self removeChild:infoLabel cleanup:YES];			
+		
+		//--- Button to test callback processing -----
+		CGSize s = [[CCDirector sharedDirector] winSize];
+		[CCMenuItemFont setFontSize:25];
+		
+		CCMenuItemFont *testCallbackProcessing = [CCMenuItemFont itemFromString:@"CallBack - It should not crash:See Console!" target:self selector:@selector(testCallback:)];
+		
+		[testCallbackProcessing.label setColor:ccc3(200,0,20)];
+		
+		CCMenu *menu = [CCMenu menuWithItems:testCallbackProcessing,nil];
+		menu.position = ccp(s.width/2, s.height/2);
+		[self addChild:menu];
+		//---------------------------------------------	
+		
+		[self scheduleOnce:@selector(update:) delay:1.0f]; 
+	}
+	
+	return self;
+}
+
+- (void) dealloc
+{
+	[CCProfiler releaseTimer:_profilingTimer];
+	[super dealloc];
+}
+
+
+-(NSString*) title
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+	return @"6 Various";
+		else
+	return @"6 new API required!";	
+}
+-(NSString*) subtitle
+{
+   if ( [[CCTouchDispatcher sharedDispatcher] respondsToSelector:@selector(locked)])
+		return @"Various Tests. See console";
+	else
+		return @"6 Various Tests - new API required!";		
+}
+-(NSString*) profilerName
+{
+	return @"6 Various Tests";
+}
+@end
+
+
+#endif
+

--- a/tests/PerformanceTests/cocos2d-ios-PerformanceTests.xcodeproj/project.pbxproj
+++ b/tests/PerformanceTests/cocos2d-ios-PerformanceTests.xcodeproj/project.pbxproj
@@ -167,6 +167,116 @@
 		50F411A91068D563002A0D5E /* fps_images.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F411A81068D563002A0D5E /* fps_images.png */; };
 		50F48B0D1045AD2F00755CFB /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F48B0B1045AD2F00755CFB /* Default.png */; };
 		50F48B0E1045AD2F00755CFB /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F48B0C1045AD2F00755CFB /* Icon.png */; };
+		657F115E150BA7970047F93C /* b1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030946E10447D98005F7AFC /* b1.png */; };
+		657F115F150BA7970047F93C /* b2.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030946F10447D98005F7AFC /* b2.png */; };
+		657F1160150BA7970047F93C /* f1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030947010447D98005F7AFC /* f1.png */; };
+		657F1161150BA7970047F93C /* f2.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030947110447D98005F7AFC /* f2.png */; };
+		657F1162150BA7970047F93C /* fire.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030947210447D98005F7AFC /* fire.png */; };
+		657F1163150BA7970047F93C /* fire.pvr in Resources */ = {isa = PBXBuildFile; fileRef = 5030947310447D98005F7AFC /* fire.pvr */; };
+		657F1164150BA7970047F93C /* r1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030947510447D98005F7AFC /* r1.png */; };
+		657F1165150BA7970047F93C /* r2.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030947610447D98005F7AFC /* r2.png */; };
+		657F1166150BA7970047F93C /* grossini.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C010447F2C005F7AFC /* grossini.png */; };
+		657F1167150BA7970047F93C /* grossini_dance_01.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C110447F2C005F7AFC /* grossini_dance_01.png */; };
+		657F1168150BA7970047F93C /* grossini_dance_02.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C210447F2C005F7AFC /* grossini_dance_02.png */; };
+		657F1169150BA7970047F93C /* grossini_dance_03.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C310447F2C005F7AFC /* grossini_dance_03.png */; };
+		657F116A150BA7970047F93C /* grossini_dance_04.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C410447F2C005F7AFC /* grossini_dance_04.png */; };
+		657F116B150BA7970047F93C /* grossini_dance_05.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C510447F2C005F7AFC /* grossini_dance_05.png */; };
+		657F116C150BA7970047F93C /* grossini_dance_06.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C610447F2C005F7AFC /* grossini_dance_06.png */; };
+		657F116D150BA7970047F93C /* grossini_dance_07.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C710447F2C005F7AFC /* grossini_dance_07.png */; };
+		657F116E150BA7970047F93C /* grossini_dance_08.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C810447F2C005F7AFC /* grossini_dance_08.png */; };
+		657F116F150BA7970047F93C /* grossini_dance_09.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094C910447F2C005F7AFC /* grossini_dance_09.png */; };
+		657F1170150BA7970047F93C /* grossini_dance_10.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094CA10447F2C005F7AFC /* grossini_dance_10.png */; };
+		657F1171150BA7970047F93C /* grossini_dance_11.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094CB10447F2C005F7AFC /* grossini_dance_11.png */; };
+		657F1172150BA7970047F93C /* grossini_dance_12.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094CC10447F2C005F7AFC /* grossini_dance_12.png */; };
+		657F1173150BA7970047F93C /* grossini_dance_13.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094CD10447F2C005F7AFC /* grossini_dance_13.png */; };
+		657F1174150BA7970047F93C /* grossini_dance_14.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094CE10447F2C005F7AFC /* grossini_dance_14.png */; };
+		657F1175150BA7970047F93C /* grossini_dance_atlas.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094CF10447F2C005F7AFC /* grossini_dance_atlas.png */; };
+		657F1176150BA7970047F93C /* grossini_dance_atlas.pvr in Resources */ = {isa = PBXBuildFile; fileRef = 503094D010447F2C005F7AFC /* grossini_dance_atlas.pvr */; };
+		657F1177150BA7970047F93C /* grossinis_sister1.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094D110447F2C005F7AFC /* grossinis_sister1.png */; };
+		657F1178150BA7970047F93C /* grossinis_sister1.pvr in Resources */ = {isa = PBXBuildFile; fileRef = 503094D210447F2C005F7AFC /* grossinis_sister1.pvr */; };
+		657F1179150BA7970047F93C /* sprite-0-0.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094D410447F2C005F7AFC /* sprite-0-0.png */; };
+		657F117A150BA7970047F93C /* sprite-0-1.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094D510447F2C005F7AFC /* sprite-0-1.png */; };
+		657F117B150BA7970047F93C /* sprite-0-2.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094D610447F2C005F7AFC /* sprite-0-2.png */; };
+		657F117C150BA7970047F93C /* sprite-0-3.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094D710447F2C005F7AFC /* sprite-0-3.png */; };
+		657F117D150BA7970047F93C /* sprite-0-4.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094D810447F2C005F7AFC /* sprite-0-4.png */; };
+		657F117E150BA7970047F93C /* sprite-0-5.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094D910447F2C005F7AFC /* sprite-0-5.png */; };
+		657F117F150BA7970047F93C /* sprite-0-6.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094DA10447F2C005F7AFC /* sprite-0-6.png */; };
+		657F1180150BA7970047F93C /* sprite-0-7.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094DB10447F2C005F7AFC /* sprite-0-7.png */; };
+		657F1181150BA7970047F93C /* sprite-1-0.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094DC10447F2C005F7AFC /* sprite-1-0.png */; };
+		657F1182150BA7970047F93C /* sprite-1-1.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094DD10447F2C005F7AFC /* sprite-1-1.png */; };
+		657F1183150BA7970047F93C /* sprite-1-2.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094DE10447F2C005F7AFC /* sprite-1-2.png */; };
+		657F1184150BA7970047F93C /* sprite-1-3.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094DF10447F2C005F7AFC /* sprite-1-3.png */; };
+		657F1185150BA7970047F93C /* sprite-1-4.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E010447F2C005F7AFC /* sprite-1-4.png */; };
+		657F1186150BA7970047F93C /* sprite-1-5.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E110447F2C005F7AFC /* sprite-1-5.png */; };
+		657F1187150BA7970047F93C /* sprite-1-6.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E210447F2C005F7AFC /* sprite-1-6.png */; };
+		657F1188150BA7970047F93C /* sprite-1-7.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E310447F2C005F7AFC /* sprite-1-7.png */; };
+		657F1189150BA7970047F93C /* sprite-2-0.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E410447F2C005F7AFC /* sprite-2-0.png */; };
+		657F118A150BA7970047F93C /* sprite-2-1.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E510447F2C005F7AFC /* sprite-2-1.png */; };
+		657F118B150BA7970047F93C /* sprite-2-2.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E610447F2C005F7AFC /* sprite-2-2.png */; };
+		657F118C150BA7970047F93C /* sprite-2-3.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E710447F2C005F7AFC /* sprite-2-3.png */; };
+		657F118D150BA7970047F93C /* sprite-2-4.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E810447F2C005F7AFC /* sprite-2-4.png */; };
+		657F118E150BA7970047F93C /* sprite-2-5.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094E910447F2C005F7AFC /* sprite-2-5.png */; };
+		657F118F150BA7970047F93C /* sprite-2-6.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094EA10447F2C005F7AFC /* sprite-2-6.png */; };
+		657F1190150BA7970047F93C /* sprite-2-7.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094EB10447F2C005F7AFC /* sprite-2-7.png */; };
+		657F1191150BA7970047F93C /* sprite-3-0.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094EC10447F2C005F7AFC /* sprite-3-0.png */; };
+		657F1192150BA7970047F93C /* sprite-3-1.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094ED10447F2C005F7AFC /* sprite-3-1.png */; };
+		657F1193150BA7970047F93C /* sprite-3-2.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094EE10447F2C005F7AFC /* sprite-3-2.png */; };
+		657F1194150BA7970047F93C /* sprite-3-3.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094EF10447F2C005F7AFC /* sprite-3-3.png */; };
+		657F1195150BA7970047F93C /* sprite-3-4.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F010447F2C005F7AFC /* sprite-3-4.png */; };
+		657F1196150BA7970047F93C /* sprite-3-5.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F110447F2C005F7AFC /* sprite-3-5.png */; };
+		657F1197150BA7970047F93C /* sprite-3-6.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F210447F2C005F7AFC /* sprite-3-6.png */; };
+		657F1198150BA7970047F93C /* sprite-3-7.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F310447F2C005F7AFC /* sprite-3-7.png */; };
+		657F1199150BA7970047F93C /* sprite-4-0.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F410447F2C005F7AFC /* sprite-4-0.png */; };
+		657F119A150BA7970047F93C /* sprite-4-1.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F510447F2C005F7AFC /* sprite-4-1.png */; };
+		657F119B150BA7970047F93C /* sprite-4-2.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F610447F2C005F7AFC /* sprite-4-2.png */; };
+		657F119C150BA7970047F93C /* sprite-4-3.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F710447F2C005F7AFC /* sprite-4-3.png */; };
+		657F119D150BA7970047F93C /* sprite-4-4.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F810447F2C005F7AFC /* sprite-4-4.png */; };
+		657F119E150BA7970047F93C /* sprite-4-5.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094F910447F2C005F7AFC /* sprite-4-5.png */; };
+		657F119F150BA7970047F93C /* sprite-4-6.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094FA10447F2C005F7AFC /* sprite-4-6.png */; };
+		657F11A0150BA7970047F93C /* sprite-4-7.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094FB10447F2C005F7AFC /* sprite-4-7.png */; };
+		657F11A1150BA7970047F93C /* sprite-5-0.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094FC10447F2C005F7AFC /* sprite-5-0.png */; };
+		657F11A2150BA7970047F93C /* sprite-5-1.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094FD10447F2C005F7AFC /* sprite-5-1.png */; };
+		657F11A3150BA7970047F93C /* sprite-5-2.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094FE10447F2C005F7AFC /* sprite-5-2.png */; };
+		657F11A4150BA7970047F93C /* sprite-5-3.png in Resources */ = {isa = PBXBuildFile; fileRef = 503094FF10447F2C005F7AFC /* sprite-5-3.png */; };
+		657F11A5150BA7970047F93C /* sprite-5-4.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950010447F2C005F7AFC /* sprite-5-4.png */; };
+		657F11A6150BA7970047F93C /* sprite-5-5.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950110447F2C005F7AFC /* sprite-5-5.png */; };
+		657F11A7150BA7970047F93C /* sprite-5-6.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950210447F2C005F7AFC /* sprite-5-6.png */; };
+		657F11A8150BA7970047F93C /* sprite-5-7.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950310447F2C005F7AFC /* sprite-5-7.png */; };
+		657F11A9150BA7970047F93C /* sprite-6-0.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950410447F2C005F7AFC /* sprite-6-0.png */; };
+		657F11AA150BA7970047F93C /* sprite-6-1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950510447F2C005F7AFC /* sprite-6-1.png */; };
+		657F11AB150BA7970047F93C /* sprite-6-2.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950610447F2C005F7AFC /* sprite-6-2.png */; };
+		657F11AC150BA7970047F93C /* sprite-6-3.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950710447F2C005F7AFC /* sprite-6-3.png */; };
+		657F11AD150BA7970047F93C /* sprite-6-4.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950810447F2C005F7AFC /* sprite-6-4.png */; };
+		657F11AE150BA7970047F93C /* sprite-6-5.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950910447F2C005F7AFC /* sprite-6-5.png */; };
+		657F11AF150BA7970047F93C /* sprite-6-6.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950A10447F2C005F7AFC /* sprite-6-6.png */; };
+		657F11B0150BA7970047F93C /* sprite-6-7.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950B10447F2C005F7AFC /* sprite-6-7.png */; };
+		657F11B1150BA7970047F93C /* sprite-7-0.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950C10447F2C005F7AFC /* sprite-7-0.png */; };
+		657F11B2150BA7970047F93C /* sprite-7-1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950D10447F2C005F7AFC /* sprite-7-1.png */; };
+		657F11B3150BA7970047F93C /* sprite-7-2.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950E10447F2C005F7AFC /* sprite-7-2.png */; };
+		657F11B4150BA7970047F93C /* sprite-7-3.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030950F10447F2C005F7AFC /* sprite-7-3.png */; };
+		657F11B5150BA7970047F93C /* sprite-7-4.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030951010447F2C005F7AFC /* sprite-7-4.png */; };
+		657F11B6150BA7970047F93C /* sprite-7-5.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030951110447F2C005F7AFC /* sprite-7-5.png */; };
+		657F11B7150BA7970047F93C /* sprite-7-6.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030951210447F2C005F7AFC /* sprite-7-6.png */; };
+		657F11B8150BA7970047F93C /* sprite-7-7.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030951310447F2C005F7AFC /* sprite-7-7.png */; };
+		657F11B9150BA7970047F93C /* spritesheet1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5030951410447F2C005F7AFC /* spritesheet1.png */; };
+		657F11BA150BA7970047F93C /* spritesheet1.pvr in Resources */ = {isa = PBXBuildFile; fileRef = 5030951510447F2C005F7AFC /* spritesheet1.pvr */; };
+		657F11BB150BA7970047F93C /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F48B0B1045AD2F00755CFB /* Default.png */; };
+		657F11BC150BA7970047F93C /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F48B0C1045AD2F00755CFB /* Icon.png */; };
+		657F11BD150BA7970047F93C /* fps_images.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F411A81068D563002A0D5E /* fps_images.png */; };
+		657F11BE150BA7970047F93C /* Icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E091E65F134EA49100C435A9 /* Icon@2x.png */; };
+		657F11BF150BA7970047F93C /* Icon-Small@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E091E660134EA49100C435A9 /* Icon-Small@2x.png */; };
+		657F11C0150BA7970047F93C /* Icon-Small.png in Resources */ = {isa = PBXBuildFile; fileRef = E091E661134EA49100C435A9 /* Icon-Small.png */; };
+		657F11C1150BA7970047F93C /* Icon-Small-50.png in Resources */ = {isa = PBXBuildFile; fileRef = E091E662134EA49100C435A9 /* Icon-Small-50.png */; };
+		657F11C2150BA7970047F93C /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = E091E663134EA49100C435A9 /* Icon-72.png */; };
+		657F11C4150BA7970047F93C /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 5030942510447BC7005F7AFC /* main.m */; };
+		657F11C9150BA7970047F93C /* libcocos2d libraries.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 506EE05E10304ED200A389B3 /* libcocos2d libraries.a */; };
+		657F11CA150BA7970047F93C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50671AB611B9596B006C0061 /* CoreGraphics.framework */; };
+		657F11CB150BA7970047F93C /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50671AB811B9596B006C0061 /* OpenGLES.framework */; };
+		657F11CC150BA7970047F93C /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50671ABA11B9596B006C0061 /* QuartzCore.framework */; };
+		657F11CD150BA7970047F93C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50671ABC11B9596B006C0061 /* UIKit.framework */; };
+		657F11CE150BA7970047F93C /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 50671ABE11B9596B006C0061 /* libz.dylib */; };
+		657F11DB150BA8180047F93C /* AppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 657F11D8150BA8180047F93C /* AppController.m */; };
+		657F11DC150BA8180047F93C /* PerformanceDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 657F11DA150BA8180047F93C /* PerformanceDispatcher.m */; };
 		E037D9AA1280E402003D39D7 /* texture1024x1024_rgba4444.pvr.gz in Resources */ = {isa = PBXBuildFile; fileRef = E037D9A81280E402003D39D7 /* texture1024x1024_rgba4444.pvr.gz */; };
 		E091E664134EA49100C435A9 /* Icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E091E65F134EA49100C435A9 /* Icon@2x.png */; };
 		E091E665134EA49100C435A9 /* Icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E091E65F134EA49100C435A9 /* Icon@2x.png */; };
@@ -448,6 +558,13 @@
 			remoteGlobalIDString = 50F411731068D3F0002A0D5E;
 			remoteInfo = FontLabel;
 		};
+		657F115C150BA7970047F93C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 506EE05D10304ED200A389B3;
+			remoteInfo = "cocos2d libraries";
+		};
 		E0B0E62E11F8C3BB00414246 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
@@ -600,6 +717,11 @@
 		50F411A81068D563002A0D5E /* fps_images.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = fps_images.png; path = ../../Resources/Fonts/fps_images.png; sourceTree = SOURCE_ROOT; };
 		50F48B0B1045AD2F00755CFB /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Default.png; path = ../../Resources/Default.png; sourceTree = SOURCE_ROOT; };
 		50F48B0C1045AD2F00755CFB /* Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Icon.png; path = ../../Resources/Icon.png; sourceTree = SOURCE_ROOT; };
+		657F11D2150BA7970047F93C /* TouchDispatcherPerformance.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TouchDispatcherPerformance.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		657F11D7150BA8180047F93C /* AppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppController.h; sourceTree = "<group>"; };
+		657F11D8150BA8180047F93C /* AppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppController.m; sourceTree = "<group>"; };
+		657F11D9150BA8180047F93C /* PerformanceDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PerformanceDispatcher.h; sourceTree = "<group>"; };
+		657F11DA150BA8180047F93C /* PerformanceDispatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PerformanceDispatcher.m; sourceTree = "<group>"; };
 		E037D9A81280E402003D39D7 /* texture1024x1024_rgba4444.pvr.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; name = texture1024x1024_rgba4444.pvr.gz; path = ../../Resources/Images/texture1024x1024_rgba4444.pvr.gz; sourceTree = SOURCE_ROOT; };
 		E091E65F134EA49100C435A9 /* Icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Icon@2x.png"; path = "../../Resources/Icon@2x.png"; sourceTree = "<group>"; };
 		E091E660134EA49100C435A9 /* Icon-Small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Icon-Small@2x.png"; path = "../../Resources/Icon-Small@2x.png"; sourceTree = "<group>"; };
@@ -862,6 +984,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		657F11C8150BA7970047F93C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				657F11C9150BA7970047F93C /* libcocos2d libraries.a in Frameworks */,
+				657F11CA150BA7970047F93C /* CoreGraphics.framework in Frameworks */,
+				657F11CB150BA7970047F93C /* OpenGLES.framework in Frameworks */,
+				657F11CC150BA7970047F93C /* QuartzCore.framework in Frameworks */,
+				657F11CD150BA7970047F93C /* UIKit.framework in Frameworks */,
+				657F11CE150BA7970047F93C /* libz.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E0B0E64311F8C3BB00414246 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -888,6 +1023,7 @@
 				506719FF11B956ED006C0061 /* ParticlePerformance.app */,
 				5006BA5711BBF4DB00E488BD /* ChildrenNodePerformance.app */,
 				E0B0E64E11F8C3BB00414246 /* TexturePerformance.app */,
+				657F11D2150BA7970047F93C /* TouchDispatcherPerformance.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -895,6 +1031,7 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
+				657F11D6150BA8180047F93C /* PerformanceDispatcherTest */,
 				E0F6BECE1271108200BF4F7D /* cocos2d */,
 				50F411831068D443002A0D5E /* FontLabel */,
 				503095C0104482EA005F7AFC /* PerformanceSpriteTest */,
@@ -1133,6 +1270,17 @@
 			name = FontLabel;
 			path = ../../external/FontLabel;
 			sourceTree = SOURCE_ROOT;
+		};
+		657F11D6150BA8180047F93C /* PerformanceDispatcherTest */ = {
+			isa = PBXGroup;
+			children = (
+				657F11D7150BA8180047F93C /* AppController.h */,
+				657F11D8150BA8180047F93C /* AppController.m */,
+				657F11D9150BA8180047F93C /* PerformanceDispatcher.h */,
+				657F11DA150BA8180047F93C /* PerformanceDispatcher.m */,
+			);
+			path = PerformanceDispatcherTest;
+			sourceTree = "<group>";
 		};
 		E0B0E65211F8C4A400414246 /* PerformanceTextureTest */ = {
 			isa = PBXGroup;
@@ -1551,6 +1699,24 @@
 			productReference = 50F411741068D3F0002A0D5E /* libFontLabel.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		657F115A150BA7970047F93C /* TouchDispatcherPerformance */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 657F11CF150BA7970047F93C /* Build configuration list for PBXNativeTarget "TouchDispatcherPerformance" */;
+			buildPhases = (
+				657F115D150BA7970047F93C /* Resources */,
+				657F11C3150BA7970047F93C /* Sources */,
+				657F11C8150BA7970047F93C /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				657F115B150BA7970047F93C /* PBXTargetDependency */,
+			);
+			name = TouchDispatcherPerformance;
+			productName = SpritePerformance;
+			productReference = 657F11D2150BA7970047F93C /* TouchDispatcherPerformance.app */;
+			productType = "com.apple.product-type.application";
+		};
 		E0B0E62C11F8C3BB00414246 /* TexturePerformance */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E0B0E64B11F8C3BB00414246 /* Build configuration list for PBXNativeTarget "TexturePerformance" */;
@@ -1598,6 +1764,7 @@
 				506719FE11B956ED006C0061 /* ParticlePerformance */,
 				5006BA3511BBF4DB00E488BD /* ChildrenNodePerformance */,
 				E0B0E62C11F8C3BB00414246 /* TexturePerformance */,
+				657F115A150BA7970047F93C /* TouchDispatcherPerformance */,
 			);
 		};
 /* End PBXProject section */
@@ -1754,6 +1921,114 @@
 				E091E66D134EA49100C435A9 /* Icon-Small.png in Resources */,
 				E091E671134EA49100C435A9 /* Icon-Small-50.png in Resources */,
 				E091E675134EA49100C435A9 /* Icon-72.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		657F115D150BA7970047F93C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				657F115E150BA7970047F93C /* b1.png in Resources */,
+				657F115F150BA7970047F93C /* b2.png in Resources */,
+				657F1160150BA7970047F93C /* f1.png in Resources */,
+				657F1161150BA7970047F93C /* f2.png in Resources */,
+				657F1162150BA7970047F93C /* fire.png in Resources */,
+				657F1163150BA7970047F93C /* fire.pvr in Resources */,
+				657F1164150BA7970047F93C /* r1.png in Resources */,
+				657F1165150BA7970047F93C /* r2.png in Resources */,
+				657F1166150BA7970047F93C /* grossini.png in Resources */,
+				657F1167150BA7970047F93C /* grossini_dance_01.png in Resources */,
+				657F1168150BA7970047F93C /* grossini_dance_02.png in Resources */,
+				657F1169150BA7970047F93C /* grossini_dance_03.png in Resources */,
+				657F116A150BA7970047F93C /* grossini_dance_04.png in Resources */,
+				657F116B150BA7970047F93C /* grossini_dance_05.png in Resources */,
+				657F116C150BA7970047F93C /* grossini_dance_06.png in Resources */,
+				657F116D150BA7970047F93C /* grossini_dance_07.png in Resources */,
+				657F116E150BA7970047F93C /* grossini_dance_08.png in Resources */,
+				657F116F150BA7970047F93C /* grossini_dance_09.png in Resources */,
+				657F1170150BA7970047F93C /* grossini_dance_10.png in Resources */,
+				657F1171150BA7970047F93C /* grossini_dance_11.png in Resources */,
+				657F1172150BA7970047F93C /* grossini_dance_12.png in Resources */,
+				657F1173150BA7970047F93C /* grossini_dance_13.png in Resources */,
+				657F1174150BA7970047F93C /* grossini_dance_14.png in Resources */,
+				657F1175150BA7970047F93C /* grossini_dance_atlas.png in Resources */,
+				657F1176150BA7970047F93C /* grossini_dance_atlas.pvr in Resources */,
+				657F1177150BA7970047F93C /* grossinis_sister1.png in Resources */,
+				657F1178150BA7970047F93C /* grossinis_sister1.pvr in Resources */,
+				657F1179150BA7970047F93C /* sprite-0-0.png in Resources */,
+				657F117A150BA7970047F93C /* sprite-0-1.png in Resources */,
+				657F117B150BA7970047F93C /* sprite-0-2.png in Resources */,
+				657F117C150BA7970047F93C /* sprite-0-3.png in Resources */,
+				657F117D150BA7970047F93C /* sprite-0-4.png in Resources */,
+				657F117E150BA7970047F93C /* sprite-0-5.png in Resources */,
+				657F117F150BA7970047F93C /* sprite-0-6.png in Resources */,
+				657F1180150BA7970047F93C /* sprite-0-7.png in Resources */,
+				657F1181150BA7970047F93C /* sprite-1-0.png in Resources */,
+				657F1182150BA7970047F93C /* sprite-1-1.png in Resources */,
+				657F1183150BA7970047F93C /* sprite-1-2.png in Resources */,
+				657F1184150BA7970047F93C /* sprite-1-3.png in Resources */,
+				657F1185150BA7970047F93C /* sprite-1-4.png in Resources */,
+				657F1186150BA7970047F93C /* sprite-1-5.png in Resources */,
+				657F1187150BA7970047F93C /* sprite-1-6.png in Resources */,
+				657F1188150BA7970047F93C /* sprite-1-7.png in Resources */,
+				657F1189150BA7970047F93C /* sprite-2-0.png in Resources */,
+				657F118A150BA7970047F93C /* sprite-2-1.png in Resources */,
+				657F118B150BA7970047F93C /* sprite-2-2.png in Resources */,
+				657F118C150BA7970047F93C /* sprite-2-3.png in Resources */,
+				657F118D150BA7970047F93C /* sprite-2-4.png in Resources */,
+				657F118E150BA7970047F93C /* sprite-2-5.png in Resources */,
+				657F118F150BA7970047F93C /* sprite-2-6.png in Resources */,
+				657F1190150BA7970047F93C /* sprite-2-7.png in Resources */,
+				657F1191150BA7970047F93C /* sprite-3-0.png in Resources */,
+				657F1192150BA7970047F93C /* sprite-3-1.png in Resources */,
+				657F1193150BA7970047F93C /* sprite-3-2.png in Resources */,
+				657F1194150BA7970047F93C /* sprite-3-3.png in Resources */,
+				657F1195150BA7970047F93C /* sprite-3-4.png in Resources */,
+				657F1196150BA7970047F93C /* sprite-3-5.png in Resources */,
+				657F1197150BA7970047F93C /* sprite-3-6.png in Resources */,
+				657F1198150BA7970047F93C /* sprite-3-7.png in Resources */,
+				657F1199150BA7970047F93C /* sprite-4-0.png in Resources */,
+				657F119A150BA7970047F93C /* sprite-4-1.png in Resources */,
+				657F119B150BA7970047F93C /* sprite-4-2.png in Resources */,
+				657F119C150BA7970047F93C /* sprite-4-3.png in Resources */,
+				657F119D150BA7970047F93C /* sprite-4-4.png in Resources */,
+				657F119E150BA7970047F93C /* sprite-4-5.png in Resources */,
+				657F119F150BA7970047F93C /* sprite-4-6.png in Resources */,
+				657F11A0150BA7970047F93C /* sprite-4-7.png in Resources */,
+				657F11A1150BA7970047F93C /* sprite-5-0.png in Resources */,
+				657F11A2150BA7970047F93C /* sprite-5-1.png in Resources */,
+				657F11A3150BA7970047F93C /* sprite-5-2.png in Resources */,
+				657F11A4150BA7970047F93C /* sprite-5-3.png in Resources */,
+				657F11A5150BA7970047F93C /* sprite-5-4.png in Resources */,
+				657F11A6150BA7970047F93C /* sprite-5-5.png in Resources */,
+				657F11A7150BA7970047F93C /* sprite-5-6.png in Resources */,
+				657F11A8150BA7970047F93C /* sprite-5-7.png in Resources */,
+				657F11A9150BA7970047F93C /* sprite-6-0.png in Resources */,
+				657F11AA150BA7970047F93C /* sprite-6-1.png in Resources */,
+				657F11AB150BA7970047F93C /* sprite-6-2.png in Resources */,
+				657F11AC150BA7970047F93C /* sprite-6-3.png in Resources */,
+				657F11AD150BA7970047F93C /* sprite-6-4.png in Resources */,
+				657F11AE150BA7970047F93C /* sprite-6-5.png in Resources */,
+				657F11AF150BA7970047F93C /* sprite-6-6.png in Resources */,
+				657F11B0150BA7970047F93C /* sprite-6-7.png in Resources */,
+				657F11B1150BA7970047F93C /* sprite-7-0.png in Resources */,
+				657F11B2150BA7970047F93C /* sprite-7-1.png in Resources */,
+				657F11B3150BA7970047F93C /* sprite-7-2.png in Resources */,
+				657F11B4150BA7970047F93C /* sprite-7-3.png in Resources */,
+				657F11B5150BA7970047F93C /* sprite-7-4.png in Resources */,
+				657F11B6150BA7970047F93C /* sprite-7-5.png in Resources */,
+				657F11B7150BA7970047F93C /* sprite-7-6.png in Resources */,
+				657F11B8150BA7970047F93C /* sprite-7-7.png in Resources */,
+				657F11B9150BA7970047F93C /* spritesheet1.png in Resources */,
+				657F11BA150BA7970047F93C /* spritesheet1.pvr in Resources */,
+				657F11BB150BA7970047F93C /* Default.png in Resources */,
+				657F11BC150BA7970047F93C /* Icon.png in Resources */,
+				657F11BD150BA7970047F93C /* fps_images.png in Resources */,
+				657F11BE150BA7970047F93C /* Icon@2x.png in Resources */,
+				657F11BF150BA7970047F93C /* Icon-Small@2x.png in Resources */,
+				657F11C0150BA7970047F93C /* Icon-Small.png in Resources */,
+				657F11C1150BA7970047F93C /* Icon-Small-50.png in Resources */,
+				657F11C2150BA7970047F93C /* Icon-72.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1941,6 +2216,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		657F11C3150BA7970047F93C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				657F11C4150BA7970047F93C /* main.m in Sources */,
+				657F11DB150BA8180047F93C /* AppController.m in Sources */,
+				657F11DC150BA8180047F93C /* PerformanceDispatcher.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E0B0E63F11F8C3BB00414246 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1983,6 +2268,11 @@
 			isa = PBXTargetDependency;
 			target = 50F411731068D3F0002A0D5E /* FontLabel */;
 			targetProxy = 50F411981068D450002A0D5E /* PBXContainerItemProxy */;
+		};
+		657F115B150BA7970047F93C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 506EE05D10304ED200A389B3 /* cocos2d libraries */;
+			targetProxy = 657F115C150BA7970047F93C /* PBXContainerItemProxy */;
 		};
 		E0B0E62D11F8C3BB00414246 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2186,6 +2476,52 @@
 			};
 			name = Release;
 		};
+		657F11D0150BA7970047F93C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(SYSTEM_LIBRARY_DIR)/Frameworks/UIKit.framework/Headers/UIKit.h";
+				INFOPLIST_FILE = ../../Resources/Info.plist;
+				INSTALL_PATH = "$(HOME)/Applications";
+				IPHONEOS_DEPLOYMENT_TARGET = 3.1.3;
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-framework",
+					UIKit,
+				);
+				PRODUCT_NAME = TouchDispatcherPerformance;
+			};
+			name = Debug;
+		};
+		657F11D1150BA7970047F93C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "$(SYSTEM_LIBRARY_DIR)/Frameworks/UIKit.framework/Headers/UIKit.h";
+				INFOPLIST_FILE = ../../Resources/Info.plist;
+				INSTALL_PATH = "$(HOME)/Applications";
+				IPHONEOS_DEPLOYMENT_TARGET = 3.1.3;
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-framework",
+					UIKit,
+				);
+				PRODUCT_NAME = TouchDispatcherPerformance;
+				ZERO_LINK = NO;
+			};
+			name = Release;
+		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2333,6 +2669,15 @@
 			buildConfigurations = (
 				50F411751068D3F1002A0D5E /* Debug */,
 				50F411761068D3F1002A0D5E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		657F11CF150BA7970047F93C /* Build configuration list for PBXNativeTarget "TouchDispatcherPerformance" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				657F11D0150BA7970047F93C /* Debug */,
+				657F11D1150BA7970047F93C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/tests/ProgressActionsTest.m
+++ b/tests/ProgressActionsTest.m
@@ -253,10 +253,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];	

--- a/tests/RenderTextureTest.m
+++ b/tests/RenderTextureTest.m
@@ -571,10 +571,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/RotateWorldTest.m
+++ b/tests/RotateWorldTest.m
@@ -180,11 +180,12 @@
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
-
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
+    
 	CCScene *scene = [CCScene node];
 
 	MainLayer * mainLayer =[MainLayer node];

--- a/tests/SceneTest.m
+++ b/tests/SceneTest.m
@@ -251,10 +251,11 @@
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 

--- a/tests/SchedulerTest.m
+++ b/tests/SchedulerTest.m
@@ -656,10 +656,11 @@ Class restartTest()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextTest() node]];

--- a/tests/SpriteTest.m
+++ b/tests/SpriteTest.m
@@ -811,7 +811,7 @@ Class restartAction()
 
 -(NSString *) subtitle
 {
-	return @"tag order in console should be 2,1,3,4,5";
+	return @"tag order in console should be 2,3,4,5,1";
 }
 
 @end
@@ -4052,7 +4052,7 @@ Class restartAction()
 			CCSprite *child1 = [CCSprite spriteWithSpriteFrameName:@"grossini_dance_01.png"];
 			[child1 setPosition: ccp(sprite.contentSize.width / 2.0f, sprite.contentSize.height / 2.0f)];
 			
-			[child1 setScale:0.8];
+			[child1 setScale:0.8f];
 
 			[sprite addChild: child1];
 			
@@ -4547,10 +4547,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+    // When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	// Assume that PVR images have premultiplied alpha
 	[CCTexture2D PVRImagesHavePremultipliedAlpha:YES];

--- a/tests/TestCocos2dExtension.m
+++ b/tests/TestCocos2dExtension.m
@@ -230,11 +230,11 @@ Class restartAction(void)
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];	
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
-
+    // When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	// create the main scene
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/Texture2dTest.m
+++ b/tests/Texture2dTest.m
@@ -1740,6 +1740,7 @@ Class restartAction()
 }
 -(void) dealloc
 {
+    [super dealloc];
 	[tex1_ release];
 	[tex2_ release];
 }
@@ -1784,6 +1785,7 @@ Class restartAction()
 }
 -(void) dealloc
 {
+    [super dealloc];
 	[tex1_ release];
 	[tex2_ release];
 }
@@ -1847,14 +1849,14 @@ Class restartAction()
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 		// Testint CCFileUtils API
 		BOOL ret;
-		ret = [CCFileUtils retinaDisplayFileExistsAtPath:@"bugs/test_issue_1179.png"];
+		ret = [CCFileUtils iPhoneRetinaDisplayFileExistsAtPath:@"bugs/test_issue_1179.png"];
 		if( ret )
 			NSLog(@"Test #3: retinaDisplayFileExistsAtPath: OK");
 		else
 			NSLog(@"Test #3: retinaDisplayFileExistsAtPath: FAILED");
 
 
-		ret = [CCFileUtils retinaDisplayFileExistsAtPath:@"grossini-does_no_exist.png"];
+		ret = [CCFileUtils iPhoneRetinaDisplayFileExistsAtPath:@"grossini-does_no_exist.png"];
 		if( !ret )
 			NSLog(@"Test #4: retinaDisplayFileExistsAtPath: OK");
 		else
@@ -1925,10 +1927,11 @@ Class restartAction()
 	// You can change it at anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];	
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];	// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/TileMapTest.m
+++ b/tests/TileMapTest.m
@@ -1610,10 +1610,11 @@ Class restartAction()
 	if( ! [director enableRetinaDisplay:YES] )
 		CCLOG(@"Retina Display Not supported");
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	// glview is a child of the main window
 	[window addSubview:glView];

--- a/tests/TransitionsTest.m
+++ b/tests/TransitionsTest.m
@@ -479,10 +479,11 @@ Class restartTransition()
 	if( ! [director enableRetinaDisplay:YES] )
 		CCLOG(@"Retina Display Not supported");
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+    // When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 
 	// glview is a child of the main window
 	[window addSubview:glView];

--- a/tests/ZwoptexTest.m
+++ b/tests/ZwoptexTest.m
@@ -278,11 +278,12 @@ static int spriteFrameIndex = 0;
 	if( ! [director enableRetinaDisplay:YES] )
 		CCLOG(@"Retina Display Not supported");
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
-
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
+    
 	// make the OpenGLView a child of the main window
 	[window addSubview:glView];
 	

--- a/tests/cocosnodeTest.m
+++ b/tests/cocosnodeTest.m
@@ -993,10 +993,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];

--- a/tests/drawPrimitivesTest.m
+++ b/tests/drawPrimitivesTest.m
@@ -225,8 +225,12 @@ Class restartAction()
 
 	// draw cubic bezier path
 	ccDrawCubicBezier(ccp(s.width/2, s.height/2), ccp(s.width/2+30,s.height/2+50), ccp(s.width/2+60,s.height/2-50),ccp(s.width, s.height/2),100);
-
-	
+    
+    CGPoint vertices3[] = {ccp(60,160), ccp(70,190), ccp(100,190), ccp(90,160)};
+    
+    //draw a solid polygon
+    ccDrawSolidPoly( vertices3, 4, YES );
+        
 	// restore original values
 	glLineWidth(1);
 	glColor4ub(255,255,255,255);
@@ -281,10 +285,11 @@ Class restartAction()
 	// You can change anytime.
 	[CCTexture2D setDefaultAlphaPixelFormat:kCCTexture2DPixelFormat_RGBA8888];
 	
-	// When in iPad / RetinaDisplay mode, CCFileUtils will append the "-ipad" / "-hd" to all loaded files
-	// If the -ipad  / -hdfile is not found, it will load the non-suffixed version
-	[CCFileUtils setiPadSuffix:@"-ipad"];			// Default on iPad is "" (empty string)
-	[CCFileUtils setRetinaDisplaySuffix:@"-hd"];	// Default on RetinaDisplay is "-hd"
+	// When in iPhone RetinaDisplay, iPad, iPad RetinaDisplay mode, CCFileUtils will append the "-hd", "-ipad", "-ipadhd" to all loaded files
+	// If the -hd, -ipad, -ipadhd files are not found, it will load the non-suffixed version
+	[CCFileUtils setiPhoneRetinaDisplaySuffix:@"-hd"];		// Default on iPhone RetinaDisplay is "-hd"
+	[CCFileUtils setiPadSuffix:@"-ipad"];					// Default on iPad is "" (empty string)
+	[CCFileUtils setiPadRetinaDisplaySuffix:@"-ipadhd"];	// Default on iPad RetinaDisplay is "-ipadhd"
 	
 	CCScene *scene = [CCScene node];
 	[scene addChild: [nextAction() node]];


### PR DESCRIPTION
. [FIX] TouchDispatcher: correctly handles addition and removal of
handlers when being inside a touch handler ( issue #1084  #1139 #1173
#1267)

. [FIX] TouchDispatcher: correctly handles priority change of the
handler when being inside a touch handler
. [NEW] TouchDispatcher: migration from NSMutableArrays to CCArray
along with the change of internal processing allows for substantial
improvements in functions' speed.
 [NEW] TouchDispatcher: user can choose which handlers process the
touches first: Standard or Targeted.
. [NEW] TouchDispatcher: user can choose one of three sorting
algorithms: InsertionSort, QSort, LMerge or none at all.
. [NEW] TouchDispatcher: user can supply his own comparator for
customized sort for the sorting algorithm. ZOrder comparator is
provided. Inverse priority sort is also an option.
. [NEW] TouchDispatcher: Introduction of new dispatcher properties:
'tag', 'disable', 'remove' and new API functions working with ranges of
attribute values give the user the ability to pinpoint and control
handler(s).
. [NEW] TouchDispatcher: New API functions give user full control over
the properties of handlers. They also allow proper disabling and
removing handlers inside and outside touch callbacks.
