### PR TITLE
Fix CCParticleSystem issues with premultiplied alpha textures

### DIFF
--- a/cocos2d/CCParticleSystem.h
+++ b/cocos2d/CCParticleSystem.h
@@ -277,6 +277,8 @@ typedef void (*CC_UPDATE_PARTICLE_IMP)(id, SEL, tCCParticle*, CGPoint);
 	CCTexture2D *texture_;
 	// blend function
 	ccBlendFunc	blendFunc_;
+	// Texture alpha behavior
+	BOOL opacityModifyRGB_;
 
 	// movment type: free or grouped
 	tCCPositionType	positionType_;
@@ -380,6 +382,8 @@ typedef void (*CC_UPDATE_PARTICLE_IMP)(id, SEL, tCCParticle*, CGPoint);
 @property (nonatomic,readwrite, retain) CCTexture2D * texture;
 /** conforms to CocosNodeTexture protocol */
 @property (nonatomic,readwrite) ccBlendFunc blendFunc;
+/** does the alpha value modify color */
+@property (nonatomic, readwrite, getter=doesOpacityModifyRGB, assign) BOOL opacityModifyRGB;
 /** whether or not the particles are using blend additive.
  If enabled, the following blending function will be used.
  @code

--- a/cocos2d/CCParticleSystem.m
+++ b/cocos2d/CCParticleSystem.m
@@ -72,6 +72,7 @@
 @synthesize emissionRate;
 @synthesize startSize, startSizeVar;
 @synthesize endSize, endSizeVar;
+@synthesize opacityModifyRGB = opacityModifyRGB_;
 @synthesize blendFunc = blendFunc_;
 @synthesize positionType = positionType_;
 @synthesize autoRemoveOnFinish = autoRemoveOnFinish_;
@@ -215,8 +216,12 @@
 		//don't get the internal texture if a batchNode is used
 		if (!batchNode_)
 		{
-		// texture
-		// Try to get the texture from the cache
+			// Set a compatible default for the alpha transfer
+			opacityModifyRGB_ = NO;
+
+			// texture
+			// Try to get the texture from the cache
+
 			NSString *textureName = [dictionary valueForKey:@"textureFileName"];
 
 			CCTexture2D *tex = [[CCTextureCache sharedTextureCache] addImage:textureName];
@@ -624,6 +629,8 @@
 -(void) setTexture:(CCTexture2D*) texture
 {
 	texture_ = [texture retain];
+
+	opacityModifyRGB_ = [texture hasPremultipliedAlpha];
 
 	// If the new texture has No premultiplied alpha, AND the blendFunc hasn't been changed, then update it
 	if( texture_ && ! [texture hasPremultipliedAlpha] &&

--- a/cocos2d/CCParticleSystemQuad.m
+++ b/cocos2d/CCParticleSystemQuad.m
@@ -336,7 +336,10 @@
 	else
 		quad = &(quads_[particleIdx]);
 
-	ccColor4B color = { p->color.r*255, p->color.g*255, p->color.b*255, p->color.a*255};
+	ccColor4B color = (opacityModifyRGB_)
+		? (ccColor4B){ p->color.r*p->color.a*255, p->color.g*p->color.a*255, p->color.b*p->color.a*255, p->color.a*255}
+		: (ccColor4B){ p->color.r*255, p->color.g*255, p->color.b*255, p->color.a*255};
+
 	quad->bl.colors = color;
 	quad->br.colors = color;
 	quad->tl.colors = color;

--- a/tests/ParticleTest.h
+++ b/tests/ParticleTest.h
@@ -200,3 +200,6 @@
 	CCParticleBatchNode *batchNode_;
 }
 @end
+
+@interface PremultipliedAlphaTest : ParticleDemo
+@end

--- a/tests/ParticleTest.m
+++ b/tests/ParticleTest.m
@@ -66,7 +66,8 @@ static NSString *transitions[] = {
 	@"MultipleParticleSystemsBatched",	
 	@"AddAndDeleteParticleSystems",
 	@"ReorderParticleSystems",
-	
+
+	@"PremultipliedAlphaTest",
 };
 
 Class nextAction(void);
@@ -2093,6 +2094,48 @@ Class restartAction()
 {
 	return @"changes every 2 seconds";
 }
+@end
+
+@implementation PremultipliedAlphaTest
+
+-(NSString *) title
+{
+	return @"premultiplied alpha";
+}
+
+-(NSString*) subtitle
+{
+	return @"no black halo, particles should fade out";
+}
+
+- (void)onEnter
+{
+	[super onEnter];
+
+	[self setColor:ccBLUE];
+	[self removeChild:background cleanup:YES];
+	background = nil;
+
+	self.emitter = [CCParticleSystemQuad particleWithFile:@"Particles/BoilingFoam.plist"];
+
+	NSAssert([self.emitter doesOpacityModifyRGB], @"Particle texture does not have premultiplied alpha, test is useless");
+
+	// Particle Designer "normal" blend func causes black halo on premul textures (ignores multiplication)
+	//self.emitter.blendFunc = (ccBlendFunc){ GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA };
+
+	// Cocos2d "normal" blend func for premul causes alpha to be ignored (oversaturates colors)
+	self.emitter.blendFunc = (ccBlendFunc) { GL_ONE, GL_ONE_MINUS_SRC_ALPHA };
+
+	// Toggle next line to see old behavior
+	//self.emitter.opacityModifyRGB = NO;
+
+	self.emitter.startColor = ccc4f(1, 1, 1, 1);
+	self.emitter.endColor   = ccc4f(1, 1, 1, 0);
+	self.emitter.startColorVar = self.emitter.endColorVar = ccc4f(0, 0, 0, 0);
+
+	[self addChild:emitter_ z:10];
+}
+
 @end
 
 


### PR DESCRIPTION
Multiple issues exist in the CCParticleSystem implementation when using
textures with premultiplied alpha and/or the Particle Designer software.
- Using a blend func of GL_ONE/GL_ONE_MINUS_SRC_ALPHA (aka "cocos2d
  normal") prevents the particles from fading out (endColor.a = 0) due to
  over-saturation of the quad vertex color.
- Using a blend func of GL_SRC_ALPHA/GL_ONE_MINUS_SRC_ALPHA (aka
  "Particle Designer normal") ignores alpha multiplication and introduces
  a black halo when overlapping particles and/or setting them against
  non-black backgrounds. Numerous users have sporadically reported
  similar issues over the past couple of years.

This fix detects textures with premultiplied alpha and modifies vertex
colors on quad systems accordingly.

The ParticleTest test case has been updated to demonstrate proper
behavior in contrast to the previous version of the implementation. See
code for details.
