### PR TITLE
Added public property to allow a CCSprite subclass to forcefully disable debug drawing.

### DIFF
--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -4768,6 +4768,7 @@
 		E0FDACE5123DAC8300F25BB4 /* larabie-16-hd.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "larabie-16-hd.png"; sourceTree = "<group>"; };
 		E0FDACE6123DAC8300F25BB4 /* larabie-16.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "larabie-16.png"; sourceTree = "<group>"; };
 		E0FDACED123DAD0000F25BB4 /* tuffy_bold_italic-charmap-hd.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "tuffy_bold_italic-charmap-hd.png"; sourceTree = "<group>"; };
+		E610367B15DD0C4F00819640 /* CCTransitionOrientationType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CCTransitionOrientationType.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -6240,6 +6241,7 @@
 				E0112F50120CB406006667F8 /* CCTransitionPageTurn.m */,
 				A0C3814F14BA0548001655CC /* CCTransitionProgress.h */,
 				A0C3815014BA0548001655CC /* CCTransitionProgress.m */,
+				E610367B15DD0C4F00819640 /* CCTransitionOrientationType.h */,
 			);
 			name = "Layers, Scenes, Transitions Nodes";
 			sourceTree = "<group>";

--- a/cocos2d/CCDirector.h
+++ b/cocos2d/CCDirector.h
@@ -27,10 +27,11 @@
 #import "ccConfig.h"
 #import "ccTypes.h"
 #import "ccMacros.h"
-
 #import "CCProtocols.h"
 #import "Platforms/CCGL.h"
 #import "kazmath/mat4.h"
+
+#import "CCTransitionOrientationType.h"
 
 /** @typedef ccDirectorProjection
  Possible OpenGL projections used by director
@@ -262,6 +263,22 @@ and when to execute the Scenes.
  */
 -(void) pushScene:(CCScene*) scene withTransition:(NSString*)transitionName duration:(ccTime)t;
 
+/**Suspends the execution of the running scene, pushing it on the stack of suspended scenes.
+ * The new scene will be executed and is going to be presented using a scene transition effect.
+ * Try to avoid big stacks of pushed scenes to reduce memory allocation.
+ * ONLY call it if there is a running scene.
+ */
+-(void) pushScene:(CCScene*) scene withTransition:(NSString*)transitionName duration:(ccTime)t
+                     withColor:(ccColor3B)color;
+
+/**Suspends the execution of the running scene, pushing it on the stack of suspended scenes.
+ * The new scene will be executed and is going to be presented using a scene transition effect.
+ * Try to avoid big stacks of pushed scenes to reduce memory allocation.
+ * ONLY call it if there is a running scene.
+ */
+-(void) pushScene:(CCScene*) scene withTransition:(NSString*)transitionName duration:(ccTime)t
+               withOrientation:(tOrientation)orientation;
+
 /**Pops out a scene from the queue.
  * This scene will replace the running one.
  * The running scene will be deleted. If there are no more scenes in the stack the execution is terminated.
@@ -275,6 +292,22 @@ and when to execute the Scenes.
  * ONLY call it if there is a running scene.
  */
 -(void) popSceneWithTransition:(NSString*)transitionName duration:(ccTime)t;
+
+/**Pops out a scene from the queue.
+ * This scene will replace the running one using a scene transition effect.
+ * The running scene will be deleted. If there are no more scenes in the stack the execution is terminated.
+ * ONLY call it if there is a running scene.
+ */
+-(void) popSceneWithTransition:(NSString*)transitionName duration:(ccTime)t
+                     withColor:(ccColor3B)color;
+
+/**Pops out a scene from the queue.
+ * This scene will replace the running one using a scene transition effect.
+ * The running scene will be deleted. If there are no more scenes in the stack the execution is terminated.
+ * ONLY call it if there is a running scene.
+ */
+-(void) popSceneWithTransition:(NSString*)transitionName duration:(ccTime)t
+                     withOrientation:(tOrientation)orientation;
 
 /**Pops out all scenes from the queue until the root scene in the queue.
  * This scene will replace the running one.

--- a/cocos2d/CCDirector.h
+++ b/cocos2d/CCDirector.h
@@ -255,12 +255,26 @@ and when to execute the Scenes.
  */
 - (void) pushScene:(CCScene*) scene;
 
+/**Suspends the execution of the running scene, pushing it on the stack of suspended scenes.
+ * The new scene will be executed and is going to be presented using a scene transition effect.
+ * Try to avoid big stacks of pushed scenes to reduce memory allocation.
+ * ONLY call it if there is a running scene.
+ */
+-(void) pushScene:(CCScene*) scene withTransition:(NSString*)transitionName duration:(ccTime)t;
+
 /**Pops out a scene from the queue.
  * This scene will replace the running one.
  * The running scene will be deleted. If there are no more scenes in the stack the execution is terminated.
  * ONLY call it if there is a running scene.
  */
 - (void) popScene;
+
+/**Pops out a scene from the queue.
+ * This scene will replace the running one using a scene transition effect.
+ * The running scene will be deleted. If there are no more scenes in the stack the execution is terminated.
+ * ONLY call it if there is a running scene.
+ */
+-(void) popSceneWithTransition:(NSString*)transitionName duration:(ccTime)t;
 
 /**Pops out all scenes from the queue until the root scene in the queue.
  * This scene will replace the running one.

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -409,6 +409,41 @@ static CCDirector *_sharedDirector = nil;
 	nextScene_ = newScene;	// nextScene_ is a weak ref
 }
 
+-(void) pushScene:(CCScene*) scene withTransition:(NSString*)transitionName duration:(ccTime)t
+        withColor:(ccColor3B)color
+{
+    NSAssert( scene != nil, @"Argument must be non-nil");
+    
+    Class transitionClass = NSClassFromString(transitionName);
+    BOOL classTest = [transitionClass respondsToSelector:@selector(transitionWithDuration:scene:withColor:)];
+    NSString * errorMsg = [NSString stringWithFormat:@"The transition \"%@\" is not a valid transition.", transitionName];
+    NSAssert (classTest, errorMsg);
+    
+	sendCleanupToScene_ = NO;
+    
+    CCScene* newScene = [transitionClass transitionWithDuration:t scene:scene withColor:color];
+	[scenesStack_ addObject: newScene];
+	nextScene_ = newScene;	// nextScene_ is a weak ref
+}
+
+-(void) pushScene:(CCScene*) scene withTransition:(NSString*)transitionName duration:(ccTime)t
+  withOrientation:(tOrientation)orientation
+{
+    NSAssert( scene != nil, @"Argument must be non-nil");
+    
+    Class transitionClass = NSClassFromString(transitionName);
+    BOOL classTest = [transitionClass respondsToSelector:@selector(transitionWithDuration:scene:withOrientation:)];
+    NSString * errorMsg = [NSString stringWithFormat:@"The transition \"%@\" is not a valid transition.", transitionName];
+    NSAssert (classTest, errorMsg);
+    
+	sendCleanupToScene_ = NO;
+    
+    CCScene* newScene = [transitionClass transitionWithDuration:t scene:scene withOrientation:orientation];
+	[scenesStack_ addObject: newScene];
+	nextScene_ = newScene;	// nextScene_ is a weak ref
+    
+}
+
 -(void) popScene
 {
 	NSAssert( runningScene_ != nil, @"A running Scene is needed");
@@ -421,6 +456,68 @@ static CCDirector *_sharedDirector = nil;
 	else {
 		sendCleanupToScene_ = YES;
 		nextScene_ = [scenesStack_ objectAtIndex:c-1];
+	}
+}
+
+-(void) popSceneWithTransition:(NSString*)transitionName duration:(ccTime)t
+{
+	NSAssert( runningScene_ != nil, @"A running Scene is needed");
+    
+    Class transitionClass = NSClassFromString(transitionName);
+    BOOL classTest = [transitionClass respondsToSelector:@selector(transitionWithDuration:scene:)];
+    NSString * errorMsg = [NSString stringWithFormat:@"The transition \"%@\" is not a valid transition.", transitionName];
+    NSAssert (classTest, errorMsg);
+    
+	[scenesStack_ removeLastObject];
+	NSUInteger c = [scenesStack_ count];
+	if( c == 0 ) {
+		[self end];
+	} else {
+		CCScene* scene = [transitionClass transitionWithDuration:t scene:[scenesStack_ objectAtIndex:c-1]];
+		[scenesStack_ replaceObjectAtIndex:c-1 withObject:scene];
+		nextScene_ = scene;
+	}
+}
+
+-(void) popSceneWithTransition:(NSString*)transitionName duration:(ccTime)t
+                     withColor:(ccColor3B)color
+{
+    NSAssert( runningScene_ != nil, @"A running Scene is needed");
+    
+    Class transitionClass = NSClassFromString(transitionName);
+    BOOL classTest = [transitionClass respondsToSelector:@selector(transitionWithDuration:scene:withColor:)];
+    NSString * errorMsg = [NSString stringWithFormat:@"The transition \"%@\" is not a valid transition.", transitionName];
+    NSAssert (classTest, errorMsg);
+    
+	[scenesStack_ removeLastObject];
+	NSUInteger c = [scenesStack_ count];
+	if( c == 0 ) {
+		[self end];
+	} else {
+		CCScene* scene = [transitionClass transitionWithDuration:t scene:[scenesStack_ objectAtIndex:c-1] withColor:color];
+		[scenesStack_ replaceObjectAtIndex:c-1 withObject:scene];
+		nextScene_ = scene;
+	}
+}
+
+-(void) popSceneWithTransition:(NSString*)transitionName duration:(ccTime)t
+               withOrientation:(tOrientation)orientation
+{
+    NSAssert( runningScene_ != nil, @"A running Scene is needed");
+    
+    Class transitionClass = NSClassFromString(transitionName);
+    BOOL classTest = [transitionClass respondsToSelector:@selector(transitionWithDuration:scene:withOrientation:)];
+    NSString * errorMsg = [NSString stringWithFormat:@"The transition \"%@\" is not a valid transition.", transitionName];
+    NSAssert (classTest, errorMsg);
+    
+	[scenesStack_ removeLastObject];
+	NSUInteger c = [scenesStack_ count];
+	if( c == 0 ) {
+		[self end];
+	} else {
+		CCScene* scene = [transitionClass transitionWithDuration:t scene:[scenesStack_ objectAtIndex:c-1] withOrientation:orientation];
+		[scenesStack_ replaceObjectAtIndex:c-1 withObject:scene];
+		nextScene_ = scene;
 	}
 }
 
@@ -445,26 +542,6 @@ static CCDirector *_sharedDirector = nil;
 		nextScene_ = [scenesStack_ lastObject];
 		sendCleanupToScene_ = NO;
     }
-}
-
--(void) popSceneWithTransition:(NSString*)transitionName duration:(ccTime)t
-{
-	NSAssert( runningScene_ != nil, @"A running Scene is needed");
-    
-    Class transitionClass = NSClassFromString(transitionName);
-    BOOL classTest = [transitionClass respondsToSelector:@selector(transitionWithDuration:scene:)];
-    NSString * errorMsg = [NSString stringWithFormat:@"The transition \"%@\" is not a valid transition.", transitionName];
-    NSAssert (classTest, errorMsg);
-    
-	[scenesStack_ removeLastObject];
-	NSUInteger c = [scenesStack_ count];
-	if( c == 0 ) {
-		[self end];
-	} else {
-		CCScene* scene = [transitionClass transitionWithDuration:t scene:[scenesStack_ objectAtIndex:c-1]];
-		[scenesStack_ replaceObjectAtIndex:c-1 withObject:scene];
-		nextScene_ = scene;
-	}
 }
 
 -(void) end

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -393,6 +393,22 @@ static CCDirector *_sharedDirector = nil;
 	nextScene_ = scene;	// nextScene_ is a weak ref
 }
 
+-(void) pushScene:(CCScene*) scene withTransition: (NSString*)transitionName duration:(ccTime)t {
+    
+    NSAssert( scene != nil, @"Argument must be non-nil");
+    
+    Class transitionClass = NSClassFromString(transitionName);
+    BOOL classTest = [transitionClass respondsToSelector:@selector(transitionWithDuration:scene:)];
+    NSString * errorMsg = [NSString stringWithFormat:@"The transition \"%@\" is not a valid transition.", transitionName];
+    NSAssert (classTest, errorMsg);
+    
+	sendCleanupToScene_ = NO;
+    
+    CCScene* newScene = [transitionClass transitionWithDuration:t scene:scene];
+	[scenesStack_ addObject: newScene];
+	nextScene_ = newScene;	// nextScene_ is a weak ref
+}
+
 -(void) popScene
 {
 	NSAssert( runningScene_ != nil, @"A running Scene is needed");
@@ -429,6 +445,26 @@ static CCDirector *_sharedDirector = nil;
 		nextScene_ = [scenesStack_ lastObject];
 		sendCleanupToScene_ = NO;
     }
+}
+
+-(void) popSceneWithTransition:(NSString*)transitionName duration:(ccTime)t
+{
+	NSAssert( runningScene_ != nil, @"A running Scene is needed");
+    
+    Class transitionClass = NSClassFromString(transitionName);
+    BOOL classTest = [transitionClass respondsToSelector:@selector(transitionWithDuration:scene:)];
+    NSString * errorMsg = [NSString stringWithFormat:@"The transition \"%@\" is not a valid transition.", transitionName];
+    NSAssert (classTest, errorMsg);
+    
+	[scenesStack_ removeLastObject];
+	NSUInteger c = [scenesStack_ count];
+	if( c == 0 ) {
+		[self end];
+	} else {
+		CCScene* scene = [transitionClass transitionWithDuration:t scene:[scenesStack_ objectAtIndex:c-1]];
+		[scenesStack_ replaceObjectAtIndex:c-1 withObject:scene];
+		nextScene_ = scene;
+	}
 }
 
 -(void) end

--- a/cocos2d/CCSprite.h
+++ b/cocos2d/CCSprite.h
@@ -107,6 +107,8 @@
 	// image is flipped
 	BOOL	flipX_;
 	BOOL	flipY_;
+    
+    BOOL    forceDisableDebugDraw_;
 }
 
 /** whether or not the Sprite needs to be updated in the Atlas */
@@ -149,6 +151,8 @@
 @property (nonatomic,readonly) CGPoint	offsetPosition;
 /** conforms to CCTextureProtocol protocol */
 @property (nonatomic,readwrite) ccBlendFunc blendFunc;
+
+@property (nonatomic, readwrite) BOOL forceDisableDebugDraw;
 
 #pragma mark CCSprite - Initializers
 

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -71,6 +71,7 @@
 @synthesize blendFunc = blendFunc_;
 @synthesize textureAtlas = textureAtlas_;
 @synthesize offsetPosition = offsetPosition_;
+@synthesize forceDisableDebugDraw = forceDisableDebugDraw_;
 
 
 +(id)spriteWithTexture:(CCTexture2D*)texture
@@ -479,14 +480,16 @@
 		[children_ makeObjectsPerformSelector:@selector(updateTransform)];
 
 #if CC_SPRITE_DEBUG_DRAW
-	// draw bounding box
-	CGPoint vertices[4] = {
-		ccp( quad_.bl.vertices.x, quad_.bl.vertices.y ),
-		ccp( quad_.br.vertices.x, quad_.br.vertices.y ),
-		ccp( quad_.tr.vertices.x, quad_.tr.vertices.y ),
-		ccp( quad_.tl.vertices.x, quad_.tl.vertices.y ),
-	};
-	ccDrawPoly(vertices, 4, YES);
+    if(!forceDisableDebugDraw_) {
+        // draw bounding box
+        CGPoint vertices[4] = {
+            ccp( quad_.bl.vertices.x, quad_.bl.vertices.y ),
+            ccp( quad_.br.vertices.x, quad_.br.vertices.y ),
+            ccp( quad_.tr.vertices.x, quad_.tr.vertices.y ),
+            ccp( quad_.tl.vertices.x, quad_.tl.vertices.y ),
+        };
+        ccDrawPoly(vertices, 4, YES);
+    }
 #endif // CC_SPRITE_DEBUG_DRAW
 
 }
@@ -533,23 +536,27 @@
 
 
 #if CC_SPRITE_DEBUG_DRAW == 1
-	// draw bounding box
-	CGPoint vertices[4]={
-		ccp(quad_.tl.vertices.x,quad_.tl.vertices.y),
-		ccp(quad_.bl.vertices.x,quad_.bl.vertices.y),
-		ccp(quad_.br.vertices.x,quad_.br.vertices.y),
-		ccp(quad_.tr.vertices.x,quad_.tr.vertices.y),
-	};
-	ccDrawPoly(vertices, 4, YES);
+    if(!forceDisableDebugDraw_) {
+        // draw bounding box
+        CGPoint vertices[4]={
+            ccp(quad_.tl.vertices.x,quad_.tl.vertices.y),
+            ccp(quad_.bl.vertices.x,quad_.bl.vertices.y),
+            ccp(quad_.br.vertices.x,quad_.br.vertices.y),
+            ccp(quad_.tr.vertices.x,quad_.tr.vertices.y),
+        };
+        ccDrawPoly(vertices, 4, YES);
+    }
 #elif CC_SPRITE_DEBUG_DRAW == 2
-	// draw texture box
-	CGSize s = self.textureRect.size;
-	CGPoint offsetPix = self.offsetPosition;
-	CGPoint vertices[4] = {
-		ccp(offsetPix.x,offsetPix.y), ccp(offsetPix.x+s.width,offsetPix.y),
-		ccp(offsetPix.x+s.width,offsetPix.y+s.height), ccp(offsetPix.x,offsetPix.y+s.height)
-	};
-	ccDrawPoly(vertices, 4, YES);
+    if(!forceDisableDebugDraw_) {
+        // draw texture box
+        CGSize s = self.textureRect.size;
+        CGPoint offsetPix = self.offsetPosition;
+        CGPoint vertices[4] = {
+            ccp(offsetPix.x,offsetPix.y), ccp(offsetPix.x+s.width,offsetPix.y),
+            ccp(offsetPix.x+s.width,offsetPix.y+s.height), ccp(offsetPix.x,offsetPix.y+s.height)
+        };
+        ccDrawPoly(vertices, 4, YES);
+    }
 #endif // CC_SPRITE_DEBUG_DRAW
 
 	CC_INCREMENT_GL_DRAWS(1);
@@ -906,7 +913,7 @@
 	return [CCSpriteFrame frameWithTexture:texture_
 							  rectInPixels:CC_RECT_POINTS_TO_PIXELS(rect_)
 								   rotated:rectRotated_
-									offset:unflippedOffsetPositionFromCenter_
+									offset:CC_POINT_POINTS_TO_PIXELS(unflippedOffsetPositionFromCenter_)
 							  originalSize:CC_SIZE_POINTS_TO_PIXELS(contentSize_)];
 }
 

--- a/cocos2d/CCTransition.h
+++ b/cocos2d/CCTransition.h
@@ -26,6 +26,8 @@
 
 
 #import "CCScene.h"
+#import "CCTransitionOrientationType.h"
+
 @class CCActionInterval;
 @class CCNode;
 
@@ -38,19 +40,6 @@
  */
 -(CCActionInterval*) easeActionWithAction:(CCActionInterval*)action;
 @end
-
-/** Orientation Type used by some transitions
- */
-typedef enum {
-	/// An horizontal orientation where the Left is nearer
-	kOrientationLeftOver = 0,
-	/// An horizontal orientation where the Right is nearer
-	kOrientationRightOver = 1,
-	/// A vertical orientation where the Up is nearer
-	kOrientationUpOver = 0,
-	/// A vertical orientation where the Bottom is nearer
-	kOrientationDownOver = 1,
-} tOrientation;
 
 /** Base class for CCTransition scenes
  */
@@ -80,9 +69,9 @@ typedef enum {
 	tOrientation orientation;
 }
 /** creates a base transition with duration and incoming scene */
-+(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s orientation:(tOrientation)o;
++(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s withOrientation:(tOrientation)o;
 /** initializes a transition with duration and incoming scene */
--(id) initWithDuration:(ccTime) t scene:(CCScene*)s orientation:(tOrientation)o;
+-(id) initWithDuration:(ccTime) t scene:(CCScene*)s withOrientation:(tOrientation)o;
 @end
 
 

--- a/cocos2d/CCTransition.m
+++ b/cocos2d/CCTransition.m
@@ -198,12 +198,12 @@ const NSInteger kSceneFade = 0xFADEFADE;
 // Oriented Transition
 //
 @implementation CCTransitionSceneOriented
-+(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s orientation:(tOrientation)o
++(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s withOrientation:(tOrientation)o
 {
-	return [[[self alloc] initWithDuration:t scene:s orientation:o] autorelease];
+	return [[[self alloc] initWithDuration:t scene:s withOrientation:o] autorelease];
 }
 
--(id) initWithDuration:(ccTime) t scene:(CCScene*)s orientation:(tOrientation)o
+-(id) initWithDuration:(ccTime) t scene:(CCScene*)s withOrientation:(tOrientation)o
 {
 	if( (self=[super initWithDuration:t scene:s]) )
 		orientation = o;

--- a/cocos2d/CCTransitionOrientationType.h
+++ b/cocos2d/CCTransitionOrientationType.h
@@ -1,0 +1,22 @@
+//
+//  ccTransitionOrientationType.h
+//  cocos2d-ios
+//
+//  Created by Goffredo Marocchi on 8/16/12.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+/** Orientation Type used by some transitions
+ */
+typedef enum {
+	/// An horizontal orientation where the Left is nearer
+	kOrientationLeftOver = 0,
+	/// An horizontal orientation where the Right is nearer
+	kOrientationRightOver = 1,
+	/// A vertical orientation where the Up is nearer
+	kOrientationUpOver = 0,
+	/// A vertical orientation where the Bottom is nearer
+	kOrientationDownOver = 1,
+} tOrientation;

--- a/cocos2d/CCTransitionOrientationType.h
+++ b/cocos2d/CCTransitionOrientationType.h
@@ -1,5 +1,5 @@
 //
-//  ccTransitionOrientationType.h
+//  CCTransitionOrientationType.h
 //  cocos2d-ios
 //
 //  Created by Goffredo Marocchi on 8/16/12.

--- a/tests/ActionsTest.m
+++ b/tests/ActionsTest.m
@@ -157,14 +157,14 @@ Class restartAction()
 {
 	CCScene *s = [CCScene node];
 	[s addChild: [nextAction() node]];
-	[[CCDirector sharedDirector] replaceScene: s];
+	[[CCDirector sharedDirector] pushScene:s withTransition:@"CCTransitionMoveInR" duration:1.0f];
 }
 
 -(void) backCallback: (id) sender
 {
 	CCScene *s = [CCScene node];
 	[s addChild: [backAction() node]];
-	[[CCDirector sharedDirector] replaceScene: s];
+	[[CCDirector sharedDirector] popSceneWithTransition:@"CCTransitionMoveInL" duration:1.0f];
 }
 
 

--- a/tests/ActionsTest.m
+++ b/tests/ActionsTest.m
@@ -157,14 +157,14 @@ Class restartAction()
 {
 	CCScene *s = [CCScene node];
 	[s addChild: [nextAction() node]];
-	[[CCDirector sharedDirector] pushScene:s withTransition:@"CCTransitionMoveInR" duration:1.0f];
+	[[CCDirector sharedDirector] pushScene:s withTransition:@"CCTransitionFlipX" duration:1.0f withOrientation:kOrientationUpOver];
 }
 
 -(void) backCallback: (id) sender
 {
 	CCScene *s = [CCScene node];
 	[s addChild: [backAction() node]];
-	[[CCDirector sharedDirector] popSceneWithTransition:@"CCTransitionMoveInL" duration:1.0f];
+	[[CCDirector sharedDirector] popSceneWithTransition:@"CCTransitionFade" duration:1.0f withColor:ccBLUE];
 }
 
 

--- a/tests/TransitionsTest.m
+++ b/tests/TransitionsTest.m
@@ -59,7 +59,7 @@
 
 @implementation FlipXLeftOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationLeftOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationLeftOver];
 }
 @end
 @implementation FadeWhiteTransition
@@ -70,57 +70,57 @@
 
 @implementation FlipXRightOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationRightOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationRightOver];
 }
 @end
 @implementation FlipYUpOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationUpOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationUpOver];
 }
 @end
 @implementation FlipYDownOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationDownOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationDownOver];
 }
 @end
 @implementation FlipAngularLeftOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationLeftOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationLeftOver];
 }
 @end
 @implementation FlipAngularRightOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationRightOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationRightOver];
 }
 @end
 @implementation ZoomFlipXLeftOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationLeftOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationLeftOver];
 }
 @end
 @implementation ZoomFlipXRightOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationRightOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationRightOver];
 }
 @end
 @implementation ZoomFlipYUpOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationUpOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationUpOver];
 }
 @end
 @implementation ZoomFlipYDownOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationDownOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationDownOver];
 }
 @end
 @implementation ZoomFlipAngularLeftOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationLeftOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationLeftOver];
 }
 @end
 @implementation ZoomFlipAngularRightOver
 +(id) transitionWithDuration:(ccTime) t scene:(CCScene*)s {
-	return [self transitionWithDuration:t scene:s orientation:kOrientationRightOver];
+	return [self transitionWithDuration:t scene:s withOrientation:kOrientationRightOver];
 }
 @end
 


### PR DESCRIPTION
When using Cocos2D as an external static library, the macro used to influence certain Cocos2D features, such as Debug drawing for CCSprites, are fixed when the library is compiled.

A workaround might be to compile the library in Release and Debug versions with the DEBUG flag directing, for example, when the debug drawing macro's allow the debug shapes to be rendered.
The problem is that this might cause cases in which the debug drawing feature for CCSprite objects is not really usable: if you have a few sprites moving in front of a large background (with the background being essentially just a large CCSprite object in some instancea), all the user will see is a huge white shape and will not be able to discern the small sprites in the foreground.

If we allow the CCSprite to override the debug drawing macro at runtime, we do not either lose performance in release mode and we make debug mode more flexible preventing the case mentioned above.
