### PR TITLE
Add support for handling OSX gesture event

### DIFF
--- a/cocos2d/CCLayer.h
+++ b/cocos2d/CCLayer.h
@@ -93,7 +93,7 @@ typedef enum {
 #elif defined(__CC_PLATFORM_MAC)
 
 
-@interface CCLayer : CCNode <CCKeyboardEventDelegate, CCMouseEventDelegate, CCTouchEventDelegate>
+@interface CCLayer : CCNode <CCKeyboardEventDelegate, CCMouseEventDelegate, CCTouchEventDelegate, CCGestureEventDelegate>
 {
 	BOOL		mouseEnabled_;
 	NSInteger	mousePriority_;
@@ -104,12 +104,21 @@ typedef enum {
 	BOOL		touchEnabled_;
 	NSInteger	touchPriority_;
 	NSInteger	touchMode_;
+    
+	BOOL		gestureEnabled_;
+	NSInteger	gesturePriority_;
 }
 
 /** whether or not it will receive touche events. */
 @property (nonatomic, readwrite, getter=isTouchEnabled) BOOL touchEnabled;
 /** priority of the touch events. Default is 0 */
 @property(nonatomic, assign) NSInteger touchPriority;
+
+/** whether or not it will receive gesture events. */
+@property (nonatomic, readwrite, getter=isGestureEnabled) BOOL gestureEnabled;
+/** priority of the gesture events. Default is 0 */
+@property(nonatomic, assign) NSInteger gesturePriority;
+
 
 /** whether or not it will receive mouse events.
 

--- a/cocos2d/CCLayer.m
+++ b/cocos2d/CCLayer.m
@@ -77,6 +77,8 @@
 #ifdef __CC_PLATFORM_IOS
 		accelerometerEnabled_ = NO;
 #elif defined(__CC_PLATFORM_MAC)
+        gestureEnabled_ = NO;
+        gesturePriority_ = 0;
 		mouseEnabled_ = NO;
 		keyboardEnabled_ = NO;
 #endif
@@ -284,6 +286,42 @@
 	}
 }
 
+-(BOOL) isGestureEnabled
+{
+	return gestureEnabled_;
+}
+
+-(void) setGestureEnabled:(BOOL)enabled
+{
+	if( gestureEnabled_ != enabled ) {
+		gestureEnabled_ = enabled;
+		if( isRunning_ ) {
+			CCDirector *director = [CCDirector sharedDirector];
+			if( enabled )
+				[[director eventDispatcher] addGestureDelegate:self priority:gesturePriority_];
+			else
+				[[director eventDispatcher] removeGestureDelegate:self];
+		}
+	}
+}
+
+-(NSInteger) gesturePriority
+{
+	return gesturePriority_;
+}
+
+-(void) setGesturePriority:(NSInteger)gesturePriority
+{
+	if( gesturePriority_ != gesturePriority ) {
+		gesturePriority_ = gesturePriority;
+		
+		if( gestureEnabled_) {
+			[self setGestureEnabled:NO];
+			[self setGestureEnabled:YES];
+		}
+	}
+}
+
 #endif // Mac
 
 
@@ -308,7 +346,10 @@
 
 	if( touchEnabled_)
 		[eventDispatcher addTouchDelegate:self priority:touchPriority_];
-
+    
+	if( gestureEnabled_)
+		[eventDispatcher addGestureDelegate:self priority:gesturePriority_];
+    
 #endif
 
 	// then iterate over all the children
@@ -349,7 +390,10 @@
 
 	if( touchEnabled_ )
 		[eventDispatcher removeTouchDelegate:self];
-
+    
+	if( gestureEnabled_ )
+		[eventDispatcher removeGestureDelegate:self];
+    
 #endif
 
 	[super onExit];

--- a/cocos2d/Platforms/Mac/CCEventDispatcher.h
+++ b/cocos2d/Platforms/Mac/CCEventDispatcher.h
@@ -186,6 +186,47 @@
 
 @end
 
+#pragma mark -
+#pragma mark CCGestureEventDelegate
+
+/** CCGestureEventDelegate protocol.
+ Implement it in your node to receive any of gesture events
+ */
+@protocol CCGestureEventDelegate <NSObject>
+@optional
+
+/** called when the "beginGesture" event is received.
+ Return YES to avoid propagating the event to other delegates.
+ */
+- (BOOL)ccBeginGestureWithEvent:(NSEvent *)event;
+
+/** called when the "magnify" gesture event is received.
+ Return YES to avoid propagating the event to other delegates.
+ */
+- (BOOL)ccMagnifyWithEvent:(NSEvent *)event;
+
+/** called when the "smartMagnify" gesture event is received.
+ Return YES to avoid propagating the event to other delegates.
+ */
+- (BOOL)ccSmartMagnifyWithEvent:(NSEvent *)event;
+
+/** called when the "rotate" gesture event is received.
+ Return YES to avoid propagating the event to other delegates.
+ */
+- (BOOL)ccRotateWithEvent:(NSEvent *)event;
+
+/** called when the "swipe" gesture event is received.
+ Return YES to avoid propagating the event to other delegates.
+ */
+- (BOOL)ccSwipeWithEvent:(NSEvent *)event;
+
+/** called when the "endGesture" event is received.
+ Return YES to avoid propagating the event to other delegates.
+ */
+- (BOOL)ccEndGestureWithEvent:(NSEvent *)event;
+
+@end
+
 #pragma mark - CCEventObject
 
 @interface CCEventObject : NSObject
@@ -219,6 +260,7 @@ struct _listAddedEntry;
 	struct	_listEntry		*keyboardDelegates_;
 	struct	_listEntry		*mouseDelegates_;
 	struct	_listEntry		*touchDelegates_;
+	struct	_listEntry		*gestureDelegates_;
 	
 	struct	_listDeletedEntry	*delegatesToBeRemoved_;
 	struct	_listAddedEntry		*delegatesToBeAdded_;
@@ -274,6 +316,24 @@ struct _listAddedEntry;
 
 /** Removes all touch delegates, releasing all the delegates */
 - (void)removeAllTouchDelegates;
+
+#pragma mark CCEventDispatcher - Gesture
+
+/** Adds a gesture delegate to the dispatcher's list.
+ Delegates with a lower priority value will be called before higher priority values.
+ All the events will be propagated to all the delegates, unless the one delegate returns YES.
+ 
+ IMPORTANT: The delegate will be retained.
+ */
+- (void)addGestureDelegate:(id<CCGestureEventDelegate>)delegate priority:(NSInteger)priority;
+
+/** Removes a gesture delegate */
+- (void)removeGestureDelegate:(id) delegate;
+
+/** Removes all gesture delegates, releasing all the delegates */
+- (void)removeAllGestureDelegates;
+
+#pragma mark CCEventDispatcher - Dispatch
 
 -(void) dispatchEvent:(CCEventObject*)event;
 

--- a/cocos2d/Platforms/Mac/CCEventDispatcher.m
+++ b/cocos2d/Platforms/Mac/CCEventDispatcher.m
@@ -53,6 +53,14 @@ enum  {
 	kCCImplementsTouchesEnded		= 1 << 15,
 	kCCImplementsTouchesCancelled	= 1 << 16,
 
+    // gesture
+    kCCImplementsBeginGestureWithEvent = 1 << 0,
+    kCCImplementsMagnifyWithEvent      = 1 << 1,
+    kCCImplementsSmartMagnifyWithEvent = 1 << 2,
+    kCCImplementsRotateWithEvent       = 1 << 3,
+    kCCImplementsSwipeWithEvent        = 1 << 4,
+    kCCImplementsEndGestureWithEvent   = 1 << 5,
+    
 	// keyboard
 	kCCImplementsKeyUp				= 1 << 0,
 	kCCImplementsKeyDown			= 1 << 1,
@@ -122,6 +130,7 @@ typedef struct _listAddedEntry
 		keyboardDelegates_ = NULL;
 		mouseDelegates_ = NULL;
 		touchDelegates_ = NULL;
+        gestureDelegates_ = NULL;
 		
 		delegatesToBeAdded_ = NULL;
 		delegatesToBeRemoved_ = NULL;
@@ -340,6 +349,35 @@ typedef struct _listAddedEntry
 	[self removeAllDelegatesFromList:&touchDelegates_];
 }
 
+- (void)addGestureDelegate:(id<CCGestureEventDelegate>)delegate priority:(NSInteger)priority
+{
+	NSUInteger flags = 0;
+    
+	flags |= ( [delegate respondsToSelector:@selector(ccBeginGestureWithEvent:)] ? kCCImplementsBeginGestureWithEvent : 0 );
+	flags |= ( [delegate respondsToSelector:@selector(ccMagnifyWithEvent:)] ? kCCImplementsMagnifyWithEvent : 0 );
+	flags |= ( [delegate respondsToSelector:@selector(ccSmartMagnifyWithEvent:)] ? kCCImplementsSmartMagnifyWithEvent : 0 );
+	flags |= ( [delegate respondsToSelector:@selector(ccRotateWithEvent:)] ? kCCImplementsRotateWithEvent : 0 );
+	flags |= ( [delegate respondsToSelector:@selector(ccSwipeWithEvent:)] ? kCCImplementsSwipeWithEvent : 0 );
+	flags |= ( [delegate respondsToSelector:@selector(ccEndGestureWithEvent:)] ? kCCImplementsEndGestureWithEvent : 0 );
+    
+	if( locked_ )
+		[self addLaterDelegate:delegate priority:priority flags:flags list:&gestureDelegates_];
+	else
+		[self addDelegate:delegate priority:priority flags:flags list:&gestureDelegates_];
+}
+
+- (void)removeGestureDelegate:(id) delegate
+{
+	if( locked_ )
+		[self removeLaterDelegate:delegate fromList:&gestureDelegates_];
+	else
+		[self removeDelegate:delegate fromList:&gestureDelegates_];
+}
+
+- (void)removeAllGestureDelegates
+{
+	[self removeAllDelegatesFromList:&gestureDelegates_];
+}
 
 #pragma mark CCEventDispatcher - Mouse events
 //
@@ -668,6 +706,100 @@ typedef struct _listAddedEntry
 		}
 	}
 }
+
+#pragma mark CCEventDispatcher - Gesture events
+
+- (void)beginGestureWithEvent:(NSEvent *)event
+{
+	if( dispatchEvents_ ) {
+		tListEntry *entry, *tmp;
+        
+		DL_FOREACH_SAFE( gestureDelegates_, entry, tmp ) {
+			if ( entry->flags & kCCImplementsBeginGestureWithEvent) {
+				void *swallows = [entry->delegate performSelector:@selector(ccBeginGestureWithEvent:) withObject:event];
+				if( swallows )
+					break;
+			}
+		}
+	}
+}
+
+- (void)magnifyWithEvent:(NSEvent *)event
+{
+	if( dispatchEvents_ ) {
+		tListEntry *entry, *tmp;
+        
+		DL_FOREACH_SAFE( gestureDelegates_, entry, tmp ) {
+			if ( entry->flags & kCCImplementsMagnifyWithEvent) {
+				void *swallows = [entry->delegate performSelector:@selector(ccMagnifyWithEvent:) withObject:event];
+				if( swallows )
+					break;
+			}
+		}
+	}
+}
+
+- (void)smartMagnifyWithEvent:(NSEvent *)event
+{
+	if( dispatchEvents_ ) {
+		tListEntry *entry, *tmp;
+        
+		DL_FOREACH_SAFE( gestureDelegates_, entry, tmp ) {
+			if ( entry->flags & kCCImplementsSmartMagnifyWithEvent) {
+				void *swallows = [entry->delegate performSelector:@selector(ccSmartMagnifyWithEvent:) withObject:event];
+				if( swallows )
+					break;
+			}
+		}
+	}
+}
+
+- (void)rotateWithEvent:(NSEvent *)event
+{
+	if( dispatchEvents_ ) {
+		tListEntry *entry, *tmp;
+        
+		DL_FOREACH_SAFE( gestureDelegates_, entry, tmp ) {
+			if ( entry->flags & kCCImplementsRotateWithEvent) {
+				void *swallows = [entry->delegate performSelector:@selector(ccRotateWithEvent:) withObject:event];
+				if( swallows )
+					break;
+			}
+		}
+	}
+}
+
+- (void)swipeWithEvent:(NSEvent *)event
+{
+	if( dispatchEvents_ ) {
+		tListEntry *entry, *tmp;
+        
+		DL_FOREACH_SAFE( gestureDelegates_, entry, tmp ) {
+			if ( entry->flags & kCCImplementsSwipeWithEvent) {
+				void *swallows = [entry->delegate performSelector:@selector(ccSwipeWithEvent:) withObject:event];
+				if( swallows )
+					break;
+			}
+		}
+	}
+}
+
+- (void)endGestureWithEvent:(NSEvent *)event
+{
+	if( dispatchEvents_ ) {
+		tListEntry *entry, *tmp;
+        
+		DL_FOREACH_SAFE( gestureDelegates_, entry, tmp ) {
+			if ( entry->flags & kCCImplementsEndGestureWithEvent) {
+				void *swallows = [entry->delegate performSelector:@selector(ccEndGestureWithEvent:) withObject:event];
+				if( swallows )
+					break;
+			}
+		}
+	}
+}
+
+#pragma mark CCEventDispatcher - Dispatch
 
 - (void)dispatchEvent:(CCEventObject*)e
 {

--- a/cocos2d/Platforms/Mac/CCGLView.h
+++ b/cocos2d/Platforms/Mac/CCGLView.h
@@ -62,6 +62,14 @@
 - (void)touchesEndedWithEvent:(NSEvent *)event;
 - (void)touchesCancelledWithEvent:(NSEvent *)event;
 
+// Gestures
+- (void)beginGestureWithEvent:(NSEvent *)event;
+- (void)magnifyWithEvent:(NSEvent *)event;
+- (void)smartMagnifyWithEvent:(NSEvent *)event;
+- (void)rotateWithEvent:(NSEvent *)event;
+- (void)swipeWithEvent:(NSEvent *)event;
+- (void)endGestureWithEvent:(NSEvent *)event;
+
 @end
 
 /** CCGLView

--- a/cocos2d/Platforms/Mac/CCGLView.m
+++ b/cocos2d/Platforms/Mac/CCGLView.m
@@ -289,6 +289,37 @@
 	DISPATCH_EVENT(theEvent, _cmd);
 }
 
+#pragma mark CCGLView - Gesture events
+- (void)beginGestureWithEvent:(NSEvent *)theEvent
+{
+	DISPATCH_EVENT(theEvent, _cmd);
+}
+
+- (void)magnifyWithEvent:(NSEvent *)theEvent
+{
+	DISPATCH_EVENT(theEvent, _cmd);
+}
+
+- (void)smartMagnifyWithEvent:(NSEvent *)theEvent
+{
+	DISPATCH_EVENT(theEvent, _cmd);
+}
+
+- (void)rotateWithEvent:(NSEvent *)theEvent
+{
+	DISPATCH_EVENT(theEvent, _cmd);
+}
+
+- (void)swipeWithEvent:(NSEvent *)theEvent
+{
+	DISPATCH_EVENT(theEvent, _cmd);
+}
+
+- (void)endGestureWithEvent:(NSEvent *)theEvent
+{
+	DISPATCH_EVENT(theEvent, _cmd);
+}
+
 @end
 
 #endif // __CC_PLATFORM_MAC

--- a/tests/EventsTest.m
+++ b/tests/EventsTest.m
@@ -299,6 +299,7 @@ Class restartAction()
 		}
 
 		self.touchEnabled = YES;
+        self.gestureEnabled = YES;
 	}
 
 	return self;
@@ -317,7 +318,7 @@ Class restartAction()
 
 -(NSString *) subtitle
 {
-	return @"Touch the trackpad. See the console";
+	return @"Touch, pinch, rotate, swipe the trackpad. See the console";
 }
 
 
@@ -397,6 +398,53 @@ Class restartAction()
     return YES;
 }
 
+- (BOOL)ccBeginGestureWithEvent:(NSEvent *)event
+{
+	NSLog(@"beginGesture: %@", event);
+    [self stopAllActions];
+    return YES;
+}
+
+- (BOOL)ccMagnifyWithEvent:(NSEvent *)event
+{
+	NSLog(@"magnify: %@", event);
+    self.scale += event.magnification;
+    return YES;
+}
+
+- (BOOL)ccSmartMagnifyWithEvent:(NSEvent *)event
+{
+	NSLog(@"smartMagnify: %@", event);
+    self.scale = self.scale == 1 ? 1.2 : 1;
+    return YES;
+}
+
+- (BOOL)ccRotateWithEvent:(NSEvent *)event
+{
+	NSLog(@"rotate: %@", event);
+    self.rotation -= event.rotation;
+    return YES;
+}
+
+- (BOOL)ccSwipeWithEvent:(NSEvent *)event
+{
+	NSLog(@"swipe: %@", event);
+    CGSize winSize = [CCDirector sharedDirector].winSize;
+    CGPoint swipeTo = ccp(winSize.width * -event.deltaX, winSize.height * event.deltaY);
+    [self runAction:[CCSequence actionOne:[CCMoveTo actionWithDuration:0.2 position:swipeTo]
+                                      two:[CCEaseBackOut actionWithAction:[CCMoveTo actionWithDuration:0.5 position:CGPointZero]]]];
+    return YES;
+}
+
+- (BOOL)ccEndGestureWithEvent:(NSEvent *)event
+{
+	NSLog(@"endGesture: %@", event);
+    if (self.rotation != 0)
+        [self runAction:[CCEaseBackOut actionWithAction:[CCRotateTo actionWithDuration:0.5 angle:0]]];
+    if (self.scale != 1)
+        [self runAction:[CCEaseBackOut actionWithAction:[CCScaleTo actionWithDuration:0.5 scale:1]]];
+    return YES;
+}
 
 @end
 


### PR DESCRIPTION
A little addition to be able to use OSX gesture.

It will compile and run on OSX 10.5.2 and later.

At runtime It should not create any problem with installation that do not supports gesture since the `NSResponder`'s gesture selectors will simply not be called.

In this commit:
- `CCGLView` delegates gesture events to `CCEventDispatcher`
- new `CCGestureEventDelegate` protocol to support: beginGesture, magnify, smartMagnify, rotate, swipe and endGesture, it supports swallowing event too
- add/remove/removeAllGestureDelegate selectors in `CCEventDispatcher` with priority
- gestureEnabled and gesturePriority properties in `CCLayer`
- edited `TouchTest` of the EventsTest target to demonstrate gestures usage

I tried to respect the cocos2d naming convention, but let me know if your are not ok with the way I named the new public protocol and selectors, I will refactor to suit your taste.
