### PR TITLE
fixed crash related to NSThread block additions

### DIFF
--- a/cocos2d/Support/NSThread+performBlock.m
+++ b/cocos2d/Support/NSThread+performBlock.m
@@ -44,7 +44,7 @@ typedef void (^BlockWithParam)(id param);
 {
     [self performSelector:@selector(executeBlock:) 
                  onThread:self
-			   withObject: block
+			   withObject: [[block copy] autorelease]
 			waitUntilDone: wait];
 }
 


### PR DESCRIPTION
blocks are made in stack, [[block copy] autorelease] copies them to heap
