### PR TITLE
Support for unicode characters > 2048 in CCLabelBMFont

### DIFF
--- a/cocos2d/CCLabelBMFont.h
+++ b/cocos2d/CCLabelBMFont.h
@@ -52,6 +52,8 @@ typedef struct _BMFontDef {
 	int yOffset;
 	//! The amount to move the current position after drawing the character (in pixels)
 	int xAdvance;
+    // Enable Hash Table
+    UT_hash_handle hh;
 } ccBMFontDef;
 
 /** @struct ccBMFontPadding
@@ -69,11 +71,6 @@ typedef struct _BMFontPadding {
 	int bottom;
 } ccBMFontPadding;
 
-enum {
-	// how many characters are supported
-	kCCBMFontMaxChars = 2048, //256,
-};
-
 /** CCBMFontConfiguration has parsed configuration of the the .fnt file
  @since v0.8
  */
@@ -82,7 +79,7 @@ enum {
     // XXX: Creating a public interface so that the bitmapFontArray[] is accesible
 @public
 	// The characters building up the font
-	ccBMFontDef	BMFontArray_[kCCBMFontMaxChars];
+	ccBMFontDef *BMFontHash_;
 	
 	// FNTConfig: Common Height
 	NSUInteger		commonHeight_;


### PR DESCRIPTION
This is a follow up to http://www.cocos2d-iphone.org/forum/topic/29494

The current version of CCLabelBMFont, allocates a 2048 sized array of ccBMFontDef for glyphs, this has two issues, one it over allocates memory for 2048 fonts that may not be used, and it does not allow for support of unicode characters above 2048.  I've modified CCLabelBMFont to use a hash to store it's fonts.  I realize this may slow down performance a bit (hash table lookup) but it seemed the best way to support all unicode characters in a CCLabelBMFont

Thanks
Rick
