### PR TITLE
CCDirector startup flicker

### DIFF
--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -366,13 +366,17 @@ static CCDirector *_sharedDirector = nil;
 - (void)runWithScene:(CCScene*) scene
 {
 	NSAssert( scene != nil, @"Argument must be non-nil");
+	NSAssert(runningScene_ == nil, @"This command can only be used to start the CCDirector. There is already a scene present.");
 
 	[self pushScene:scene];
-	[self startAnimation];
+	
+	NSThread *thread = [self runningThread];
+	[self performSelector:@selector(drawScene) onThread:thread withObject:nil waitUntilDone:YES];
 }
 
 -(void) replaceScene: (CCScene*) scene
 {
+	NSAssert( runningScene_, @"Use runWithScene: instead to start the director");
 	NSAssert( scene != nil, @"Argument must be non-nil");
 
 	NSUInteger index = [scenesStack_ count];

--- a/cocos2d/CCProtocols.h
+++ b/cocos2d/CCProtocols.h
@@ -127,6 +127,10 @@
 /** Returns a Boolean value indicating whether the CCDirector supports the specified orientation. Default value is YES (supports all possible orientations) */
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
 
+/** Called when projection is resized (due to layoutSubviews on the view). This is important to respond to in order to setup your scene with the proper dimensions (which only exist after the first call to layoutSubviews) so that you can set your scene as early as possible to avoid startup flicker
+ */
+-(void) directorDidReshapeProjection;
+
 #endif // __CC_PLATFORM_IOS
 
 @end

--- a/cocos2d/Platforms/Mac/CCGLView.m
+++ b/cocos2d/Platforms/Mac/CCGLView.m
@@ -133,7 +133,10 @@
 	[director reshapeProjection: NSSizeToCGSize(rect.size) ];
 
 	// avoid flicker
-	[director drawScene];
+  // Only draw if there is something to draw, otherwise it actually creates a flicker of the current glClearColor
+	if(director.runningScene){
+    [director drawScene];
+  }
 //	[self setNeedsDisplay:YES];
 	
 	[self unlockOpenGLContext];

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -315,6 +315,9 @@ CGFloat	__ccContentScaleFactor = 1;
 	winSizeInPixels_ = CGSizeMake(winSizeInPoints_.width * __ccContentScaleFactor, winSizeInPoints_.height *__ccContentScaleFactor);
 
 	[self setProjection:projection_];
+  
+  if( [delegate_ respondsToSelector:@selector(directorDidReshapeProjection)] )
+    [delegate_ directorDidReshapeProjection];
 }
 
 #pragma mark Director Point Convertion

--- a/cocos2d/Platforms/iOS/CCGLView.m
+++ b/cocos2d/Platforms/iOS/CCGLView.m
@@ -223,8 +223,11 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 	[director reshapeProjection:size_];
 
 	// Avoid flicker. Issue #350
-	NSThread *thread = [director runningThread];
-	[director performSelector:@selector(drawScene) onThread:thread withObject:nil waitUntilDone:YES];
+	// Only draw if there is something to draw, otherwise it actually creates a flicker of the current glClearColor
+	if(director.runningScene){
+		NSThread *thread = [director runningThread];
+		[director performSelector:@selector(drawScene) onThread:thread withObject:nil waitUntilDone:YES];
+	}
 }
 
 - (void) swapBuffers


### PR DESCRIPTION
CCDirector.m

runWithScene:
- Added assert to prevent calling this with a scene already on the scene stack
- Removed call to startAnimation
- Added forced draw after pushing the scene

replaceScene:
- Added assert to prevent calling this with the first scene and a note to use runWithScene: instead

pushScene:
- No changes, but I could not add an assert to prevent calling this for the first scene since it is internally called by runWithScene: Maybe it should output a log warning?

CCGLView.m

layoutSubviews
- Added a conditional check to make sure there is actually a runningScene before drawing to prevent drawing the clear color as the first draw
