### PR TITLE
Objective chipmunk integration

### DIFF
--- a/cocos2d/CCPhysicsDebugNode.h
+++ b/cocos2d/CCPhysicsDebugNode.h
@@ -22,17 +22,10 @@
 #import "ccConfig.h"
 
 #if CC_ENABLE_CHIPMUNK_INTEGRATION
-
-#ifdef CP_ALLOW_PRIVATE_ACCESS
-#undef CP_ALLOW_PRIVATE_ACCESS
-#endif
-
-#define CP_ALLOW_PRIVATE_ACCESS 1
-#import "chipmunk.h"
-
 #import "CCDrawNode.h"
 
 @class ChipmunkSpace;
+struct cpSpace *space;
 
 /**
  A Node that draws the components of a physics engine.
@@ -46,17 +39,17 @@
 @interface CCPhysicsDebugNode : CCDrawNode
 {
 	ChipmunkSpace *_spaceObj;
-	cpSpace *_spacePtr;
+	struct cpSpace *_spacePtr;
 }
 
 // property for the cpSpace
-@property (nonatomic, readwrite, assign) cpSpace *space;
+@property (nonatomic, readwrite, assign) struct cpSpace *space;
 
 /** Create a debug node for an Objective-Chipmunk space. */
 + (id) debugNodeForChipmunkSpace:(ChipmunkSpace *)space;
 
 /** Create a debug node for a regular Chipmunk space. */
-+ (id) debugNodeForCPSpace:(cpSpace *)space;
++ (id) debugNodeForCPSpace:(struct cpSpace *)space;
 
 @end
 

--- a/cocos2d/CCPhysicsDebugNode.m
+++ b/cocos2d/CCPhysicsDebugNode.m
@@ -25,6 +25,7 @@
 #if CC_ENABLE_CHIPMUNK_INTEGRATION
 
 #import "CCPhysicsDebugNode.h"
+#import "chipmunk_private.h"
 
 #import "ccTypes.h"
 

--- a/cocos2d/CCPhysicsSprite.h
+++ b/cocos2d/CCPhysicsSprite.h
@@ -24,7 +24,7 @@
 
 
 #if CC_ENABLE_CHIPMUNK_INTEGRATION
-#import "chipmunk.h"
+struct cpBody;
 @class ChipmunkBody;
 
 #elif CC_ENABLE_BOX2D_INTEGRATION
@@ -48,7 +48,7 @@ class b2Body;
 	BOOL	_ignoreBodyRotation;
 	
 #if CC_ENABLE_CHIPMUNK_INTEGRATION
-	cpBody	*_body;
+	struct cpBody	*_body;
 	
 #elif CC_ENABLE_BOX2D_INTEGRATION
 	b2Body	*_body;
@@ -64,7 +64,7 @@ class b2Body;
 #if CC_ENABLE_CHIPMUNK_INTEGRATION
 
 /** Body accessor when using regular Chipmunk */
-@property(nonatomic, assign) cpBody *body;
+@property(nonatomic, assign) struct cpBody *body;
 
 /** Body accessor when using Objective-Chipmunk */
 @property(nonatomic, assign) ChipmunkBody *chipmunkBody;


### PR DESCRIPTION
Including chipmunk.h in the headers when Chipmunk integration was turned on was causing problems for including Objective-Chipmunk in a project. It would try to include chipmunk.h a second time and cause issues because of the CP_ALLOW_PRIVATE_ACCESS stuff.

I changed it to use forward declarations of the Chipmunk structs instead.
