### PR TITLE
Rendertexture issue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Contributors (alphabetically ordered):
 	Word Wrap works on LabelTTF on Mac
 	bug fixes for failure to compile on 32-bit mac builds
 	created new drawPrimitives functions, ccDrawRect, ccDrawSolidRect and ccDrawSolidPoly.
+    bug fix for CCTMXXMLParser in release mode
 	
 * Jerrod Putman (http://www.tinytimgames.com)
 	Original author of ARC compatibility code

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ version 1.1-beta2 xx - 2012
 . [NEW] Types: Added convenience function to create a ccColor4F from color components
 . [FIX] Actions: incorrect behavior of CCRepeat
 . [FIX] CCLabelBMFont: full unicode support
+. [FIX] CCTMXXMLParser: removed unused variables in release mode
 . [FIX] ColorLayer: incorrect size in init method
 . [FIX] Denshion: Background music fades ok (issue #1304)
 . [FIX] EAGLView: always destroy and recreate OpenGL buffers completely (issue #1254) 

--- a/cocos2d/CCRenderTexture.h
+++ b/cocos2d/CCRenderTexture.h
@@ -49,6 +49,8 @@ enum
  the render texture to your scene and treat it like any other CocosNode.
  There are also functions for saving the render texture to disk in PNG or JPG format.
  
+ 
+ 
  @since v0.8.1
  */
 @interface CCRenderTexture : CCNode 
@@ -96,9 +98,13 @@ enum
 -(BOOL)saveBuffer:(NSString*)name;
 /** saves the texture into a file. The format can be JPG or PNG */
 -(BOOL)saveBuffer:(NSString*)name format:(int)format;
-/* get buffer as UIImage, can only save a render buffer which has a RGBA8888 pixel format */
+/** get buffer as UIImage, can only save a render buffer which has a RGBA8888 pixel format */
 -(NSData*)getUIImageAsDataFromBuffer:(int) format;
-/* get buffer as UIImage */
+/** get buffer as UIImage 
+ In rare cases getUIImageFromBuffer produces artifacts, a workaround for this is 
+ NSData *imageData = [renderer getUIImageAsDataFromBuffer:kCCImageFormatPNG];
+ UIImage *image = [UIImage imageWithData:imageData];
+ */
 -(UIImage *)getUIImageFromBuffer;
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED

--- a/cocos2d/CCTMXXMLParser.m
+++ b/cocos2d/CCTMXXMLParser.m
@@ -186,7 +186,7 @@
 	[super dealloc];
 }
 
-- (NSError*) parseXMLData:(NSData*)data
+- (void) parseXMLData:(NSData*)data
 {
 	NSXMLParser *parser = [[[NSXMLParser alloc] initWithData:data] autorelease];
 	
@@ -197,22 +197,21 @@
 	[parser setShouldResolveExternalEntities:NO];
 	[parser parse];
 	
-	return [parser parserError];
+     NSAssert1( ![parser parserError], @"Error parsing TMX data: %@.", [NSString stringWithCharacters:[data bytes] length:[data length]] );
 }
 
 - (void) parseXMLString:(NSString *)xmlString
 {
 	NSData* data = [xmlString dataUsingEncoding:NSUTF8StringEncoding];
-	NSError* err = [self parseXMLData:data];
-	NSAssert1( !err, @"Error parsing TMX data: %@.", [NSString stringWithCharacters:[data bytes] length:[data length]] );
+	[self parseXMLData:data];
+	
 }
 
 - (void) parseXMLFile:(NSString *)xmlFilename
 {
 	NSURL *url = [NSURL fileURLWithPath:[CCFileUtils fullPathFromRelativePath:xmlFilename] ];
 	NSData *data = [NSData dataWithContentsOfURL:url];
-	NSError* err = [self parseXMLData:data];
-	NSAssert3(!err, @"Error parsing TMX file: %@, %@ (%d).", xmlFilename, [err localizedDescription], [err code]);
+	[self parseXMLData:data];
 }
 
 // the XML parser calls here with all the elements


### PR DESCRIPTION
getUIImageFromBuffer is now a bit faster and is more conform with getUIImageAsDataFromBuffer. 

One commit also fixes the unused variables in the CCTMXXMLParser in release mode.
