### PR TITLE
Changed %@ = %08X in format strings for printing memory addresses, other format string type issues

### DIFF
--- a/cocos2d/CCAction.m
+++ b/cocos2d/CCAction.m
@@ -62,7 +62,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i>", [self class], self, tag_];
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i>", [self class], self, tag_];
 }
 
 -(id) copyWithZone: (NSZone*) zone

--- a/cocos2d/CCActionInstant.m
+++ b/cocos2d/CCActionInstant.m
@@ -248,7 +248,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i | target = %@ | selector = %@>",
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i | target = %@ | selector = %@>",
 			[self class],
 			self,
 			tag_,

--- a/cocos2d/CCActionManager.m
+++ b/cocos2d/CCActionManager.m
@@ -51,7 +51,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X>", [self class], self];
+	return [NSString stringWithFormat:@"<%@ = %p>", [self class], self];
 }
 
 - (void) dealloc

--- a/cocos2d/CCAnimation.m
+++ b/cocos2d/CCAnimation.m
@@ -64,7 +64,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | SpriteFrame = %08X, delayUnits = %0.2f >", [self class], self, spriteFrame_, delayUnits_ ];
+	return [NSString stringWithFormat:@"<%@ = %p | SpriteFrame = %p, delayUnits = %0.2f >", [self class], self, spriteFrame_, delayUnits_ ];
 }
 @end
 
@@ -142,7 +142,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | frames=%d, totalDelayUnits=%d, delayPerUnit=%f, loops=%d>", [self class], self,
+	return [NSString stringWithFormat:@"<%@ = %p | frames=%d, totalDelayUnits=%f, delayPerUnit=%f, loops=%d>", [self class], self,
 			[frames_ count],
 			totalDelayUnits_,
 			delayPerUnit_,

--- a/cocos2d/CCAnimationCache.m
+++ b/cocos2d/CCAnimationCache.m
@@ -72,7 +72,7 @@ static CCAnimationCache *sharedAnimationCache_=nil;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | num of animations =  %i>", [self class], self, [animations_ count]];
+	return [NSString stringWithFormat:@"<%@ = %p | num of animations =  %i>", [self class], self, [animations_ count]];
 }
 
 -(void) dealloc

--- a/cocos2d/CCCamera.m
+++ b/cocos2d/CCCamera.m
@@ -44,7 +44,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | center = (%.2f,%.2f,%.2f)>", [self class], self, centerX_, centerY_, centerZ_];
+	return [NSString stringWithFormat:@"<%@ = %p | center = (%.2f,%.2f,%.2f)>", [self class], self, centerX_, centerY_, centerZ_];
 }
 
 

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -175,7 +175,7 @@ static CCDirector *_sharedDirector = nil;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Size: %0.f x %0.f, view = %@>", [self class], self, winSizeInPoints_.width, winSizeInPoints_.height, view_];
+	return [NSString stringWithFormat:@"<%@ = %p | Size: %0.f x %0.f, view = %@>", [self class], self, winSizeInPoints_.width, winSizeInPoints_.height, view_];
 }
 
 - (void) dealloc

--- a/cocos2d/CCGLProgram.m
+++ b/cocos2d/CCGLProgram.m
@@ -114,7 +114,7 @@ typedef void (*GLLogFunction) (GLuint program,
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Program = %i, VertexShader = %i, FragmentShader = %i>", [self class], self, program_, vertShader_, fragShader_];
+	return [NSString stringWithFormat:@"<%@ = %p | Program = %i, VertexShader = %i, FragmentShader = %i>", [self class], self, program_, vertShader_, fragShader_];
 }
 
 

--- a/cocos2d/CCGrid.m
+++ b/cocos2d/CCGrid.m
@@ -137,7 +137,7 @@
 }
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Dimensions = %ix%i>", [self class], self, gridSize_.x, gridSize_.y];
+	return [NSString stringWithFormat:@"<%@ = %p | Dimensions = %ix%i>", [self class], self, gridSize_.x, gridSize_.y];
 }
 
 - (void) dealloc

--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -138,7 +138,7 @@ typedef struct _FontDefHashElement
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Glphys:%d Kernings:%d | Image = %@>", [self class], self,
+	return [NSString stringWithFormat:@"<%@ = %p | Glphys:%d Kernings:%d | Image = %@>", [self class], self,
 			HASH_COUNT(fontDefDictionary_),
 			HASH_COUNT(kerningDictionary_),
 			atlasName_];

--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -276,6 +276,6 @@
 {
 	// XXX: string_, fontName_ can't be displayed here, since they might be already released
 
-	return [NSString stringWithFormat:@"<%@ = %08X | FontSize = %.1f>", [self class], self, fontSize_];
+	return [NSString stringWithFormat:@"<%@ = %p | FontSize = %.1f>", [self class], self, fontSize_];
 }
 @end

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -167,7 +167,7 @@ static NSUInteger globalOrderOfArrival = 1;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i>", [self class], self, tag_];
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i>", [self class], self, tag_];
 }
 
 - (void) dealloc

--- a/cocos2d/CCParticleBatchNode.m
+++ b/cocos2d/CCParticleBatchNode.m
@@ -124,7 +124,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i>", [self class], self, tag_ ];
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i>", [self class], self, tag_ ];
 }
 
 -(void)dealloc

--- a/cocos2d/CCScheduler.m
+++ b/cocos2d/CCScheduler.m
@@ -129,7 +129,7 @@ typedef struct _hashSelectorEntry
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | target:%@ selector:(%@)>", [self class], self, [target class], NSStringFromSelector(selector)];
+	return [NSString stringWithFormat:@"<%@ = %p | target:%@ selector:(%@)>", [self class], self, [target class], NSStringFromSelector(selector)];
 }
 
 -(void) dealloc
@@ -230,7 +230,7 @@ typedef struct _hashSelectorEntry
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | timeScale = %0.2f >", [self class], self, timeScale_];
+	return [NSString stringWithFormat:@"<%@ = %p | timeScale = %0.2f >", [self class], self, timeScale_];
 }
 
 - (void) dealloc

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -239,7 +239,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Rect = (%.2f,%.2f,%.2f,%.2f) | tag = %i | atlasIndex = %i>", [self class], self,
+	return [NSString stringWithFormat:@"<%@ = %p | Rect = (%.2f,%.2f,%.2f,%.2f) | tag = %i | atlasIndex = %i>", [self class], self,
 			rect_.origin.x, rect_.origin.y, rect_.size.width, rect_.size.height,
 			tag_,
 			atlasIndex_

--- a/cocos2d/CCSpriteBatchNode.m
+++ b/cocos2d/CCSpriteBatchNode.m
@@ -123,7 +123,7 @@ const NSUInteger defaultCapacity = 29;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i>", [self class], self, tag_ ];
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i>", [self class], self, tag_ ];
 }
 
 -(void)dealloc

--- a/cocos2d/CCSpriteFrame.m
+++ b/cocos2d/CCSpriteFrame.m
@@ -102,7 +102,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Texture=%@, Rect = (%.2f,%.2f,%.2f,%.2f)> rotated:%d", [self class], self,
+	return [NSString stringWithFormat:@"<%@ = %p | Texture=%@, Rect = (%.2f,%.2f,%.2f,%.2f)> rotated:%d", [self class], self,
 			textureFilename_,
 			rect_.origin.x,
 			rect_.origin.y,

--- a/cocos2d/CCSpriteFrameCache.m
+++ b/cocos2d/CCSpriteFrameCache.m
@@ -82,7 +82,7 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | num of sprite frames =  %i>", [self class], self, [spriteFrames_ count]];
+	return [NSString stringWithFormat:@"<%@ = %p | num of sprite frames =  %i>", [self class], self, [spriteFrames_ count]];
 }
 
 -(void) dealloc

--- a/cocos2d/CCTMXXMLParser.m
+++ b/cocos2d/CCTMXXMLParser.m
@@ -232,7 +232,7 @@
 		else if( [orientationStr isEqualToString:@"hexagonal"])
 			orientation_ = CCTMXOrientationHex;
 		else
-			CCLOG(@"cocos2d: TMXFomat: Unsupported orientation: %@", orientation_);
+			CCLOG(@"cocos2d: TMXFomat: Unsupported orientation: %d", orientation_);
 
 		mapSize_.width = [[attributeDict objectForKey:@"width"] intValue];
 		mapSize_.height = [[attributeDict objectForKey:@"height"] intValue];

--- a/cocos2d/CCTexture2D.m
+++ b/cocos2d/CCTexture2D.m
@@ -195,7 +195,7 @@ static CCTexture2DPixelFormat defaultAlphaPixelFormat_ = kCCTexture2DPixelFormat
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Name = %i | Dimensions = %ix%i | Coordinates = (%.2f, %.2f)>", [self class], self, name_, width_, height_, maxS_, maxT_];
+	return [NSString stringWithFormat:@"<%@ = %p | Name = %i | Dimensions = %ix%i | Coordinates = (%.2f, %.2f)>", [self class], self, name_, width_, height_, maxS_, maxT_];
 }
 
 -(CGSize) contentSize

--- a/cocos2d/CCTextureAtlas.m
+++ b/cocos2d/CCTextureAtlas.m
@@ -126,7 +126,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | totalQuads =  %i>", [self class], self, totalQuads_];
+	return [NSString stringWithFormat:@"<%@ = %p | totalQuads =  %i>", [self class], self, totalQuads_];
 }
 
 -(void) dealloc

--- a/cocos2d/CCTextureCache.m
+++ b/cocos2d/CCTextureCache.m
@@ -113,7 +113,7 @@ static CCTextureCache *sharedTextureCache;
 {
 	__block NSString *desc = nil;
 	dispatch_sync(_dictQueue, ^{
-		desc = [NSString stringWithFormat:@"<%@ = %08X | num of textures =  %i | keys: %@>",
+		desc = [NSString stringWithFormat:@"<%@ = %p | num of textures =  %i | keys: %@>",
 			[self class],
 			self,
 			[textures_ count],

--- a/cocos2d/Platforms/iOS/CCES2Renderer.m
+++ b/cocos2d/Platforms/iOS/CCES2Renderer.m
@@ -178,7 +178,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | size = %ix%i>", [self class], self, backingWidth_, backingHeight_];
+	return [NSString stringWithFormat:@"<%@ = %p | size = %ix%i>", [self class], self, backingWidth_, backingHeight_];
 }
 
 - (unsigned int) colorRenderBuffer

--- a/cocos2d/Support/CCArray.m
+++ b/cocos2d/Support/CCArray.m
@@ -291,7 +291,7 @@
 
 - (NSString*) description
 {
-	NSMutableString *ret = [NSMutableString stringWithFormat:@"<%@ = %08X> = ( ", [self class], self];
+	NSMutableString *ret = [NSMutableString stringWithFormat:@"<%@ = %p> = ( ", [self class], self];
 
 	for( id obj in self)
 		[ret appendFormat:@"%@, ",obj];


### PR DESCRIPTION
...to %@ = %p. The type 08X is "wrong" and...future...versions of Apple LLVM are very (very) strict about format strings. Without this change compilation fails (LLVM > 3)

Similar changes to types specified in format strings changed, e.g. "Unsupported orientation: %@", orientation_"; orientation is an int. Without this change, compilation fails (LLVM > 3)
