### PR TITLE
Mac: preserve view allows touches after toggling fullscreen/windowed

### DIFF
--- a/cocos2d/Platforms/Mac/CCDirectorMac.m
+++ b/cocos2d/Platforms/Mac/CCDirectorMac.m
@@ -139,6 +139,7 @@
 		return;
 
 	CCGLView *openGLview = (CCGLView*) self.view;
+    BOOL viewAcceptsTouchEvents = openGLview.acceptsTouchEvents;
 
     if( fullscreen ) {
         originalWinRect_ = [openGLview frame];
@@ -199,7 +200,9 @@
 
     // re-configure glView
     [self setView:openGLview];
-
+    
+    [openGLview setAcceptsTouchEvents:viewAcceptsTouchEvents];
+    
     [openGLview release]; // Retain -1
 
     [openGLview setNeedsDisplay:YES];

--- a/tests/FullScreenTest.m
+++ b/tests/FullScreenTest.m
@@ -136,6 +136,7 @@ Class restartAction()
 		[director setResizeMode:kCCDirectorResize_AutoScale];
 
 		self.isMouseEnabled = YES;
+        self.isTouchEnabled = YES;
 
 		CGSize s = [director winSize];
 		[self addNewSpriteWithCoords:ccp(50,50)];
@@ -205,6 +206,25 @@ Class restartAction()
 	[self addNewSpriteWithCoords: location];
 
 	return YES;
+}
+
+-(BOOL) ccTouchesBeganWithEvent:(NSEvent *)event {
+    // get touches began
+    NSView *view = [[CCDirector sharedDirector] view];
+    NSSet *touches = [event touchesMatchingPhase:NSTouchPhaseBegan inView:view];
+    
+    CGSize winSize = [[CCDirector sharedDirector] winSize];
+    
+    for (NSTouch *touch in touches) {
+        // convert touch to window location
+        CGPoint location = CCNSPointToCGPoint(touch.normalizedPosition);
+        location = ccpCompMult(location, ccp(winSize.width, winSize.height));
+        
+        CCLOG(@"touch began: %.2f,%.2f", location.x, location.y);
+        [self addNewSpriteWithCoords: location];
+    }
+    
+    return YES;
 }
 #endif
 
@@ -234,6 +254,7 @@ Class restartAction()
 		[director setResizeMode:kCCDirectorResize_NoScale];
 
 		self.isMouseEnabled = YES;
+        self.isTouchEnabled = YES;
 
 		CGSize s = [director winSize];
 		[self addNewSpriteWithCoords:ccp(50,50)];
@@ -305,6 +326,25 @@ Class restartAction()
 	return YES;
 
 }
+
+-(BOOL) ccTouchesBeganWithEvent:(NSEvent *)event {
+    // get touches began
+    NSView *view = [[CCDirector sharedDirector] view];
+    NSSet *touches = [event touchesMatchingPhase:NSTouchPhaseBegan inView:view];
+    
+    CGSize winSize = [[CCDirector sharedDirector] winSize];
+    
+    for (NSTouch *touch in touches) {
+        // convert touch to window location
+        CGPoint location = CCNSPointToCGPoint(touch.normalizedPosition);
+        location = ccpCompMult(location, ccp(winSize.width, winSize.height));
+        
+        CCLOG(@"touch began: %.2f,%.2f", location.x, location.y);
+        [self addNewSpriteWithCoords: location];
+    }
+    
+    return YES;
+}
 #endif
 
 -(NSString *) title
@@ -332,6 +372,7 @@ Class restartAction()
 		[director setResizeMode:kCCDirectorResize_NoScale];
 
 		self.isMouseEnabled = YES;
+        self.isTouchEnabled = YES;
 
 		CGSize s = [director winSize];
 
@@ -526,7 +567,9 @@ Class restartAction()
 	[scene addChild: [nextAction() node]];
 
 //	[director setProjection:kCCDirectorProjection2D];
-
+    
+    [[(CCDirectorMac*)director_ view] setAcceptsTouchEvents:YES];
+    
 	[director_ runWithScene:scene];
 }
 @end


### PR DESCRIPTION
Fixes Mac view problem with touches. OpenGL view now sets acceptsTouches based on current value when toggling between fullscreen/windowed views.
