### PR TITLE
Actually attach the stencil part to the framebuffer...

### DIFF
--- a/cocos2d/Platforms/iOS/CCES2Renderer.m
+++ b/cocos2d/Platforms/iOS/CCES2Renderer.m
@@ -155,6 +155,10 @@
 
 		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthBuffer_);
 
+		if (depthFormat_ == GL_DEPTH24_STENCIL8_OES) {
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthBuffer_);
+		}
+        
 		// bind color buffer
 		glBindRenderbuffer(GL_RENDERBUFFER, colorRenderbuffer_);		
 	}


### PR DESCRIPTION
... when creating a CCGLView using GL_DEPTH24_STENCIL8_OES as depthFormat.

To be able to use GL_STENCIL_TEST into CCNode draw/visit.

I am no OpenGL expert but i think this was missing.
