### PR TITLE
Make startAnimation and stopAnimation idempotent in CCDirector

### DIFF
--- a/cocos2d/CCDirector.h
+++ b/cocos2d/CCDirector.h
@@ -102,6 +102,9 @@ and when to execute the Scenes.
 
 	/* is the running scene paused */
 	BOOL isPaused_;
+    
+    /* Is the director running */
+    BOOL isAnimating_;
 
 	/* The running scene */
 	CCScene *runningScene_;
@@ -167,6 +170,8 @@ and when to execute the Scenes.
 @property (nonatomic,readwrite,assign) BOOL nextDeltaTimeZero;
 /** Whether or not the Director is paused */
 @property (nonatomic,readonly) BOOL isPaused;
+/** Whether or not the Director is active (animating) */
+@property (nonatomic,readonly) BOOL isAnimating;
 /** Sets an OpenGL projection */
 @property (nonatomic,readwrite) ccDirectorProjection projection;
 /** How many frames were called since the director started */

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -91,6 +91,7 @@ extern NSString * cocos2dVersion(void);
 @synthesize displayStats = displayStats_;
 @synthesize nextDeltaTimeZero = nextDeltaTimeZero_;
 @synthesize isPaused = isPaused_;
+@synthesize isAnimating = isAnimating_;
 @synthesize sendCleanupToScene = sendCleanupToScene_;
 @synthesize runningThread = runningThread_;
 @synthesize notificationNode = notificationNode_;

--- a/cocos2d/Platforms/Mac/CCDirectorMac.m
+++ b/cocos2d/Platforms/Mac/CCDirectorMac.m
@@ -421,6 +421,9 @@ static CVReturn MyDisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTime
 
 - (void) startAnimation
 {
+    if(isAnimating_)
+        return;
+
 	CCLOG(@"cocos2d: startAnimation");
 #if (CC_DIRECTOR_MAC_THREAD == CC_MAC_USE_OWN_THREAD)
 	runningThread_ = [[NSThread alloc] initWithTarget:self selector:@selector(mainLoop) object:nil];
@@ -445,10 +448,15 @@ static CVReturn MyDisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTime
 
 	// Activate the display link
 	CVDisplayLinkStart(displayLink);
+    
+    isAnimating_ = YES;
 }
 
 - (void) stopAnimation
 {
+    if(!isAnimating_)
+        return;
+
 	CCLOG(@"cocos2d: stopAnimation");
 
 	if( displayLink ) {
@@ -464,6 +472,8 @@ static CVReturn MyDisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTime
         runningThread_ = nil;
 #endif
 	}
+    
+    isAnimating_ = NO;
 }
 
 -(void) dealloc

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -459,7 +459,8 @@ CGFloat	__ccContentScaleFactor = 1;
 
 - (void) startAnimation
 {
-	NSAssert( displayLink_ == nil, @"displayLink must be nil. Calling startAnimation twice?");
+    if(isAnimating_)
+        return;
 
 	gettimeofday( &lastUpdate_, NULL);
 
@@ -482,11 +483,14 @@ CGFloat	__ccContentScaleFactor = 1;
 	[displayLink_ addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
 #endif
 
-
+    isAnimating_ = YES;
 }
 
 - (void) stopAnimation
 {
+    if(!isAnimating_)
+        return;
+
 	CCLOG(@"cocos2d: animation stopped");
 
 #if CC_DIRECTOR_IOS_USE_BACKGROUND_THREAD
@@ -497,6 +501,7 @@ CGFloat	__ccContentScaleFactor = 1;
 
 	[displayLink_ invalidate];
 	displayLink_ = nil;
+    isAnimating_ = NO;
 }
 
 // Overriden in order to use a more stable delta time

--- a/tests/SchedulerTest.h
+++ b/tests/SchedulerTest.h
@@ -80,6 +80,10 @@
 {}
 @end
 
+@interface DirectorStartStopAnimating : SchedulerTest
+{}
+@end
+
 @interface SchedulerTimeScale : SchedulerTest
 {
 #ifdef __CC_PLATFORM_IOS

--- a/tests/SchedulerTest.m
+++ b/tests/SchedulerTest.m
@@ -29,6 +29,7 @@ static NSString *transitions[] = {
 	@"SchedulerUpdateFromCustom",
 	@"RescheduleSelector",
 	@"SchedulerDelayAndRepeat",
+	@"DirectorStartStopAnimating",
 };
 
 Class nextTest(void);
@@ -848,6 +849,66 @@ Class restartTest()
 -(void) update:(ccTime)dt
 {
 	NSLog(@"update called:%f", dt);
+}
+
+@end
+
+
+#pragma mark DirectorStartStopAnimating
+@implementation DirectorStartStopAnimating
+
+-(id) init
+{
+	if( (self=[super init]) ) {
+        
+		CGSize s = [[CCDirector sharedDirector] winSize];
+        
+        CCSprite *sprite = [CCSprite spriteWithFile:@"grossinis_sister1.png"];
+        sprite.position = ccp(s.width/2, s.height/2);
+        [self addChild:sprite];
+        [sprite runAction:[CCRepeatForever actionWithAction:[CCRotateBy actionWithDuration:3.0 angle:360]]];
+        
+		[self schedule:@selector(stop:) interval:3 repeat:NO delay:0];
+        [self performSelectorOnMainThread:@selector(scheduleRestartTimer) withObject:nil waitUntilDone:NO];
+	}
+    
+	return self;
+}
+
+- (void) scheduleRestartTimer
+{
+    // This timer must run on the main thread since the director thread gets killed (on Mac).
+    [NSTimer scheduledTimerWithTimeInterval:5.0 target:self selector:@selector(restart:) userInfo:nil repeats:NO];
+}
+
+- (void) onExit
+{
+    if(![CCDirector sharedDirector].isAnimating)
+        [[CCDirector sharedDirector] startAnimation];
+}
+
+-(NSString *) title
+{
+	return @"Start/Stop Animating";
+}
+
+-(NSString *) subtitle
+{
+	return @"Everything will stop after 3s, then resume at 5s. See console";
+}
+
+-(void) stop:(ccTime)dt
+{
+    NSLog(@"Stopping the director (isAnimating = %d)", [CCDirector sharedDirector].isAnimating);
+	[[CCDirector sharedDirector] stopAnimation];
+    NSLog(@"Director has stopped (isAnimating = %d)", [CCDirector sharedDirector].isAnimating);
+}
+
+- (void) restart:(NSTimer*) timer
+{
+    NSLog(@"Restarting the director (isAnimating = %d)", [CCDirector sharedDirector].isAnimating);
+	[[CCDirector sharedDirector] startAnimation];
+    NSLog(@"Director has restarted (isAnimating = %d)", [CCDirector sharedDirector].isAnimating);
 }
 
 @end


### PR DESCRIPTION
Since CCDirector is a view controller, and is also a singleton, it causes some problems when moving between UIKit and cocos2d. I've made a custom view controller to get around this, but CCDirector still gets view notifications, and shuts itself down (stopAnimation). Thus, I need to be able to safely call startAnimation from my own view controller without worrying about it being active already (and throwing an assert as a result).
