### PR TITLE
Make CCParticleSystem unschedule its update selector on dealloc

### DIFF
--- a/cocos2d/CCParticleSystem.m
+++ b/cocos2d/CCParticleSystem.m
@@ -342,6 +342,8 @@
 
 -(void) dealloc
 {
+	[self unscheduleUpdate];
+
 	free( particles );
 
 	if (animationFrameData_) 


### PR DESCRIPTION
We ran into an issue where a CCParticleSystem was being created at the same memory address as a CCParticleSystem that was previously dealloc'd. We would then (with `COCOS2D_DEBUG=1`) get a "CCScheduler: You can't re-schedule an 'update' selector'. Unschedule it first" error.

Adding an unschedule to the CCParticleSystem dealloc fixes this and seems like the correct behavior - it doesn't make sense to leave a selector scheduled for an object that no longer exists?
