### PR TITLE
Cleanup scheduled actions of a CCTransitionRadialCCW that is popped

### DIFF
--- a/cocos2d/CCTransitionRadial.m
+++ b/cocos2d/CCTransitionRadial.m
@@ -98,7 +98,7 @@ enum {
 -(void) onExit
 {
 	// remove our layer and release all containing objects
-	[self removeChildByTag:kSceneRadial cleanup:NO];
+	[self removeChildByTag:kSceneRadial cleanup:YES];
 	[super onExit];
 }
 @end


### PR DESCRIPTION
Cleanup scheduled actions of a CCTransitionRadialCCW that is popped before finishing its animation.

When a CCTransitionRadial\* transition scene is popped from the director before the animation completes, the layerAction's CCCallFunc action will never be called, but it retains a reference to its target object, so neither the transition scene, nor its outgoing and incoming scenes will ever be deallocated.

By cleaning up the scheduled actions and animations of the CCProgressTimer instance (identified by the kSceneRadial tag), we can get rid of this reference.
