### PR TITLE
EventsTest: fix memory leak with sprites_ array

### DIFF
--- a/tests/EventsTest.m
+++ b/tests/EventsTest.m
@@ -306,6 +306,7 @@ Class restartAction()
 
 -(void) dealloc
 {
+    free(sprites_);
 	[super dealloc];
 }
 


### PR DESCRIPTION
This is independent from my previous pull request regarding EventsTest (https://github.com/cocos2d/cocos2d-iphone/pull/260).

This commit simply fix a memory leak with the `sprites_` array in the `TouchTest` class of OSX EventsTest.

It was malloc'd but never free'd.

I added `free(sprites_)` in `-(void) dealloc`.
