### PR TITLE
Fix some small problems for CCScheduler

### DIFF
--- a/cocos2d/CCScheduler.m
+++ b/cocos2d/CCScheduler.m
@@ -155,7 +155,7 @@ typedef struct _hashSelectorEntry
 				}
 			}
 
-			if (_nTimesExecuted > _repeat)
+			if (!_runForever && _nTimesExecuted > _repeat)
 			{	//unschedule timer
 				[self cancel];
 			}
@@ -770,6 +770,15 @@ typedef struct _hashSelectorEntry
     {
 		return element->paused;
     }
+	
+	// We should check update selectors if target does not have custom selectors
+	tHashUpdateEntry * elementUpdate = NULL;
+	HASH_FIND_INT(hashForUpdates, &target, elementUpdate);
+	if ( elementUpdate )
+	{
+		return elementUpdate->entry->paused;
+	}
+	
     return NO;  // should never get here
 
 }
@@ -795,20 +804,20 @@ typedef struct _hashSelectorEntry
         DL_FOREACH_SAFE( updatesNeg, entry, tmp ) {
             if(entry->priority >= minPriority) {
                 entry->paused = YES;
-                [idsWithSelectors addObject:entry->target];
+				[idsWithSelectors addObject:entry->target];
             }
         }
     }
     if(minPriority <= 0) {
         DL_FOREACH_SAFE( updates0, entry, tmp ) {
             entry->paused = YES;
-            [idsWithSelectors addObject:entry->target];
+			[idsWithSelectors addObject:entry->target];
         }
     }
     DL_FOREACH_SAFE( updatesPos, entry, tmp ) {
         if(entry->priority >= minPriority) {
             entry->paused = YES;
-            [idsWithSelectors addObject:entry->target];
+			[idsWithSelectors addObject:entry->target];
         }
     }
     

--- a/tests/SchedulerTest.m
+++ b/tests/SchedulerTest.m
@@ -235,6 +235,7 @@ Class restartTest()
         [self addChild:sprite];
         [sprite runAction:[CCRepeatForever actionWithAction:[CCRotateBy actionWithDuration:3.0 angle:360]]];
         
+		[self scheduleUpdate];
 		[self schedule:@selector(tick1:) interval:0.5f];
 		[self schedule:@selector(tick2:) interval:1];
 		[self schedule:@selector(pause:) interval:3 repeat:NO delay:0];
@@ -266,6 +267,11 @@ Class restartTest()
 	return @"Everything will pause after 3s, then resume at 5s. See console";
 }
 
+-(void) update:(ccTime)delta
+{
+	// do nothing
+}
+
 -(void) tick1:(ccTime)dt
 {
 	NSLog(@"tick1");
@@ -281,6 +287,11 @@ Class restartTest()
     NSLog(@"Pausing");
 	CCDirector *director = [CCDirector sharedDirector];
     self.pausedTargets = [director.scheduler pauseAllTargets];
+	if([self.pausedTargets count] > 2)
+	{
+		// should have only 2 items: CCActionManager, self
+		NSLog(@"Error: pausedTargets should have only 2 items");
+	}
 }
 
 - (void) resume


### PR DESCRIPTION
1. Add runForever check before cancel timer automatically.
2. Check paused state for target without custom selectors correctly.
3. NSSet has avoided adding dup item already. Added a simple test for
   this.
