### PR TITLE
Bug with newlines in multiline labels

### DIFF
--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -552,9 +552,10 @@ void FNTConfigRemoveCache( void )
         //Go through each character and insert line breaks as necessary
         for (int j = 0; j < [children_ count]; j++) {
             CCSprite *characterSprite;
-			
-            while(!(characterSprite = (CCSprite *)[self getChildByTag:j+skip]))
-                skip++;
+            int justSkipped = 0;
+            while(!(characterSprite = (CCSprite *)[self getChildByTag:j+skip+justSkipped]))
+                justSkipped++;
+            skip += justSkipped;
 			
             if (!characterSprite.visible) continue;
 			
@@ -572,13 +573,14 @@ void FNTConfigRemoveCache( void )
             //Put lastWord on the current line and start a new line
             //Reset lastWord
             if ([[NSCharacterSet newlineCharacterSet] characterIsMember:character]) {
-                lastWord = [[lastWord stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] stringByAppendingFormat:@"%C", character];
+                lastWord = [lastWord stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+                lastWord = [lastWord stringByPaddingToLength:[lastWord length] + justSkipped withString:[NSString stringWithFormat:@"%C", character] startingAtIndex:0];
                 multilineString = [multilineString stringByAppendingString:lastWord];
                 lastWord = @"";
                 startOfWord = -1;
                 line++;
                 startOfLine = -1;
-                i++;
+                i+=justSkipped;
 				
                 //CCLabelBMFont do not have a character for new lines, so do NOT "continue;" in the for loop. Process the next character
                 if (i >= stringLength || i < 0)

--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -52,17 +52,17 @@ NSMutableDictionary *configurations = nil;
 CCBMFontConfiguration* FNTConfigLoadFile( NSString *fntFile)
 {
 	CCBMFontConfiguration *ret = nil;
-
+    
 	if( configurations == nil )
 		configurations = [[NSMutableDictionary dictionaryWithCapacity:3] retain];
-
+    
 	ret = [configurations objectForKey:fntFile];
 	if( ret == nil ) {
 		ret = [CCBMFontConfiguration configurationWithFNTFile:fntFile];
 		if( ret )
 			[configurations setObject:ret forKey:fntFile];
 	}
-
+    
 	return ret;
 }
 
@@ -71,30 +71,11 @@ void FNTConfigRemoveCache( void )
 	[configurations removeAllObjects];
 }
 
-#pragma mark - Hash Element
-
-// Equal function for targetSet.
-typedef struct _KerningHashElement
-{
-	int				key;		// key for the hash. 16-bit for 1st element, 16-bit for 2nd element
-	int				amount;
-	UT_hash_handle	hh;
-} tKerningHashElement;
-
-
 #pragma mark -
 #pragma mark BitmapFontConfiguration
 
-typedef struct _FontDefHashElement
-{
-	NSUInteger		key;		// key. Font Unicode value
-	ccBMFontDef		fontDef;	// font definition
-	UT_hash_handle	hh;
-} tFontDefHashElement;
-
-
 @interface CCBMFontConfiguration ()
--(BOOL) parseConfigFile:(NSString*)controlFile;
+-(NSMutableString *) parseConfigFile:(NSString*)controlFile;
 -(void) parseCharacterDefinition:(NSString*)line charDef:(ccBMFontDef*)characterDefinition;
 -(void) parseInfoArguments:(NSString*)line;
 -(void) parseCommonArguments:(NSString*)line;
@@ -108,6 +89,7 @@ typedef struct _FontDefHashElement
 #pragma mark CCBMFontConfiguration
 
 @implementation CCBMFontConfiguration
+@synthesize characterSet=characterSet_;
 @synthesize atlasName=atlasName_;
 
 +(id) configurationWithFNTFile:(NSString*)FNTfile
@@ -118,14 +100,18 @@ typedef struct _FontDefHashElement
 -(id) initWithFNTfile:(NSString*)fntFile
 {
 	if((self=[super init])) {
-
+        
 		kerningDictionary_ = NULL;
 		fontDefDictionary_ = NULL;
-
-		if( ! [self parseConfigFile:fntFile] ) {
+    
+		NSMutableString *validCharsString = [self parseConfigFile:fntFile];
+		  
+		if( ! validCharsString ) {
 			[self release];
 			return nil;
 		}
+    
+		characterSet_ = [[NSCharacterSet characterSetWithCharactersInString:validCharsString] retain];
 	}
 	return self;
 }
@@ -133,6 +119,7 @@ typedef struct _FontDefHashElement
 - (void) dealloc
 {
 	CCLOGINFO( @"cocos2d: deallocing %@", self);
+	[characterSet_ release];
 	[self purgeFontDefDictionary];
 	[self purgeKerningDictionary];
 	[atlasName_ release];
@@ -150,7 +137,7 @@ typedef struct _FontDefHashElement
 
 -(void) purgeFontDefDictionary
 {	
-	tFontDefHashElement *current, *tmp;
+	tCCFontDefHashElement *current, *tmp;
 	
 	HASH_ITER(hh, fontDefDictionary_, current, tmp) {
 		HASH_DEL(fontDefDictionary_, current);
@@ -160,8 +147,8 @@ typedef struct _FontDefHashElement
 
 -(void) purgeKerningDictionary
 {
-	tKerningHashElement *current;
-
+	tCCKerningHashElement *current;
+    
 	while(kerningDictionary_) {
 		current = kerningDictionary_;
 		HASH_DEL(kerningDictionary_,current);
@@ -169,26 +156,28 @@ typedef struct _FontDefHashElement
 	}
 }
 
-- (BOOL)parseConfigFile:(NSString*)fntFile
+- (NSMutableString *)parseConfigFile:(NSString*)fntFile
 {
 	NSString *fullpath = [[CCFileUtils sharedFileUtils] fullPathFromRelativePath:fntFile];
 	NSError *error;
 	NSString *contents = [NSString stringWithContentsOfFile:fullpath encoding:NSUTF8StringEncoding error:&error];
-
+  
+  NSMutableString *validCharsString	= [[NSMutableString alloc] initWithCapacity:512];
+    
 	if( ! contents ) {
 		NSLog(@"cocos2d: Error parsing FNTfile %@: %@", fntFile, error);
-		return NO;
+		return nil;
 	}
-
+    
 	// Move all lines in the string, which are denoted by \n, into an array
 	NSArray *lines = [[NSArray alloc] initWithArray:[contents componentsSeparatedByString:@"\n"]];
-
+    
 	// Create an enumerator which we can use to move through the lines read from the control file
 	NSEnumerator *nse = [lines objectEnumerator];
-
+    
 	// Create a holder for each line we are going to work with
 	NSString *line;
-
+    
 	// Loop through all the lines in the lines array processing each one
 	while( (line = [nse nextObject]) ) {
 		// parse spacing / padding
@@ -209,16 +198,18 @@ typedef struct _FontDefHashElement
 		}
 		else if([line hasPrefix:@"char"]) {
 			// Parse the current line and create a new CharDef
-			tFontDefHashElement *element = malloc( sizeof(*element) );
+			tCCFontDefHashElement *element = malloc( sizeof(*element) );
 			
 			[self parseCharacterDefinition:line charDef:&element->fontDef];
 			
 			element->key = element->fontDef.charID;
 			HASH_ADD_INT(fontDefDictionary_, key, element);
+      
+      [validCharsString appendString:[NSString stringWithFormat:@"%C", element->fontDef.charID]];
 		}
-//		else if([line hasPrefix:@"kernings count"]) {
-//			[self parseKerningCapacity:line];
-//		}
+        //		else if([line hasPrefix:@"kernings count"]) {
+        //			[self parseKerningCapacity:line];
+        //		}
 		else if([line hasPrefix:@"kerning first"]) {
 			[self parseKerningEntry:line];
 		}
@@ -226,36 +217,36 @@ typedef struct _FontDefHashElement
 	// Finished with lines so release it
 	[lines release];
 	
-	return  YES;
+	return [validCharsString autorelease];
 }
 
 -(void) parseImageFileName:(NSString*)line fntFile:(NSString*)fntFile
 {
 	NSString *propertyValue = nil;
-
+    
 	// Break the values for this line up using =
 	NSArray *values = [line componentsSeparatedByString:@"="];
-
+    
 	// Get the enumerator for the array of components which has been created
 	NSEnumerator *nse = [values objectEnumerator];
-
+    
 	// We need to move past the first entry in the array before we start assigning values
 	[nse nextObject];
-
+    
 	// page ID. Sanity check
 	propertyValue = [nse nextObject];
 	NSAssert( [propertyValue intValue] == 0, @"XXX: LabelBMFont only supports 1 page");
-
+    
 	// file
 	propertyValue = [nse nextObject];
 	NSArray *array = [propertyValue componentsSeparatedByString:@"\""];
 	propertyValue = [array objectAtIndex:1];
 	NSAssert(propertyValue,@"LabelBMFont file could not be found");
-
+    
 	// Supports subdirectories
 	NSString *dir = [fntFile stringByDeletingLastPathComponent];
 	atlasName_ = [dir stringByAppendingPathComponent:propertyValue];
-
+    
 	[atlasName_ retain];
 }
 
@@ -269,62 +260,62 @@ typedef struct _FontDefHashElement
 	NSArray *values = [line componentsSeparatedByString:@"="];
 	NSEnumerator *nse = [values objectEnumerator];
 	NSString *propertyValue = nil;
-
+    
 	// We need to move past the first entry in the array before we start assigning values
 	[nse nextObject];
-
+    
 	// face (ignore)
 	[nse nextObject];
-
+    
 	// size (ignore)
 	[nse nextObject];
-
+    
 	// bold (ignore)
 	[nse nextObject];
-
+    
 	// italic (ignore)
 	[nse nextObject];
-
+    
 	// charset (ignore)
 	[nse nextObject];
-
+    
 	// unicode (ignore)
 	[nse nextObject];
-
+    
 	// strechH (ignore)
 	[nse nextObject];
-
+    
 	// smooth (ignore)
 	[nse nextObject];
-
+    
 	// aa (ignore)
 	[nse nextObject];
-
+    
 	// padding (ignore)
 	propertyValue = [nse nextObject];
 	{
-
+        
 		NSArray *paddingValues = [propertyValue componentsSeparatedByString:@","];
 		NSEnumerator *paddingEnum = [paddingValues objectEnumerator];
 		// padding top
 		propertyValue = [paddingEnum nextObject];
 		padding_.top = [propertyValue intValue];
-
+        
 		// padding right
 		propertyValue = [paddingEnum nextObject];
 		padding_.right = [propertyValue intValue];
-
+        
 		// padding bottom
 		propertyValue = [paddingEnum nextObject];
 		padding_.bottom = [propertyValue intValue];
-
+        
 		// padding left
 		propertyValue = [paddingEnum nextObject];
 		padding_.left = [propertyValue intValue];
-
+        
 		CCLOG(@"cocos2d: padding: %d,%d,%d,%d", padding_.left, padding_.top, padding_.right, padding_.bottom);
 	}
-
+    
 	// spacing (ignore)
 	[nse nextObject];
 }
@@ -338,30 +329,30 @@ typedef struct _FontDefHashElement
 	NSArray *values = [line componentsSeparatedByString:@"="];
 	NSEnumerator *nse = [values objectEnumerator];
 	NSString *propertyValue = nil;
-
+    
 	// We need to move past the first entry in the array before we start assigning values
 	[nse nextObject];
-
+    
 	// Character ID
 	propertyValue = [nse nextObject];
 	commonHeight_ = [propertyValue intValue];
-
+    
 	// base (ignore)
 	[nse nextObject];
-
-
+    
+    
 	// scaleW. sanity check
 	propertyValue = [nse nextObject];
 	NSAssert( [propertyValue intValue] <= [[CCConfiguration sharedConfiguration] maxTextureSize], @"CCLabelBMFont: page can't be larger than supported");
-
+    
 	// scaleH. sanity check
 	propertyValue = [nse nextObject];
 	NSAssert( [propertyValue intValue] <= [[CCConfiguration sharedConfiguration] maxTextureSize], @"CCLabelBMFont: page can't be larger than supported");
-
+    
 	// pages. sanity check
 	propertyValue = [nse nextObject];
 	NSAssert( [propertyValue intValue] == 1, @"CCBitfontAtlas: only supports 1 page");
-
+    
 	// packed (ignore) What does this mean ??
 }
 - (void)parseCharacterDefinition:(NSString*)line charDef:(ccBMFontDef*)characterDefinition
@@ -370,15 +361,15 @@ typedef struct _FontDefHashElement
 	NSArray *values = [line componentsSeparatedByString:@"="];
 	NSEnumerator *nse = [values objectEnumerator];
 	NSString *propertyValue;
-
+    
 	// We need to move past the first entry in the array before we start assigning values
 	[nse nextObject];
-
+    
 	// Character ID
 	propertyValue = [nse nextObject];
 	propertyValue = [propertyValue substringToIndex: [propertyValue rangeOfString: @" "].location];
 	characterDefinition->charID = [propertyValue intValue];
-
+    
 	// Character x
 	propertyValue = [nse nextObject];
 	characterDefinition->rect.origin.x = [propertyValue intValue];
@@ -407,23 +398,23 @@ typedef struct _FontDefHashElement
 	NSArray *values = [line componentsSeparatedByString:@"="];
 	NSEnumerator *nse = [values objectEnumerator];
 	NSString *propertyValue;
-
+    
 	// We need to move past the first entry in the array before we start assigning values
 	[nse nextObject];
-
+    
 	// first
 	propertyValue = [nse nextObject];
 	int first = [propertyValue intValue];
-
+    
 	// second
 	propertyValue = [nse nextObject];
 	int second = [propertyValue intValue];
-
+    
 	// second
 	propertyValue = [nse nextObject];
 	int amount = [propertyValue intValue];
-
-	tKerningHashElement *element = calloc( sizeof( *element ), 1 );
+    
+	tCCKerningHashElement *element = calloc( sizeof( *element ), 1 );
 	element->amount = amount;
 	element->key = (first<<16) | (second&0xffff);
 	HASH_ADD_INT(kerningDictionary_,key, element);
@@ -498,25 +489,25 @@ typedef struct _FontDefHashElement
 	NSAssert( (theString && fntFile) || (theString==nil && fntFile==nil), @"Invalid params for CCLabelBMFont");
 	
 	CCTexture2D *texture = nil;
-
+    
 	if( fntFile ) {
 		CCBMFontConfiguration *newConf = FNTConfigLoadFile(fntFile);
 		NSAssert( newConf, @"CCLabelBMFont: Impossible to create font. Please check file: '%@'", fntFile );
-
+        
 		configuration_ = [newConf retain];
-    
+        
 		fntFile_ = [fntFile retain];
-
+        
 		texture = [[CCTextureCache sharedTextureCache] addImage:configuration_.atlasName];
-
+        
 	} else
 		texture = [[[CCTexture2D alloc] init] autorelease];
-
-
+    
+    
 	if( (self=[super initWithTexture:texture capacity:[theString length]]) ) {
         width_ = width;
         alignment_ = alignment;
-
+        
 		opacity_ = 255;
 		color_ = ccWHITE;
 		
@@ -525,12 +516,12 @@ typedef struct _FontDefHashElement
 		opacityModifyRGB_ = [[textureAtlas_ texture] hasPremultipliedAlpha];
 		
 		anchorPoint_ = ccp(0.5f, 0.5f);
-
+        
 		imageOffset_ = offset;
-
+        
 		[self setString:theString updateLabel:YES];
 	}
-
+    
 	return self;
 }
 
@@ -540,7 +531,7 @@ typedef struct _FontDefHashElement
     [initialString_ release];
 	[configuration_ release];
     [fntFile_ release];
-
+    
 	[super dealloc];
 }
 
@@ -561,12 +552,9 @@ typedef struct _FontDefHashElement
         //Go through each character and insert line breaks as necessary
         for (int j = 0; j < [children_ count]; j++) {
             CCSprite *characterSprite;
-	    int justSkipped = 0;
 			
-            while(!(characterSprite = (CCSprite *)[self getChildByTag:j+skip+justSkipped]))
-                justSkipped++;
-
-	    skip += justSkipped;
+            while(!(characterSprite = (CCSprite *)[self getChildByTag:j+skip]))
+                skip++;
 			
             if (!characterSprite.visible) continue;
 			
@@ -584,8 +572,7 @@ typedef struct _FontDefHashElement
             //Put lastWord on the current line and start a new line
             //Reset lastWord
             if ([[NSCharacterSet newlineCharacterSet] characterIsMember:character]) {
-                lastWord = [lastWord stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-                lastWord = [lastWord stringByPaddingToLength:[lastWord length] + justSkipped withString:[NSString stringWithFormat:@"%C", character] startingAtIndex:0];
+                lastWord = [[lastWord stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] stringByAppendingFormat:@"%C", character];
                 multilineString = [multilineString stringByAppendingString:lastWord];
                 lastWord = @"";
                 startOfWord = -1;
@@ -697,14 +684,14 @@ typedef struct _FontDefHashElement
 {
 	int ret = 0;
 	unsigned int key = (first<<16) | (second & 0xffff);
-
+    
 	if( configuration_->kerningDictionary_ ) {
-		tKerningHashElement *element = NULL;
+		tCCKerningHashElement *element = NULL;
 		HASH_FIND_INT(configuration_->kerningDictionary_, &key, element);
 		if(element)
 			ret = element->amount;
 	}
-
+    
 	return ret;
 }
 
@@ -714,18 +701,20 @@ typedef struct _FontDefHashElement
 	NSInteger nextFontPositionY = 0;
 	unichar prev = -1;
 	NSInteger kerningAmount = 0;
-
+    
 	CGSize tmpSize = CGSizeZero;
-
+    
 	NSInteger longestLine = 0;
 	NSUInteger totalHeight = 0;
-
+    
 	NSUInteger quantityOfLines = 1;
-
+  
+	NSCharacterSet *charSet	= configuration_.characterSet;
+    
 	NSUInteger stringLen = [string_ length];
 	if( ! stringLen )
 		return;
-
+    
 	// quantity of lines NEEDS to be calculated before parsing the lines,
 	// since the Y position needs to be calcualted before hand
 	for(NSUInteger i=0; i < stringLen-1;i++) {
@@ -733,39 +722,46 @@ typedef struct _FontDefHashElement
 		if( c=='\n')
 			quantityOfLines++;
 	}
-
+    
 	totalHeight = configuration_->commonHeight_ * quantityOfLines;
 	nextFontPositionY = -(configuration_->commonHeight_ - configuration_->commonHeight_*quantityOfLines);
-
+    
 	for(NSUInteger i = 0; i<stringLen; i++) {
 		unichar c = [string_ characterAtIndex:i];
-
+        
 		if (c == '\n') {
 			nextFontPositionX = 0;
 			nextFontPositionY -= configuration_->commonHeight_;
 			continue;
 		}
-
+    
+		if(![charSet characterIsMember:c]){
+			CCLOGWARN(@"CCLabelBMFont: Attempted to use character not defined in this bitmap: %C", c);
+			continue;
+		}
+        
 		kerningAmount = [self kerningAmountForFirst:prev second:c];
-
 		
-		tFontDefHashElement *element = NULL;
+		tCCFontDefHashElement *element = NULL;
 		
 		// unichar is a short, and an int is needed on HASH_FIND_INT
 		NSUInteger key = (NSUInteger)c;
 		HASH_FIND_INT(configuration_->fontDefDictionary_ , &key, element);
-		NSAssert(element, @"FontDefinition could not be found!");
-
+		if( ! element ) {
+			CCLOGWARN(@"cocos2d: LabelBMFont: characer not found %c", c);
+			continue;
+		}
+        
 		ccBMFontDef fontDef = element->fontDef;
-
+        
 		CGRect rect = fontDef.rect;
 		rect = CC_RECT_PIXELS_TO_POINTS(rect);
 		
 		rect.origin.x += imageOffset_.x;
 		rect.origin.y += imageOffset_.y;
-
+        
 		CCSprite *fontChar;
-
+        
 		fontChar = (CCSprite*) [self getChildByTag:i];
 		if( ! fontChar ) {
 			fontChar = [[CCSprite alloc] initWithTexture:textureAtlas_.texture rect:rect];
@@ -775,12 +771,12 @@ typedef struct _FontDefHashElement
 		else {
 			// reusing fonts
 			[fontChar setTextureRect:rect rotated:NO untrimmedSize:rect.size];
-
+            
 			// restore to default in case they were modified
 			fontChar.visible = YES;
 			fontChar.opacity = 255;
 		}
-
+        
 		// See issue 1343. cast( signed short + unsigned integer ) == unsigned integer (sign is lost!)
 		NSInteger yOffset = configuration_->commonHeight_ - fontDef.yOffset;
 		CGPoint fontPos = ccp( (CGFloat)nextFontPositionX + fontDef.xOffset + fontDef.rect.size.width*0.5f + kerningAmount,
@@ -790,24 +786,24 @@ typedef struct _FontDefHashElement
 		// update kerning
 		nextFontPositionX += fontDef.xAdvance + kerningAmount;
 		prev = c;
-
+        
 		// Apply label properties
 		[fontChar setOpacityModifyRGB:opacityModifyRGB_];
 		// Color MUST be set before opacity, since opacity might change color if OpacityModifyRGB is on
 		[fontChar setColor:color_];
-
+        
 		// only apply opacity if it is different than 255 )
 		// to prevent modifying the color too (issue #610)
 		if( opacity_ != 255 )
 			[fontChar setOpacity: opacity_];
-
+        
 		if (longestLine < nextFontPositionX)
 			longestLine = nextFontPositionX;
 	}
-
+    
 	tmpSize.width = longestLine;
 	tmpSize.height = totalHeight;
-
+    
 	[self setContentSize:CC_SIZE_PIXELS_TO_POINTS(tmpSize)];
 }
 
@@ -852,7 +848,7 @@ typedef struct _FontDefHashElement
 -(void) setColor:(ccColor3B)color
 {
 	color_ = color;
-
+    
 	CCSprite *child;
 	CCARRAY_FOREACH(children_, child)
     [child setColor:color_];
@@ -861,7 +857,7 @@ typedef struct _FontDefHashElement
 -(void) setOpacity:(GLubyte)opacity
 {
 	opacity_ = opacity;
-
+    
 	id<CCRGBAProtocol> child;
 	CCARRAY_FOREACH(children_, child)
     [child setOpacity:opacity_];
@@ -869,7 +865,7 @@ typedef struct _FontDefHashElement
 -(void) setOpacityModifyRGB:(BOOL)modify
 {
 	opacityModifyRGB_ = modify;
-
+    
 	id<CCRGBAProtocol> child;
 	CCARRAY_FOREACH(children_, child)
     [child setOpacityModifyRGB:modify];
@@ -914,7 +910,7 @@ typedef struct _FontDefHashElement
 		
 		[configuration_ release];
 		configuration_ = [newConf retain];
-	
+        
 		[self setTexture:[[CCTextureCache sharedTextureCache] addImage:configuration_.atlasName]];
 		[self createFontChars];
 	}
@@ -930,7 +926,7 @@ typedef struct _FontDefHashElement
 -(void) draw
 {
 	[super draw];
-
+    
 	CGSize s = [self contentSize];
 	CGPoint vertices[4]={
 		ccp(0,0),ccp(s.width,0),


### PR DESCRIPTION
When a multiline label updates it counts multiple newlines as one and the string gets trimmed at the end.

This fixes that, keeping track of how many newlines where just skipped and appending as many characters that was skipped.

This is an extract from my code that produced the error with the last character being trimmed.
It should say "Error\n\nSome error" but it shows "Error\n\nSome erro"

```
CCLabelBMFont *message = [CCLabelBMFont labelWithString:@"Error\n\nSome error message" fntFile:@"#########.fnt"];
message.color = ccc3(0, 0, 0);
message.anchorPoint = ccp(0.5f, 1);
[message setWidth:290];
[message setAlignment:kCCTextAlignmentCenter];
message.position = ccp(dialog.contentSize.width / 2.0f, dialog.contentSize.height - 20);
[dialog addChild:message];
```
