### PR TITLE
Gles20

### DIFF
--- a/templates/README-templates.txt
+++ b/templates/README-templates.txt
@@ -2,7 +2,7 @@ Xcode 4 templates:
 ------------------
 
 
-The Xcode4 template format is not documented, so the the current templates doesn't have all
+The Xcode4 template format is not documented, so the current templates doesn't have all
 the power of the Xcode3 templates. Once the format is documented, more functionality will be added.
 
 

--- a/templates/Xcode4_templates/cocos2d Mac.xctemplate/HelloWorldLayer.m
+++ b/templates/Xcode4_templates/cocos2d Mac.xctemplate/HelloWorldLayer.m
@@ -33,12 +33,12 @@
 {
 	// always call "super" init
 	// Apple recommends to re-assign "self" with the "super" return value
-	if( (self=[super init])) {
+	if( (self=[super init]) ) {
 		
 		// create and initialize a Label
 		CCLabelTTF *label = [CCLabelTTF labelWithString:@"Hello World" fontName:@"Marker Felt" fontSize:64];
 
-		// ask director the the window size
+		// ask director for the window size
 		CGSize size = [[CCDirector sharedDirector] winSize];
 	
 		// position the label on the center of the screen

--- a/templates/Xcode4_templates/cocos2d iOS.xctemplate/HelloWorldLayer.m
+++ b/templates/Xcode4_templates/cocos2d iOS.xctemplate/HelloWorldLayer.m
@@ -39,12 +39,12 @@
 {
 	// always call "super" init
 	// Apple recommends to re-assign "self" with the "super's" return value
-	if( (self=[super init])) {
+	if( (self=[super init]) ) {
 		
 		// create and initialize a Label
 		CCLabelTTF *label = [CCLabelTTF labelWithString:@"Hello World" fontName:@"Marker Felt" fontSize:64];
 
-		// ask director the the window size
+		// ask director for the window size
 		CGSize size = [[CCDirector sharedDirector] winSize];
 	
 		// position the label on the center of the screen


### PR DESCRIPTION
Nyaa! I corrected a typo in a comment in the Cocos2d iOS and Mac templates.

Changes done:
- Changed a double "the" to "for the" in two files and fixed templates/readme with same typo. 
- Added a space to the end of an if() statements to match the style you use in the rest of the cocos2d project.

Thank you!
