### PR TITLE
Add sound events to CocosDenshion's SimpleAudioEngine.

### DIFF
--- a/CocosDenshion/CocosDenshion/SimpleAudioEngine+SoundEvents.h
+++ b/CocosDenshion/CocosDenshion/SimpleAudioEngine+SoundEvents.h
@@ -1,0 +1,35 @@
+//
+//  SimpleAudioEngine+SoundEvents.h
+//
+//  Created by Jon Manning on 29/02/12.
+//  Copyright (c) 2012 Secret Lab. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//  
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//  
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import "SimpleAudioEngine.h"
+
+@interface SimpleAudioEngine (SoundEvents)
+
+// Play a sound with a given name. Returns YES if the sound is or will be playing, NO if the sound couldn't be played or was blocked by other sound. 
+- (BOOL) playSoundForEvent:(NSString*)eventName;
+
+// Stop the background music and clear the voiceover queue
+- (void) stopSounds; 
+
+@end

--- a/CocosDenshion/CocosDenshion/SimpleAudioEngine+SoundEvents.m
+++ b/CocosDenshion/CocosDenshion/SimpleAudioEngine+SoundEvents.m
@@ -1,0 +1,261 @@
+//
+//  SimpleAudioEngine+SoundEvents.m
+//  ClockPhysics
+//
+//  Created by Jon Manning on 29/02/12.
+//  Copyright (c) 2012 Secret Lab. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//  
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//  
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import "SimpleAudioEngine+SoundEvents.h"
+
+NSString* const SimpleAudioEngineQueueModeAlways = @"always";
+NSString* const SimpleAudioEngineQueueModeNever = @"never";
+
+static NSDictionary* _soundEvents = nil; // dictionary mapping event strings to sound info
+static NSTimer* _voiceoverTimer = nil; // timer that indicates when to play the next queued voiceover sound
+static NSMutableArray* _voiceoverQueue = nil; // array of queued voiceover lines
+
+@implementation SimpleAudioEngine (SoundEvents)
+
+// Return the dictionary describing all sound events.
+// This will first try to load a file in the Documents directory 
+// called SoundEvents.json. If it can't find it, it will look in
+// the main bundle.
+
++ (NSDictionary*)soundEvents {
+    if (_soundEvents == nil) {
+        
+        NSError* error = nil;
+        
+        // Try and load the file from documents
+        NSString* documentsDirectory = [[[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject] path];
+        NSString* fileName = [documentsDirectory stringByAppendingPathComponent:@"SoundEvents.json"];
+        if ([[NSFileManager defaultManager] fileExistsAtPath:fileName]) {
+            NSData* data = [NSData dataWithContentsOfFile:fileName];
+            _soundEvents = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+            
+            if (error) {
+                NSLog(@"Error loading SoundEvents.json: %@", error);
+                return nil;
+            }
+        }
+        
+        if (_soundEvents == nil)  {
+            NSString* fileName = [[NSBundle mainBundle] pathForResource:@"SoundEvents" ofType:@"json"];
+            NSData* data = [NSData dataWithContentsOfFile:fileName];
+            _soundEvents = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+            if (error) {
+                NSLog(@"Error loading SoundEvents.json: %@", error);
+                return nil;
+            }
+
+        }
+        
+        if (_soundEvents == nil) {
+            NSLog(@"Couldn't find SoundEvents.json in either the bundle or in the Documents directory; check to see if it's added to the target and is named correctly!");
+        }
+    }
+    
+    return _soundEvents;
+}
+
+// Returns (and creates, if necessary) the queue of voiceover sounds.
++ (NSMutableArray*)voiceoverQueue {
+    if (_voiceoverQueue == nil)
+        _voiceoverQueue = [NSMutableArray array];
+    return _voiceoverQueue;
+}
+
+// Empties the voiceover queue. No currently playing voiceover lines will be stopped.
+- (void) removeAllItemsFromVoiceoverQueue {
+    [[SimpleAudioEngine voiceoverQueue] removeAllObjects];
+}
+
+// Plays the next item in the voiceover queue, and removes that item from the queue.
+- (void) playNextItemInQueue {
+    // Only do work if there's something in the queue.
+    if ([[SimpleAudioEngine voiceoverQueue] count] <= 0)
+        return;
+    
+    NSString* nextEvent = [[SimpleAudioEngine voiceoverQueue] objectAtIndex:0];
+    [[SimpleAudioEngine voiceoverQueue] removeObjectAtIndex:0];
+    
+    [self playSoundForEvent:nextEvent];
+}
+
+// Adds an item to the voiceover queue.
+- (void) addEffectToQueue:(NSString*)effect {
+    [[SimpleAudioEngine voiceoverQueue] addObject:effect];
+}
+
+// Works out the location of a sound file, first by looking in the 
+// Documents folder, and then in the main bundle.
++ (NSString*) pathForFileNamed:(NSString*)fileName {
+    
+    // If the filename doesn't have an extension, append ".wav" to it.
+    if ([[fileName pathExtension] isEqualToString:@""])
+        fileName = [fileName stringByAppendingPathExtension:@"wav"];
+    
+    NSString* path = nil;
+    
+    // Try and find the file in documents
+    NSString* documentsDirectory = [[[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject] path];
+    path = [documentsDirectory stringByAppendingPathComponent:fileName];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+        return path;
+    }
+    
+    // Else try and play it from resources
+    path = [[NSBundle mainBundle] pathForResource:[fileName stringByDeletingPathExtension] ofType:[fileName pathExtension]];
+    
+    if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+        return path;
+    }
+        
+    // Else just give up
+    NSLog(@"Can't find sound file %@ in either the bundle or the Documents directory!", fileName);
+    return nil;
+}
+
+// Given a sound event name, work out what sound we should play, and 
+// how it should be played.
+// Returns YES if the sound is playing or queued, NO if otherwise.
+- (BOOL) playSoundForEvent:(NSString *)eventName {
+    
+    // Get the event from the sound events dictionary. It can 
+    // be an NSString or NSDictionary.
+    id event = [[SimpleAudioEngine soundEvents] objectForKey:eventName];
+    
+    // Set up the default settings. The sound event data may override these.
+    NSString* fileName = nil;
+    BOOL background = NO;
+    BOOL looping = NO;
+    NSString* queueMode;
+    CGFloat gain = 1.0;
+    CGFloat pitch = 1.0;
+    
+    // If the event is an NSString, we're just playing a straight sound,
+    // so just set the filename. If it's an NSDictionary, get additional
+    // data about the sound.
+    if ([event isKindOfClass:[NSString class]]) {
+        
+        fileName = [SimpleAudioEngine pathForFileNamed:event];
+    } else if ([event isKindOfClass:[NSDictionary class]]) {
+        
+        fileName = [SimpleAudioEngine pathForFileNamed:[event objectForKey:@"file"]];
+        background = [[event objectForKey:@"background"] boolValue];
+        
+        if (background) {
+            looping = [[event objectForKey:@"loop"] boolValue];
+        }
+        
+        if ([event objectForKey:@"gain"]) {
+            gain = [[event objectForKey:@"gain"] floatValue];
+            if (gain < 0) gain = 0;
+            if (gain > 1) gain = 1;
+        }
+        
+        queueMode = [event objectForKey:@"queue"];
+        
+        if ([event objectForKey:@"pitch-variability"]) {
+            CGFloat variability = [[event objectForKey:@"pitch-variability"] floatValue];
+            CGFloat randomNumber = (random() % 10000 / 10000.0);
+            pitch += randomNumber * (variability + variability) - variability;
+            
+        }
+        
+    }
+    
+    if (fileName == nil) {
+        return NO;
+    }
+        
+    if (background)  {
+        // If it's a background effect, play it in the background!
+        [self playBackgroundMusic:fileName loop:looping];
+        return YES;
+    } else {
+        
+        // It's not a background effect, so figure out if we need to worry about
+        // the queue and then act on that.
+        
+        // No queue mode set? Go ahead and play it!
+        // (It will overlap with any currently playing sound.)
+        if (queueMode == nil) {
+            [self playEffect:fileName pitch:pitch pan:0 gain:gain];
+            return YES;
+        }
+        
+        // Is the voiceover timer running? If it is, a queued sound is playing
+        if (_voiceoverTimer != nil) {
+            
+            // If the effect is "never queue", drop it
+            if ([queueMode isEqualToString:SimpleAudioEngineQueueModeNever]) {
+                NSLog(@"Dropping effect %@, which is set to never queue.", eventName);
+                return NO;
+            }
+            
+            // If the effect is "always queue", queue it up
+            else if ([queueMode isEqualToString:SimpleAudioEngineQueueModeAlways]) {
+                NSLog(@"Queueing effect %@.", eventName);
+                [self addEffectToQueue:eventName];
+                return YES;
+            }
+            
+            // Otherwise, the queue mode is invalid and we should log a warning
+            else {
+                NSLog(@"Sound event %@ has invalid queue mode %@!", eventName, queueMode);
+                return NO;
+            }
+                
+        } else {
+            // The timer is not running. Start it up!
+            
+            // First, get the duration of this effect.
+            float timerDuration = [self durationForEffect:fileName];
+            if (timerDuration <= 0) {
+                NSLog(@"Sound event %@ tried to be queued, but its duration was reported to be <= 0!", eventName);
+                return NO;
+            }
+            
+            NSLog(@"Playing queued sound %@ (%.1fs long)", eventName, timerDuration);
+
+            // Start the timer.
+            _voiceoverTimer = [NSTimer scheduledTimerWithTimeInterval:timerDuration target:^{
+                _voiceoverTimer = nil;
+                NSLog(@"Reached the end of playing %@", eventName);
+                [self playNextItemInQueue];
+            } selector:@selector(invoke) userInfo:nil repeats:NO];
+            
+            // Finally, actually start the thing playing!
+            [self playEffect:fileName pitch:pitch pan:0 gain:gain];
+            return YES;
+        }
+    } 
+    
+}
+
+// Stops the background music track, and cancels any pending voiceover clips.
+- (void)stopSounds {
+    [self stopBackgroundMusic];
+    [self removeAllItemsFromVoiceoverQueue];
+}
+
+@end

--- a/CocosDenshion/CocosDenshion/SoundEvents.mdown
+++ b/CocosDenshion/CocosDenshion/SoundEvents.mdown
@@ -1,0 +1,109 @@
+# CocosDenshion Sound Events
+
+Version 1.0
+30 April 2012
+
+© Secret Lab: http://www.tothesecretlab.com
+Coded and written up by Jon Manning.
+
+Questions? Comments? jon@secretlab.com.au
+
+## Introduction
+
+So we happened to be working on a project that involved quite a lot of sound effects, including looped background audio, sound effects and voiceover content. CocosDenshion was our natural choice for a simple-to-use sound system.
+
+However, our audio designers didn't want to have to deal with the pain of rebuilding the application every time they wanted to change a file, and didn't want the app to hard-code the sound file names, since they often named the sound files after what the sounds contained and not when the sound was used. They also wanted to indicate which files should be looped, tweak volume and pitch, and other little things.
+
+We also wanted to have good support for voiceover lines, which have special requirements in that you can't ever have two voiceover lines play at the same time, since they collide badly. So, we added a queue system that gives you better control over how to deal with voiceover lines.
+
+So, we came up with this: a "sound event" system, which separates the audio from the context in which it's used. The way it works is that you create a JSON file that maps sound event names (like "player died") to sound files (like "scream.wav"). If you want to get fancy, you can provide settings that control additional settings.
+
+Finally, the whole thing is set up to allow you to modify both the sound event mapping and the sound files themselves through iTunes File Sharing. You can hand copies of your game to your audio designers, and they can replace and tune files by updating the files stored in your app, without having to get new builds.
+
+## The sound events list
+
+The sound events list is a JSON file called `SoundEvents.json`. You add it to your project, so that it's compiled into the project. If the app finds a file called `SoundEvents.json` in the Documents directory in its sandbox, it will use that file instead.
+
+The sound events list looks like this:
+
+    {
+        "player-died": "scream",
+        "shot": "rifle-shot",
+        "level-intro": {
+            "file":"voiceover-levelintro",
+            "queue":"always"
+        },
+        "level-warning": {
+            "file":"voiceover-watchout",
+            "queue":"never"
+        },
+        "level-background-music": {
+            "file": "levelmusic03",
+            "background": true,
+            "loop": true
+        },
+        "explosion" : {
+            "file":"explode",
+            "gain":0.2,
+            "pitch-variability": 0.1
+        }
+    }
+    
+Each entry in the list can be either a string or a dictionary.
+
+If the entry is a string, the item's name is the sound event, and the item's value is the name of the audio file. So, for the first entry, we're creating a sound event called "player-died", which will play the file "scream.wav" when triggered. (If you don't include ".wav" in the audio file name, CocosDenshion will add it for you.)
+
+If the entry is a dictionary, you can provide additional information about the sound event. The settings you can provide are:
+
+* `file`: String. The name of the audio file that should be played when the sound event is triggered. You must include this setting, or the event won't play a sond.
+* `background`: Boolean. If true, the audio file will play in the background. Only one background audio file may play at once; if you play one when another is currently playing, the first sound will stop.
+* `loop`: Boolean. If true and the file is a background sound, the sound will loop until stopped. This setting is ignored if the sound is not a background sound.
+* `gain`: Number. Setting this value to 0 makes the sound silent, and setting it to 1 (the default) makes the sound play at full volume. 
+* `pitch-variability`: Number. Setting this number to anything greater than 0 will make the sound play at a slightly varied pitch (making it great for things like collision noises or anything you need to play over and over without getting too repetitive). Higher numbers mean more variability.
+* `queue`: String, either "always" or "never". This setting controls whether the sound works with the voiceover queue (see below.)
+
+Note that SoundEvents.json must be valid JSON, or else it won't load. A great OS X JSON editor is "Jason": http://olivierlabs.com/jason/
+
+## Working with sound events
+
+To trigger a sound event, you do this:
+
+    [[SimpleAudioEngine sharedEngine] playSoundForEvent:@"player-died"];
+    
+This makes the sound engine play the sound associated with the provided sound event. The same call is used for background audio and voiceovers.
+
+When you're done with a scene, you do this:
+
+    [[SimpleAudioEngine sharedEngine] stopSounds];
+    
+This stops the background music, and cancels any queued voiceover lines.
+
+That's the entire API - we realised that you want to keep the amount of audio code in the game to an absolute minimum, so the entire thing is based around triggering audio events.
+
+### The voiceover queue
+
+Voiceover lines are somewhat special cases, since if you play two at a time, they collide and you can't understand them. To solve this problem, we added queued audio support.
+
+The philosophy of the system is this: voiceover lines should never overlap, and you shouldn't end up with a situation where repeatedly triggering a voiceover event queues a huge amount of lines up.
+
+In the sound events system, you can mark sound events should participate in the queue. To do this, you provide a `queue` setting in the sound event's dictionary. Here's an example of two (from above):
+
+    "level-intro": {
+        "file":"voiceover-levelintro",
+        "queue":"always"
+    },
+    "level-warning": {
+        "file":"voiceover-watchout",
+        "queue":"never"
+    }
+    
+If you set the `queue` setting to "always", the sound file will be added to the queue. If the queue is empty, the sound file will start playing at once. If the queue is not empty, the sound file will wait until it's ready. Multiple items can be added to the queue at once.
+
+If you set the `queue` setting to "never", the sound file will _only_ play if the queue is empty. If a sound file that's in the queue is currently playing, the sound won't play. 
+
+If you don't provide a `queue` setting, the sound event ignores the queue and plays, overlapping any existing sounds.
+
+This allows you to indicate which voiceover lines are important, and should always be played, and which voiceover lines are less important and can afford to not be heard.
+
+Mad props: This queue system was directly inspired by Darren Korb (@DarrenKorb), from Supergiant Games.
+

--- a/cocos2d-mac.xcodeproj/project.pbxproj
+++ b/cocos2d-mac.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		6898A4FE154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.h in Headers */ = {isa = PBXBuildFile; fileRef = 6898A4FB154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.h */; };
+		6898A4FF154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 6898A4FC154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.m */; };
 		A02C341D13C918690081CFF7 /* grossini_pvr_rgba8888.pvr in Resources */ = {isa = PBXBuildFile; fileRef = A02C341C13C918550081CFF7 /* grossini_pvr_rgba8888.pvr */; };
 		A0AAB8241451C8C000850F2C /* CCParticleBatchNode.h in Headers */ = {isa = PBXBuildFile; fileRef = A0AAB8221451C8C000850F2C /* CCParticleBatchNode.h */; };
 		A0AAB8251451C8C000850F2C /* CCParticleBatchNode.m in Sources */ = {isa = PBXBuildFile; fileRef = A0AAB8231451C8C000850F2C /* CCParticleBatchNode.m */; };
@@ -3565,6 +3567,9 @@
 		13E42FB307B3F0F600E4EEF1 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		6898A4FB154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SimpleAudioEngine+SoundEvents.h"; sourceTree = "<group>"; };
+		6898A4FC154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SimpleAudioEngine+SoundEvents.m"; sourceTree = "<group>"; };
+		6898A4FD154EC6AA00F1DF79 /* SoundEvents.mdown */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SoundEvents.mdown; sourceTree = "<group>"; };
 		A02C341C13C918550081CFF7 /* grossini_pvr_rgba8888.pvr */ = {isa = PBXFileReference; lastKnownFileType = file; path = grossini_pvr_rgba8888.pvr; sourceTree = "<group>"; };
 		A0AAB8211451C8A700850F2C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		A0AAB8221451C8C000850F2C /* CCParticleBatchNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCParticleBatchNode.h; sourceTree = "<group>"; };
@@ -4776,6 +4781,9 @@
 				E056C7E1134FF53B001C3DFD /* CocosDenshion.m */,
 				E056C7E2134FF53B001C3DFD /* SimpleAudioEngine.h */,
 				E056C7E3134FF53B001C3DFD /* SimpleAudioEngine.m */,
+				6898A4FB154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.h */,
+				6898A4FC154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.m */,
+				6898A4FD154EC6AA00F1DF79 /* SoundEvents.mdown */,
 			);
 			path = CocosDenshion;
 			sourceTree = "<group>";
@@ -5495,6 +5503,7 @@
 				E056C858134FF53B001C3DFD /* SimpleAudioEngine.h in Headers */,
 				E056C85A134FF53B001C3DFD /* CDXMacOSXSupport.h in Headers */,
 				E056C85C134FF53B001C3DFD /* CDXPropertyModifierAction.h in Headers */,
+				6898A4FE154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9067,6 +9076,7 @@
 				E056C859134FF53B001C3DFD /* SimpleAudioEngine.m in Sources */,
 				E056C85B134FF53B001C3DFD /* CDXMacOSXSupport.m in Sources */,
 				E056C85D134FF53B001C3DFD /* CDXPropertyModifierAction.m in Sources */,
+				6898A4FF154EC6AA00F1DF79 /* SimpleAudioEngine+SoundEvents.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Hi there!

I added support for sound events in CocosDenshion, which allow you to have pretty sophisticated control over sound playback while minimising the amount of code a game needs to write. It also makes it easier for sound designers to tweak the sounds used in the game without having to rebuild the app. Finally, it has support for queueing voiceover lines, to prevent collisions. This based on a modified version of CocosDenshion that we're using in a very audio-heavy iPad app.

Full documentation follows (and this file is also included in the commit.) Let me know what you think!
# CocosDenshion Sound Events

Version 1.0
30 April 2012

© Secret Lab: http://www.tothesecretlab.com
Coded and written up by Jon Manning.

Questions? Comments? jon@secretlab.com.au
## Introduction

So we happened to be working on a project that involved quite a lot of sound effects, including looped background audio, sound effects and voiceover content. CocosDenshion was our natural choice for a simple-to-use sound system.

However, our audio designers didn't want to have to deal with the pain of rebuilding the application every time they wanted to change a file, and didn't want the app to hard-code the sound file names, since they often named the sound files after what the sounds contained and not when the sound was used. They also wanted to indicate which files should be looped, tweak volume and pitch, and other little things.

We also wanted to have good support for voiceover lines, which have special requirements in that you can't ever have two voiceover lines play at the same time, since they collide badly. So, we added a queue system that gives you better control over how to deal with voiceover lines.

So, we came up with this: a "sound event" system, which separates the audio from the context in which it's used. The way it works is that you create a JSON file that maps sound event names (like "player died") to sound files (like "scream.wav"). If you want to get fancy, you can provide settings that control additional settings.

Finally, the whole thing is set up to allow you to modify both the sound event mapping and the sound files themselves through iTunes File Sharing. You can hand copies of your game to your audio designers, and they can replace and tune files by updating the files stored in your app, without having to get new builds.
## The sound events list

The sound events list is a JSON file called `SoundEvents.json`. You add it to your project, so that it's compiled into the project. If the app finds a file called `SoundEvents.json` in the Documents directory in its sandbox, it will use that file instead.

The sound events list looks like this:

```
{
    "player-died": "scream",
    "shot": "rifle-shot",
    "level-intro": {
        "file":"voiceover-levelintro",
        "queue":"always"
    },
    "level-warning": {
        "file":"voiceover-watchout",
        "queue":"never"
    },
    "level-background-music": {
        "file": "levelmusic03",
        "background": true,
        "loop": true
    },
    "explosion" : {
        "file":"explode",
        "gain":0.2,
        "pitch-variability": 0.1
    }
}
```

Each entry in the list can be either a string or a dictionary.

If the entry is a string, the item's name is the sound event, and the item's value is the name of the audio file. So, for the first entry, we're creating a sound event called "player-died", which will play the file "scream.wav" when triggered. (If you don't include ".wav" in the audio file name, CocosDenshion will add it for you.)

If the entry is a dictionary, you can provide additional information about the sound event. The settings you can provide are:
- `file`: String. The name of the audio file that should be played when the sound event is triggered. You must include this setting, or the event won't play a sond.
- `background`: Boolean. If true, the audio file will play in the background. Only one background audio file may play at once; if you play one when another is currently playing, the first sound will stop.
- `loop`: Boolean. If true and the file is a background sound, the sound will loop until stopped. This setting is ignored if the sound is not a background sound.
- `gain`: Number. Setting this value to 0 makes the sound silent, and setting it to 1 (the default) makes the sound play at full volume. 
- `pitch-variability`: Number. Setting this number to anything greater than 0 will make the sound play at a slightly varied pitch (making it great for things like collision noises or anything you need to play over and over without getting too repetitive). Higher numbers mean more variability.
- `queue`: String, either "always" or "never". This setting controls whether the sound works with the voiceover queue (see below.)

Note that SoundEvents.json must be valid JSON, or else it won't load. A great OS X JSON editor is "Jason": http://olivierlabs.com/jason/
## Working with sound events

To trigger a sound event, you do this:

```
[[SimpleAudioEngine sharedEngine] playSoundForEvent:@"player-died"];
```

This makes the sound engine play the sound associated with the provided sound event. The same call is used for background audio and voiceovers.

When you're done with a scene, you do this:

```
[[SimpleAudioEngine sharedEngine] stopSounds];
```

This stops the background music, and cancels any queued voiceover lines.

That's the entire API - we realised that you want to keep the amount of audio code in the game to an absolute minimum, so the entire thing is based around triggering audio events.
### The voiceover queue

Voiceover lines are somewhat special cases, since if you play two at a time, they collide and you can't understand them. To solve this problem, we added queued audio support.

The philosophy of the system is this: voiceover lines should never overlap, and you shouldn't end up with a situation where repeatedly triggering a voiceover event queues a huge amount of lines up.

In the sound events system, you can mark sound events should participate in the queue. To do this, you provide a `queue` setting in the sound event's dictionary. Here's an example of two (from above):

```
"level-intro": {
    "file":"voiceover-levelintro",
    "queue":"always"
},
"level-warning": {
    "file":"voiceover-watchout",
    "queue":"never"
}
```

If you set the `queue` setting to "always", the sound file will be added to the queue. If the queue is empty, the sound file will start playing at once. If the queue is not empty, the sound file will wait until it's ready. Multiple items can be added to the queue at once.

If you set the `queue` setting to "never", the sound file will _only_ play if the queue is empty. If a sound file that's in the queue is currently playing, the sound won't play. 

If you don't provide a `queue` setting, the sound event ignores the queue and plays, overlapping any existing sounds.

This allows you to indicate which voiceover lines are important, and should always be played, and which voiceover lines are less important and can afford to not be heard.

Mad props: This queue system was directly inspired by Darren Korb (@DarrenKorb), from Supergiant Games.
