### PR TITLE
Optimization - eliminated costly [NSNumber floatValue] calls

### DIFF
--- a/cocos2d/CCActionInterval.h
+++ b/cocos2d/CCActionInterval.h
@@ -428,7 +428,7 @@ typedef struct _ccBezierConfig {
 /** Animates a sprite given the name of an Animation */
 @interface CCAnimate : CCActionInterval <NSCopying>
 {
-	NSMutableArray		*splitTimes_;
+	NSData				*splitTimes_;
 	NSInteger			nextFrame_;
 	CCAnimation			*animation_;
 	id					origFrame_;

--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -1333,18 +1333,20 @@ static inline CGFloat bezierat( float a, float b, float c, float d, ccTime t )
 		origFrame_ = nil;
 		executedLoops_ = 0;
 		
-		splitTimes_ = [[NSMutableArray alloc] initWithCapacity:anim.frames.count];
-		
 		float accumUnitsOfTime = 0;
 		float newUnitOfTimeValue = singleDuration / anim.totalDelayUnits;
 		
+		float *splitTimes = malloc(sizeof(float) * anim.frames.count);
+		int i = 0;
+		
 		for( CCAnimationFrame *frame in anim.frames ) {
 
-			NSNumber *value = [NSNumber numberWithFloat: (accumUnitsOfTime * newUnitOfTimeValue) / singleDuration];
+			splitTimes[i++] = (accumUnitsOfTime * newUnitOfTimeValue) / singleDuration;
 			accumUnitsOfTime += frame.delayUnits;
 
-			[splitTimes_ addObject:value];
 		}		
+
+		splitTimes_ = [[NSData alloc] initWithBytesNoCopy:splitTimes length:sizeof(float) * anim.frames.count freeWhenDone:YES];
 	}
 	return self;
 }
@@ -1409,10 +1411,9 @@ static inline CGFloat bezierat( float a, float b, float c, float d, ccTime t )
 	NSUInteger numberOfFrames = [frames count];
 	CCSpriteFrame *frameToDisplay = nil;
 
+	const float *splitTimes = [splitTimes_ bytes];
 	for( NSUInteger i=nextFrame_; i < numberOfFrames; i++ ) {
-		NSNumber *splitTime = [splitTimes_ objectAtIndex:i];
-
-		if( [splitTime floatValue] <= t ) {
+		if( splitTimes[i] <= t ) {
 			CCAnimationFrame *frame = [frames objectAtIndex:i];
 			frameToDisplay = [frame spriteFrame];
 			[(CCSprite*)target_ setDisplayFrame: frameToDisplay];


### PR DESCRIPTION
[NSNumber floatValue] is expensive, this patch removes the need for floatValue during animations by using an array of floats in an NSData container instead.
