### PR TITLE
CCGLProgram guards, fixes and debugging info

### DIFF
--- a/cocos2d/CCGLProgram.h
+++ b/cocos2d/CCGLProgram.h
@@ -139,6 +139,9 @@ struct _hashUniformEntry;
 /** will update the MVP matrix on the MVP uniform if it is different than the previous call for this same shader program. */
 -(void) setUniformForModelViewProjectionMatrix;
 
+/** calls glGetUniformLocation only if the shader program has been properly initialized **/
+- (GLint)uniformLocationForName:(NSString*)name;
+
 /** returns the vertexShader error log */
 - (NSString *)vertexShaderLog;
 

--- a/cocos2d/CCShaderCache.m
+++ b/cocos2d/CCShaderCache.m
@@ -190,7 +190,7 @@ static CCShaderCache *_sharedShaderCache;
 	p = [[CCGLProgram alloc] initWithVertexShaderByteArray:ccPosition_uColor_vert
 								   fragmentShaderByteArray:ccPosition_uColor_frag];	
 	
-	[p addAttribute:@"aVertex" index:kCCVertexAttrib_Position];
+	[p addAttribute:kCCAttributeNamePosition index:kCCVertexAttrib_Position];
 	
 	[p link];
 	[p updateUniforms];


### PR DESCRIPTION
Added some asserts to help with debugging shaders, fixed a couple of
bugs that were hiding/overwriting programLog information (complicating
debugging), and subsequently found/fixed a minor bug in the
CCShaderCache default shader initialization routine.

With these changes it is much easier to figure out why a shader is not
compiling/linking as expected. It also makes it less likely that cocos
will start spewing gl error codes from weird locations because the shader
asserts will break much closer to the actual problem.
