### PR TITLE
Fix EventsTest problems (OSX touch inconsistency, Dangling pointer)

### DIFF
--- a/tests/EventsTest.h
+++ b/tests/EventsTest.h
@@ -28,4 +28,7 @@
 	NSUInteger nuSprites_;
 	NSUInteger capacity;
 }
+
+- (void)resetToTouchesMatchingPhaseTouchingWithEvent:(NSEvent *)event;
+
 @end

--- a/tests/EventsTest.m
+++ b/tests/EventsTest.m
@@ -336,107 +336,64 @@ Class restartAction()
 	[super onExit];
 }
 
+- (void)resetToTouchesMatchingPhaseTouchingWithEvent:(NSEvent *)event
+{
+    for(int i = 0; i < nuSprites_; i++) {
+        CCSprite *sprite = sprites_[i];
+        sprite.visible = NO;
+        sprite.userObject = nil;
+    }
+    nuSprites_ = 0;
+    
+    NSSet *touches = [event touchesMatchingPhase:NSTouchPhaseTouching inView:[CCDirector sharedDirector].view];
+    for (NSTouch *touch in touches) {
+        
+		CCSprite *sprite = sprites_[nuSprites_++];
+        sprite.visible = YES;
+        sprite.position = ccpCompMult(CCNSPointToCGPoint(touch.normalizedPosition), ccpFromSize(contentSize_));
+        sprite.userObject = touch.identity;
+        
+        if (nuSprites_ > capacity) {
+            nuSprites_ = capacity;
+            break;
+        }
+    }
+}
+
 -(BOOL) ccTouchesBeganWithEvent:(NSEvent *)event
 {
-	NSLog(@"touchesBegan: %@", event);
-
-	NSView *view = [[CCDirector sharedDirector] view];
-	NSSet *touches = [event touchesMatchingPhase:NSTouchPhaseBegan inView:view];
-
-	for (NSTouch *touch in touches)
-	{
-		CGPoint pos = CCNSPointToCGPoint(touch.normalizedPosition);
-		// convert to absolute position
-		pos = ccpCompMult(pos, ccp(contentSize_.width, contentSize_.height));
-
-		CCSprite *newSprite = sprites_[nuSprites_];
-		[newSprite setVisible:YES];
-		[newSprite setUserData:[touch identity]];
-		[newSprite setPosition:pos];
-
-		nuSprites_++;
-		nuSprites_ = nuSprites_ >capacity ? capacity : nuSprites_;
-	}
-	return YES;
+    NSLog(@"touchesBegan: %@", event);
+    [self resetToTouchesMatchingPhaseTouchingWithEvent:event];
+    return YES;
 }
 
 -(BOOL) ccTouchesMovedWithEvent:(NSEvent *)event
 {
-	NSLog(@"touchesMoved: %@", event);
-
-	NSView *view = [[CCDirector sharedDirector] view];
-	NSSet *touches = [event touchesMatchingPhase:NSTouchPhaseMoved inView:view];
-
-	for (NSTouch *touch in touches)
-	{
-		id <NSObject> identity = [touch identity];
-		CGPoint pos = CCNSPointToCGPoint(touch.normalizedPosition);
-		pos = ccpCompMult(pos, ccp(contentSize_.width, contentSize_.height));
-
-		for(int i = 0; i<nuSprites_; i++)
-		{
-			CCSprite *sprite = sprites_[i];
-			if([identity isEqual:[sprite userData]])
-				[sprite setPosition:pos];
-		}
-	}
-	return YES;
+    NSLog(@"touchesMoved: %@", event);
+    NSSet *touches = [event touchesMatchingPhase:NSTouchPhaseMoved inView:[CCDirector sharedDirector].view];
+    for (NSTouch *touch in touches) {
+        for(int i = 0; i < nuSprites_; i++) {
+            CCSprite *sprite = sprites_[i];
+            if ([sprite.userObject isEqual:touch.identity])
+                sprite.position = ccpCompMult(CCNSPointToCGPoint(touch.normalizedPosition), ccpFromSize(contentSize_));
+        }
+    }
+    
+    return YES;
 }
 
 -(BOOL) ccTouchesEndedWithEvent:(NSEvent *)event
 {
-	NSLog(@"touchesEnded: %@", event);
-
-	NSView *view = [[CCDirector sharedDirector] view];
-	NSSet *touches = [event touchesMatchingPhase:NSTouchPhaseEnded inView:view];
-
-	for (NSTouch *touch in touches)
-	{
-		id <NSObject> identity = [touch identity];
-
-		for(int i = 0; i<nuSprites_; i++)
-		{
-			CCSprite *sprite = sprites_[i];
-			if([identity isEqual:[sprite userData]])
-			{
-				[sprite setVisible:NO];
-				[sprite setUserData:nil];
-
-				nuSprites_--;
-				sprites_[i] = sprites_[nuSprites_];
-				sprites_[nuSprites_] = sprite;
-			}
-		}
-	}
-	return YES;
+    NSLog(@"touchesEnded: %@", event);
+    [self resetToTouchesMatchingPhaseTouchingWithEvent:event];
+    return YES;
 }
 
 -(BOOL) ccTouchesCancelledWithEvent:(NSEvent *)event
 {
-	NSLog(@"touchesCancelled: %@", event);
-
-	NSView *view = [[CCDirector sharedDirector] view];
-	NSSet *touches = [event touchesMatchingPhase:NSTouchPhaseCancelled inView:view];
-
-	for (NSTouch *touch in touches)
-	{
-		id <NSObject> identity = [touch identity];
-
-		for(int i = 0; i<nuSprites_; i++)
-		{
-			CCSprite *sprite = sprites_[i];
-			if([identity isEqual:[sprite userData]])
-			{
-				[sprite setVisible:NO];
-				[sprite setUserData:nil];
-
-				nuSprites_--;
-				sprites_[i] = sprites_[nuSprites_];
-				sprites_[nuSprites_] = sprite;
-			}
-		}
-	}
-	return YES;
+    NSLog(@"touchesCancelled: %@", event);
+    [self resetToTouchesMatchingPhaseTouchingWithEvent:event];
+    return YES;
 }
 
 


### PR DESCRIPTION
A little refactor of the TouchTest test in the OSX EventsTest target.

This refactor fixes two problem:

1: OSX touch inconsistency.

It seems OSX (at least on 10.8.2 here) suffer from a strange problem with the way it handle touches. There is two problems here:

1.1: When we leave the app using an OSX gesture (MissionControl, Exposé), OSX will never call the `NSResponder.touchesEndedWithEvent` nor `NSResponder.touchesCancelledWithEvent`, but when we get back to the app, the previously touching `NSTouch` will be released before the app had the time to notice it.

1.2: I found that in some circumstances (quickly touching/releasing the trackpad, easy reproducible with the MagicTrackpad as there is more lag due to Bluetooth), OSX will not consistently call its callbacks.
For example, one quickly tap (touch/release) 4 fingers on the trackpad, here is an expected sequence of callback (it may vary, since its a matter of millisecond):
- `touchesBeganWithEvent` with a count of 3 in `touchesMatchingPhase:NSTouchPhaseBegan`
- `touchesBeganWithEvent` with a count of 1 in `touchesMatchingPhase:NSTouchPhaseBegan`
- `touchesEndedWithEvent` with a count of 2 in `touchesMatchingPhase:NSTouchPhaseEnded`
- `touchesEndedWithEvent` with a count of 2 in `touchesMatchingPhase:NSTouchPhaseEnded`

But, sometime, one can see this sequence:
- `touchesBeganWithEvent` with a count of 3 in `touchesMatchingPhase:NSTouchPhaseBegan`
- `touchesBeganWithEvent` with a count of 1 in `touchesMatchingPhase:NSTouchPhaseBegan`
- `touchesEndedWithEvent` with a count of 2 in `touchesMatchingPhase:NSTouchPhaseEnded`
- `touchesEndedWithEvent` with a count of 1 in `touchesMatchingPhase:NSTouchPhaseEnded`

So the application thinks that there is still a finger touching the trackpad, since 4 touches matches the `NSTouchPhaseBegan` but only 3 matches `NSTouchPhaseEnded`.

2: Dangling pointer.

Given that the code uses `CCSprite.userData` to store the `NSTouch.identity`,
and given that the `NSTouch` are released (along with their `identity`) when we get back from an OSX gesture,
The app crash when trying to test if an old `NSTouch.identity` stored in `CCSprite.userData` is equals to a new `NSTouch.identity`,
at this line:
`if([identity isEqual:[sprite userData]])`

So the refactor was to:
- not rely only on `touchesEndedWithEvent` nor `touchesCancelledWithEvent` to detect that fingers are released from the trackpad. But instead, the state of the `CCSprite` is reset on `touchesBeganWithEvent` using all `touchesMatchingPhase:NSTouchPhaseTouching`.
- use `CCSprite.userObject` to store the `NSTouch.identity`, thus preventing it from begin released along with its `NSTouch` when resuming the app after an OSX gesture.

Suggestions, comments and critics are welcome :)
