### PR TITLE
[FIX] CCMenuItemToggle - Tags of children were modified by the component

### DIFF
--- a/cocos2d/CCMenuItem.h
+++ b/cocos2d/CCMenuItem.h
@@ -390,6 +390,7 @@
 	NSMutableArray* subItems_;
 	GLubyte		opacity_;
 	ccColor3B	color_;
+    CCMenuItem* currentItem_;
 }
 
 /** conforms with CCRGBAProtocol protocol */

--- a/cocos2d/CCMenuItem.m
+++ b/cocos2d/CCMenuItem.m
@@ -731,8 +731,15 @@ const NSInteger	kCCZoomActionTag = 0xc0c05002;
 //
 // MenuItemToggle
 //
-@implementation CCMenuItemToggle
+@interface CCMenuItemToggle ()
+/**
+ Reference to the current display item.
+ */
+@property (nonatomic, assign) CCMenuItem *currentItem;
+@end
 
+@implementation CCMenuItemToggle
+@synthesize currentItem = currentItem_;
 @synthesize subItems = subItems_;
 @synthesize opacity = opacity_, color = color_;
 
@@ -785,6 +792,7 @@ const NSInteger	kCCZoomActionTag = 0xc0c05002;
 
 		self.subItems = [NSMutableArray arrayWithArray:arrayOfItems];
 
+        currentItem_ = nil;
 		selectedIndex_ = NSUIntegerMax;
 		[self setSelectedIndex:0];
 	}
@@ -802,12 +810,13 @@ const NSInteger	kCCZoomActionTag = 0xc0c05002;
 {
 	if( index != selectedIndex_ ) {
 		selectedIndex_=index;
-		CCMenuItem *currentItem = (CCMenuItem*)[self getChildByTag:kCCCurrentItemTag];
-		if( currentItem )
-			[currentItem removeFromParentAndCleanup:NO];
+        
+		if( currentItem_ )
+			[currentItem_ removeFromParentAndCleanup:NO];
 		
 		CCMenuItem *item = [subItems_ objectAtIndex:selectedIndex_];
-		[self addChild:item z:0 tag:kCCCurrentItemTag];
+		[self addChild:item z:0];
+        self.currentItem = item;
 
 		CGSize s = [item contentSize];
 		[self setContentSize: s];


### PR DESCRIPTION
Hi,

Today an user has noticed an issue for the CCMenuItemToggle on StackOverFlow: http://stackoverflow.com/questions/11644584/ccmenuitems-loose-tags/11665881#11665881.

It appears that the CCMenuItemToggle erase the tags of the items when we put them as children of the toggle.
So I have fixed this problem by keeping into reference the displayed item instead of changing its tag.

I hope it'll help you.

Best,
Yannick
