### PR TITLE
Adding support for rotations on iOS 6. We need access to will rotate not...

### DIFF
--- a/cocos2d/CCProtocols.h
+++ b/cocos2d/CCProtocols.h
@@ -126,6 +126,7 @@
 #ifdef __CC_PLATFORM_IOS
 /** Returns a Boolean value indicating whether the CCDirector supports the specified orientation. Default value is YES (supports all possible orientations) */
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
+- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration;
 
 #endif // __CC_PLATFORM_IOS
 

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -377,7 +377,8 @@ CGFloat	__ccContentScaleFactor = 1;
 
 -(void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
-	// do something ?
+	if( [delegate_ respondsToSelector:_cmd] )
+		[delegate_ willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
 }
 
 


### PR DESCRIPTION
willRotateToInterfaceOrientation should be passed onto the delegate because that allows the developer to move things around in the cocos2d scene if the aspect ratio has changed. (If the app supports both portrait and landscape)

willRotateToInterfaceOrientation is called on all versions of iOS including iOS 6 when a rotation will occur, so it creates the perfect place to handle interface orientations in your app.

Using UIDeviceOrientationDidChangeNotification to get notification on your scene is not a reasonable solution because device orientations are different than interface orientations, for example, UIDeviceOrientationFaceUp is a device orientation, but not an interface orientation.
