### PR TITLE
CCSprite: don't call visit method if opacity_ == 0.

### DIFF
--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -634,6 +634,15 @@ static SEL selSortMethod = NULL;
 	
 }
 
+- (void)visit
+{
+  if ( opacity_ == 0 )
+    return;
+  
+  [super visit];
+}
+
+
 #pragma mark CCSprite - CCNode overrides
 
 -(void) addChild:(CCSprite*)child z:(NSInteger)z tag:(NSInteger) aTag


### PR DESCRIPTION
Hello!

While I have been working on game at Dash & Dot I've met a problem with FPS. I can't understand for a long, why FPS in our tutorial scene was only 40. 

Let me describe how I was creating all items in this scene. At first, we have several independent CCLayer object that represents different elements of tutorial scene: 1) bottom layer with main game field 2) middle layer with different labels that should describe what player sees 3) and top layer, that shows "Pause" menu and other UI stuff. We have 56 elements on middle layer, but at one time we are showing 3-4 of them. All of 56 elements are belong to one sprite sheet. Each time I'm switching visible elements with fadeIn/fadeOut animation.

After small research I've found that all "invisible" elements just have opacity = 0 at moment, when they are created. It was a little confusing for me to understand, that sprites with opacity = 0 are redrawn each time and thats why FPS was 40. 

I understand, that the good practice should be using visible = YES/NO for initial state for sprites, but I think that anybody can forgot to switch state of visibility after fadeOut animation. And I think that sprite shouldn't be drawn each time if it has opacity = 0 because it means that it is invisible.

If you have another opinion it will be great to hear it.
