### PR TITLE
Alternate fix for the Objective-Chipmunk integration issues.

### DIFF
--- a/cocos2d/CCPhysicsDebugNode.h
+++ b/cocos2d/CCPhysicsDebugNode.h
@@ -23,11 +23,6 @@
 
 #if CC_ENABLE_CHIPMUNK_INTEGRATION
 
-#ifdef CP_ALLOW_PRIVATE_ACCESS
-#undef CP_ALLOW_PRIVATE_ACCESS
-#endif
-
-#define CP_ALLOW_PRIVATE_ACCESS 1
 #import "chipmunk.h"
 
 #import "CCDrawNode.h"

--- a/cocos2d/CCPhysicsDebugNode.m
+++ b/cocos2d/CCPhysicsDebugNode.m
@@ -46,9 +46,9 @@
 
 static ccColor4F ColorForBody(cpBody *body)
 {
-	if(cpBodyIsStatic(body) || cpBodyIsSleeping(body)){
+	if(cpBodyIsRogue(body) || cpBodyIsSleeping(body)){
 		return ccc4f(0.5, 0.5, 0.5 ,0.5);
-	} else if(body->node.idleTime > body->space->sleepTimeThreshold) {
+	} else if(body->CP_PRIVATE(node).idleTime > body->CP_PRIVATE(space)->sleepTimeThreshold) {
 		return ccc4f(0.33, 0.33, 0.33, 0.5);
 	} else {
 		return ccc4f(1, 0, 0, 0.5);
@@ -61,7 +61,7 @@ DrawShape(cpShape *shape, CCDrawNode *renderer)
 	cpBody *body = shape->body;
 	ccColor4F color = ColorForBody(body);
 
-	switch(shape->klass->type){
+	switch(shape->CP_PRIVATE(klass)->type){
 		case CP_CIRCLE_SHAPE: {
 				cpCircleShape *circle = (cpCircleShape *)shape;
 				cpVect center = circle->tc;
@@ -93,7 +93,7 @@ DrawConstraint(cpConstraint *constraint, CCDrawNode *renderer)
 	cpBody *body_a = constraint->a;
 	cpBody *body_b = constraint->b;
 
-	const cpConstraintClass *klass = constraint->klass;
+	const cpConstraintClass *klass = constraint->CP_PRIVATE(klass);
 	if(klass == cpPinJointGetClass()){
 		cpPinJoint *joint = (cpPinJoint *)constraint;
 		


### PR DESCRIPTION
Ok, so I found an alternate solution that should work for both of us then. I disabled private access in CCPhysicsDebugNode.h and instead used the CP_PRIVATE() macro in the .m file. I also had to make some small changes to Objective-Chipmunk.h to better deal with including chipmunk.h twice.

I also fixed a small bug where shapes attached to rogue bodies would cause the debug layer to crash.
