### PR TITLE
Offset on touch position when using overlayed UIScrollView.

### DIFF
--- a/cocos2d/CCMenu.m
+++ b/cocos2d/CCMenu.m
@@ -177,7 +177,7 @@ enum {
 
 -(CCMenuItem *) itemForTouch: (UITouch *) touch
 {
-	CGPoint touchLocation = [touch locationInView: [touch view]];
+	CGPoint touchLocation = [touch locationInView: [[CCDirector sharedDirector] view]];
 	touchLocation = [[CCDirector sharedDirector] convertToGL: touchLocation];
 
 	CCMenuItem* item;

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -869,14 +869,14 @@ static NSUInteger globalOrderOfArrival = 1;
 
 - (CGPoint)convertTouchToNodeSpace:(UITouch *)touch
 {
-	CGPoint point = [touch locationInView: [touch view]];
+	CGPoint point = [touch locationInView: [[CCDirector sharedDirector] view]];
 	point = [[CCDirector sharedDirector] convertToGL: point];
 	return [self convertToNodeSpace:point];
 }
 
 - (CGPoint)convertTouchToNodeSpaceAR:(UITouch *)touch
 {
-	CGPoint point = [touch locationInView: [touch view]];
+	CGPoint point = [touch locationInView: [[CCDirector sharedDirector] view]];
 	point = [[CCDirector sharedDirector] convertToGL: point];
 	return [self convertToNodeSpaceAR:point];
 }


### PR DESCRIPTION
When using with additional overlayed views (such as UIScrollView) we get an offset, and this fixes that.
