### PR TITLE
Ported kaicherry's patch that fixed LLVM > 3 compile errors in v2.x to v1.x

### DIFF
--- a/cocos2d/CCAction.m
+++ b/cocos2d/CCAction.m
@@ -64,7 +64,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i>", [self class], self, tag_];
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i>", [self class], self, tag_];
 }
 
 -(id) copyWithZone: (NSZone*) zone

--- a/cocos2d/CCActionInstant.m
+++ b/cocos2d/CCActionInstant.m
@@ -255,7 +255,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i | target = %@ | selector = %@>",
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i | target = %@ | selector = %@>",
 			[self class],
 			self,
 			tag_,

--- a/cocos2d/CCAnimation.m
+++ b/cocos2d/CCAnimation.m
@@ -64,7 +64,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | SpriteFrame = %08X, delayUnits = %0.2f >", [self class], self, spriteFrame_, delayUnits_ ];
+	return [NSString stringWithFormat:@"<%@ = %p | SpriteFrame = %p, delayUnits = %0.2f >", [self class], self, spriteFrame_, delayUnits_ ];
 }
 @end
 
@@ -140,7 +140,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | frames=%d, totalDelayUnits=%d, delayPerUnit=%f>", [self class], self,
+	return [NSString stringWithFormat:@"<%@ = %p | frames=%d, totalDelayUnits=%f, delayPerUnit=%f>", [self class], self,
 			[frames_ count],
 			totalDelayUnits_,
 			delayPerUnit_

--- a/cocos2d/CCAnimationCache.m
+++ b/cocos2d/CCAnimationCache.m
@@ -72,7 +72,7 @@ static CCAnimationCache *sharedAnimationCache_=nil;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | num of animations =  %i>", [self class], self, [animations_ count]];
+	return [NSString stringWithFormat:@"<%@ = %p | num of animations =  %i>", [self class], self, [animations_ count]];
 }
 
 -(void) dealloc

--- a/cocos2d/CCCamera.m
+++ b/cocos2d/CCCamera.m
@@ -43,7 +43,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | center = (%.2f,%.2f,%.2f)>", [self class], self, centerX_, centerY_, centerZ_];
+	return [NSString stringWithFormat:@"<%@ = %p | center = (%.2f,%.2f,%.2f)>", [self class], self, centerX_, centerY_, centerZ_];
 }
 
 

--- a/cocos2d/CCGrid.m
+++ b/cocos2d/CCGrid.m
@@ -125,7 +125,7 @@
 }
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Dimensions = %ix%i>", [self class], self, gridSize_.x, gridSize_.y];
+	return [NSString stringWithFormat:@"<%@ = %p | Dimensions = %ix%i>", [self class], self, gridSize_.x, gridSize_.y];
 }
 
 - (void) dealloc

--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -127,7 +127,7 @@ typedef struct _KerningHashElement
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Kernings:%d | Image = %@>", [self class], self,
+	return [NSString stringWithFormat:@"<%@ = %p | Kernings:%d | Image = %@>", [self class], self,
 			HASH_COUNT(kerningDictionary_),
 			atlasName_];
 }

--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -153,6 +153,6 @@
 {
 	// XXX: string_, fontName_ can't be displayed here, since they might be already released
 
-	return [NSString stringWithFormat:@"<%@ = %08X | FontSize = %.1f>", [self class], self, fontSize_];
+	return [NSString stringWithFormat:@"<%@ = %p | FontSize = %.1f>", [self class], self, fontSize_];
 }
 @end

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -324,7 +324,7 @@ static NSUInteger globalOrderOfArrival = 0;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i>", [self class], self, tag_];
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i>", [self class], self, tag_];
 }
 
 - (void) dealloc

--- a/cocos2d/CCParticleBatchNode.m
+++ b/cocos2d/CCParticleBatchNode.m
@@ -170,7 +170,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i>", [self class], self, tag_ ];
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i>", [self class], self, tag_ ];
 }
 
 -(void)dealloc

--- a/cocos2d/CCRibbon.m
+++ b/cocos2d/CCRibbon.m
@@ -311,7 +311,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | end = %i, begin = %i>", [self class], self, end, begin];
+	return [NSString stringWithFormat:@"<%@ = %p | end = %i, begin = %i>", [self class], self, end, begin];
 }
 
 - (void) dealloc

--- a/cocos2d/CCScheduler.m
+++ b/cocos2d/CCScheduler.m
@@ -128,7 +128,7 @@ typedef struct _hashSelectorEntry
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | target:%@ selector:(%@)>", [self class], self, [target class], NSStringFromSelector(selector)];
+	return [NSString stringWithFormat:@"<%@ = %p | target:%@ selector:(%@)>", [self class], self, [target class], NSStringFromSelector(selector)];
 }
 
 -(void) dealloc

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -281,7 +281,7 @@ static SEL selSortMethod = NULL;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Rect = (%.2f,%.2f,%.2f,%.2f) | tag = %i | atlasIndex = %i>", [self class], self,
+	return [NSString stringWithFormat:@"<%@ = %p | Rect = (%.2f,%.2f,%.2f,%.2f) | tag = %i | atlasIndex = %i>", [self class], self,
 			rect_.origin.x, rect_.origin.y, rect_.size.width, rect_.size.height,
 			tag_,
 			atlasIndex_

--- a/cocos2d/CCSpriteBatchNode.m
+++ b/cocos2d/CCSpriteBatchNode.m
@@ -126,7 +126,7 @@ static SEL selSortMethod =NULL;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Tag = %i>", [self class], self, tag_ ];
+	return [NSString stringWithFormat:@"<%@ = %p | Tag = %i>", [self class], self, tag_ ];
 }
 
 -(void)dealloc

--- a/cocos2d/CCSpriteFrame.m
+++ b/cocos2d/CCSpriteFrame.m
@@ -64,7 +64,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | TextureName=%d, Rect = (%.2f,%.2f,%.2f,%.2f)> rotated:%d, offset = (%.2f,%.2f), originalSize w %.2f h %.2f)", [self class], self,
+	return [NSString stringWithFormat:@"<%@ = %p | TextureName=%d, Rect = (%.2f,%.2f,%.2f,%.2f)> rotated:%d, offset = (%.2f,%.2f), originalSize w %.2f h %.2f)", [self class], self,
 			texture_.name,
 			rect_.origin.x,
 			rect_.origin.y,

--- a/cocos2d/CCSpriteFrameCache.m
+++ b/cocos2d/CCSpriteFrameCache.m
@@ -80,7 +80,7 @@ static CCSpriteFrameCache *sharedSpriteFrameCache_=nil;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | num of sprite frames =  %i>", [self class], self, [spriteFrames_ count]];
+	return [NSString stringWithFormat:@"<%@ = %p | num of sprite frames =  %i>", [self class], self, [spriteFrames_ count]];
 }
 
 -(void) dealloc

--- a/cocos2d/CCTMXXMLParser.m
+++ b/cocos2d/CCTMXXMLParser.m
@@ -229,7 +229,7 @@
 		else if( [orientationStr isEqualToString:@"hexagonal"])
 			orientation_ = CCTMXOrientationHex;
 		else
-			CCLOG(@"cocos2d: TMXFomat: Unsupported orientation: %@", orientation_);
+			CCLOG(@"cocos2d: TMXFomat: Unsupported orientation: %d", orientation_);
 
 		mapSize_.width = [[attributeDict valueForKey:@"width"] intValue];
 		mapSize_.height = [[attributeDict valueForKey:@"height"] intValue];

--- a/cocos2d/CCTexture2D.m
+++ b/cocos2d/CCTexture2D.m
@@ -194,7 +194,7 @@ static CCTexture2DPixelFormat defaultAlphaPixelFormat_ = kCCTexture2DPixelFormat
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | Name = %i | Dimensions = %ix%i | Coordinates = (%.2f, %.2f)>", [self class], self, name_, width_, height_, maxS_, maxT_];
+	return [NSString stringWithFormat:@"<%@ = %p | Name = %i | Dimensions = %ix%i | Coordinates = (%.2f, %.2f)>", [self class], self, name_, width_, height_, maxS_, maxT_];
 }
 
 -(CGSize) contentSize

--- a/cocos2d/CCTextureAtlas.m
+++ b/cocos2d/CCTextureAtlas.m
@@ -112,7 +112,7 @@
 
 -(NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | totalQuads =  %i>", [self class], self, totalQuads_];
+	return [NSString stringWithFormat:@"<%@ = %p | totalQuads =  %i>", [self class], self, totalQuads_];
 }
 
 -(void) dealloc

--- a/cocos2d/CCTextureCache.m
+++ b/cocos2d/CCTextureCache.m
@@ -111,7 +111,7 @@ static CCTextureCache *sharedTextureCache;
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | num of textures =  %i | keys: %@>",
+	return [NSString stringWithFormat:@"<%@ = %p | num of textures =  %i | keys: %@>",
 			[self class],
 			self,
 			[textures_ count],

--- a/cocos2d/Platforms/iOS/ES1Renderer.m
+++ b/cocos2d/Platforms/iOS/ES1Renderer.m
@@ -215,7 +215,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %08X | size = %ix%i>", [self class], self, backingWidth_, backingHeight_];
+	return [NSString stringWithFormat:@"<%@ = %p | size = %ix%i>", [self class], self, backingWidth_, backingHeight_];
 }
 
 

--- a/cocos2d/Support/CCArray.m
+++ b/cocos2d/Support/CCArray.m
@@ -417,7 +417,7 @@ static inline NSInteger selectorCompare(id object1,id object2,void *userData){
 
 - (NSString*) description
 {
-	NSMutableString *ret = [NSMutableString stringWithFormat:@"<%@ = %08X> = ( ", [self class], self];
+	NSMutableString *ret = [NSMutableString stringWithFormat:@"<%@ = %p> = ( ", [self class], self];
 
 	for( id obj in self)
 		[ret appendFormat:@"%@, ",obj];


### PR DESCRIPTION
As of xcode 4.4 / LLVM 4 cocos2d v1 fails to compile due to incorrect format paramaters in strings. Kaicherry committed a patch that fixes these issues in v2.x however these changes were never applied to v1.x. This patch contains the require changes to make v1.x compile successfully.

Original Patch: https://github.com/cocos2d/cocos2d-iphone/commit/f09b1502651765401ffad12d2baf994c909d6c43
