### PR TITLE
Don't allocate the stats labels if setting view to nil

### DIFF
--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -315,12 +315,12 @@ static CCDirector *_sharedDirector = nil;
 
 		// set size
 		winSizeInPixels_ = winSizeInPoints_ = CCNSSizeToCGSize( [view_ bounds].size );
-
-		[self createStatsLabel];
 		
 		// it could be nil
-		if( view )
+		if( view ) {
+            [self createStatsLabel];
 			[self setGLDefaultValues];
+        }
 
 		CHECK_GL_ERROR_DEBUG();
 	}


### PR DESCRIPTION
This creates unused objects when cleaning up the director. We use cocos2d in an app that also uses UIKit. So we frequently initialise/cleanup the CCDirector. During its cleanup, it sets the view to nil and this was allocating labels that can never be used.

You can confirm this using the Allocations Instrument. Do a heapshot before initialising cocos2d, then do one after cleanup. Repeat a few times - you'll see various CC objects on the heap after cleanup has complete.
