### PR TITLE
Respect custom projections when converting coordinates.

### DIFF
--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -336,28 +336,38 @@ CGFloat	__ccContentScaleFactor = 1;
 
 -(CGPoint)convertToGL:(CGPoint)uiPoint
 {
-	CGSize s = winSizeInPoints_;
-	float newY = s.height - uiPoint.y;
-
-	return ccp( uiPoint.x, newY );
+	kmMat4 projection;
+	kmGLGetMatrix(KM_GL_PROJECTION, &projection);
+	
+	kmMat4 inv_projection;
+	kmMat4Inverse(&inv_projection, &projection);
+	
+	CGSize glSize = view_.bounds.size;
+	kmVec3 glCoord;
+	kmVec3 v = {2.0*uiPoint.x/glSize.width - 1.0, 1.0 - 2.0*uiPoint.y/glSize.height, 0.0};
+	kmVec3TransformCoord(&glCoord, &v, &inv_projection);
+	
+	return ccp(glCoord.x, glCoord.y);
 }
 
 -(CGPoint)convertTouchToGL:(UITouch*)touch
 {
 	CGPoint uiPoint = [touch locationInView: [touch view]];
-	CGSize s = winSizeInPoints_;
-	float newY = s.height - uiPoint.y;
-	
-	return ccp( uiPoint.x, newY );
+	return [self convertToGL:uiPoint];
 }
 
 
 -(CGPoint)convertToUI:(CGPoint)glPoint
 {
-	CGSize winSize = winSizeInPoints_;
-	int oppositeY = winSize.height - glPoint.y;
-
-	return ccp(glPoint.x, oppositeY);
+	kmMat4 projection;
+	kmGLGetMatrix(KM_GL_PROJECTION, &projection);
+		
+	kmVec3 clipCoord;
+	kmVec3 v = {glPoint.x, glPoint.y, 0.0};
+	kmVec3TransformCoord(&clipCoord, &v, &projection);
+	
+	CGSize glSize = view_.bounds.size;
+	return ccp(glSize.width*(clipCoord.x*0.5 + 0.5), glSize.height*(-clipCoord.y*0.5 + 0.5));
 }
 
 -(void) end


### PR DESCRIPTION
I use custom projections in all of my universal Cocos2D projects so I can set an iPad resolution of 512x384. That along with a terrible hack so it runs with a content scale of 2x on the iPad (4x on retina iPad), it makes the iPad versions a lot easier to manage. They are pretty close to retina iPhone size, just a little bit bigger. Makes it much easier to share code and content between the two versions as the sizing all stays the same.

Anyway I won't share the terrible, fragile content scale hack, but one of the issues with using a custom projection is that the CCDirector methods don't know how to convert coordinates for them. It just does a simple flip assuming that GL coords are just flipped and calls it good. I fixed them to use the projection matrix instead.
