### PR TITLE
Removed warnings becuase of unrecognised arc related pragma 

### DIFF
--- a/cocos2d/Support/ccCArray.h
+++ b/cocos2d/Support/ccCArray.h
@@ -276,7 +276,9 @@ static inline void ccArrayMakeObjectsPerformSelector(ccArray *arr, SEL sel)
 {
 	for( NSUInteger i = 0; i < arr->num; i++)
 #pragma clang diagnostic push
+#if defined(__has_feature) && __has_feature(objc_arc)				
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+#endif		
 		[arr->arr[i] performSelector:sel];
 #pragma clang diagnostic pop
 }
@@ -285,7 +287,10 @@ static inline void ccArrayMakeObjectsPerformSelectorWithObject(ccArray *arr, SEL
 {
 	for( NSUInteger i = 0; i < arr->num; i++)
 #pragma clang diagnostic push
+		
+#if defined(__has_feature) && __has_feature(objc_arc)		
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+#endif		
 		[arr->arr[i] performSelector:sel withObject:object];
 #pragma clang diagnostic pop
 }
@@ -294,7 +299,10 @@ static inline void ccArrayMakeObjectPerformSelectorWithArrayObjects(ccArray *arr
 {
 	for( NSUInteger i = 0; i < arr->num; i++)
 #pragma clang diagnostic push
+		
+#if defined(__has_feature) && __has_feature(objc_arc)		
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+#endif		
 		[object performSelector:sel withObject:arr->arr[i]];
 #pragma clang diagnostic pop
 }

--- a/cocos2d/Support/ccCArray.h
+++ b/cocos2d/Support/ccCArray.h
@@ -506,7 +506,9 @@ static inline int mergesortL(ccCArray* array, size_t width, int (*compar)(const 
                 //memcpy aritmetics aren't allowed on void* types
                 //explicitely casting didn't work
                 #pragma clang diagnostic push
+#if defined(__has_feature) && __has_feature(objc_arc)				
                 #pragma clang diagnostic ignored "-Warc-non-pod-memaccess"
+#endif				
                 
                 memcpy(B, &arr[j], (m-j) * width);
                 #pragma clang diagnostic pop


### PR DESCRIPTION
Hi,

I am using xcode3.2.6(LLVM compiler 1.7),  iOS-sdk 4.3   on snow leopard. 

The Compiler doesn't recognize -Warc-performSelector-leaks and -Warc-non-pod-memaccess and gives a bunch of warnings for for 'ccCArray.h'.
That results  54 errors in the release build.

I just wrapped them in "#if defined(__has_feature) && __has_feature(objc_arc)"

Thanks
