### PR TITLE
Add hexadecimal color support

### DIFF
--- a/cocos2d/CCRenderTexture.m
+++ b/cocos2d/CCRenderTexture.m
@@ -387,7 +387,7 @@
 #if __CC_PLATFORM_IOS
 	
 	UIImage* image	= [[UIImage alloc] initWithCGImage:imageRef scale:CC_CONTENT_SCALE_FACTOR() orientation:UIImageOrientationUp];
-	NSData *imageData;
+	NSData *imageData = nil;
 
 	if( format == kCCImageFormatPNG )
 		imageData = UIImagePNGRepresentation( image );

--- a/cocos2d/ccTypes.h
+++ b/cocos2d/ccTypes.h
@@ -127,6 +127,35 @@ static inline ccColor4F ccc4FFromccc4B(ccColor4B c)
 	return (ccColor4F){c.r/255.f, c.g/255.f, c.b/255.f, c.a/255.f};
 }
 
+/** Returns a ccColor4F from a hexadecimal color (ex: 0xFF0000) and alpha value.
+ */
+static inline ccColor4F ccc4FFromHexAnda(const int h, const float a)
+{    
+    const float r = (h & 0xFF0000) >> 16;
+    const float g = (h & 0xFF00) >> 8;
+    const float b = (h & 0xFF);
+    
+	return (ccColor4F) {r/255, g/255, b/255, a};
+}
+
+/** Returns a ccColor4F from a hexadecimal color (ex: 0xFF0000).
+ */
+static inline ccColor4F ccc4FFromHex(const int h)
+{    
+    return ccc4FFromHexAnda(h, 1.0f);
+}
+
+/** Returns a ccColor3B from a hexadecimal color (ex: 0xFF0000).
+ */
+static inline ccColor3B ccc3BFromHex(const int h)
+{    
+    const float r = (h & 0xFF0000) >> 16;
+    const float g = (h & 0xFF00) >> 8;
+    const float b = (h & 0xFF);
+    
+	return (ccColor3B) {r/255, g/255, b/255};
+}
+
 /** returns YES if both ccColor4F are equal. Otherwise it returns NO.
  @since v0.99.1
  */


### PR DESCRIPTION
Hello Cocos2D team !

I just add some basic methods to easily use hexadecimal colors in Cocos2D. This is more easy and fast to copy and paste a hexadecimal color value from your favorite image editor than to copy and paste three values for RGB.

As I said, just a really tiny contribution. :-)

Thank you very much for this awesome IPhone framework and have a good day.

Tony
