### PR TITLE
Automatically load Widescreen (4") optimized images

### DIFF
--- a/cocos2d/Support/CCFileUtils.h
+++ b/cocos2d/Support/CCFileUtils.h
@@ -40,6 +40,8 @@
 	
 #ifdef __CC_PLATFORM_IOS	
 	NSString *iPhoneRetinaDisplaySuffix_;
+	NSString *iPhoneWidescreenDisplaySuffix_;
+	NSString *iPhoneWidescreenRetinaDisplaySuffix_;
 	NSString *iPadSuffix_;
 	NSString *iPadRetinaDisplaySuffix_;
 #elif defined(__CC_PLATFORM_MAC)
@@ -79,6 +81,13 @@
  @since v1.1
  */
 @property (nonatomic,readwrite, copy, setter = setiPhoneRetinaDisplaySuffix:) NSString *iPhoneRetinaDisplaySuffix;
+
+/** The iPhone 5 / iPod touch 5g (4") Widescreen suffixes to load resources.
+ By default it is "-widehd", "-wide" "-hd" and "", in that order.
+ Only valid on iOS. Not valid for OS X.
+ */
+@property (nonatomic,readwrite, copy, setter = setiPhoneWidescreenDisplaySuffix:) NSString *iPhoneWidescreenDisplaySuffix;
+@property (nonatomic,readwrite, copy, setter = setiPhoneWidescreenRetinaDisplaySuffix:) NSString *iPhoneWidescreenRetinaDisplaySuffix;
 
 /** The iPad suffixes to load resources.
  By default it is "-ipad", "-hd", "", in that order.
@@ -177,6 +186,12 @@
  @since v1.1
  */
 -(BOOL) iPhoneRetinaDisplayFileExistsAtPath:(NSString*)filename;
+
+/** Returns whether or not a given path exists with the iPhone 5 (4") Widescreen suffix.
+ Only available on iOS. Not supported on OS X.
+ */
+-(BOOL) iPhoneWidescreenDisplayFileExistsAtPath:(NSString*)filename;
+-(BOOL) iPhoneWidescreenRetinaDisplayFileExistsAtPath:(NSString*)filename;
 
 /** Returns whether or not a given filename exists with the iPad suffix.
  Only available on iOS. Not supported on OS X.

--- a/cocos2d/ccGLStateCache.m
+++ b/cocos2d/ccGLStateCache.m
@@ -152,8 +152,10 @@ void ccGLDeleteTexture( GLuint textureId )
 
 void ccGLDeleteTextureN( GLuint textureUnit, GLuint textureId )
 {
+#if CC_ENABLE_GL_STATE_CACHE
 	if( _ccCurrentBoundTexture[ textureUnit ] == textureId )
 		_ccCurrentBoundTexture[ textureUnit ] = -1;
+#endif
 	
 	glDeleteTextures(1, &textureId );
 }


### PR DESCRIPTION
Added two new suffixes -- "-wide" and "-widehd" for assets optimized for the iPhone 5 / iPod touch 5th gen "widescreen" displays.

The reason why there are two separate suffixes is that, for performance/memory usage reasons, sometimes you may not want to actually load a full-res image, even though all widescreen devices are also retina.

Images load fine, don't see the need for a test case, but I can write one if you absolutely insist =)

Also, there was a small issue with GL State caching related code, gave an error when building with state cache disabled.
