### PR TITLE
Stackable CCMoveBy and CCMoveTo actions

### DIFF
--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -5284,7 +5284,7 @@
 		508CA7E711932A1F003AC397 /* SchedulerTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SchedulerTest.h; path = tests/SchedulerTest.h; sourceTree = "<group>"; };
 		508EAC2F1193F8B0007F058D /* utlist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utlist.h; sourceTree = "<group>"; };
 		509807081175041800EA7266 /* libbuild all tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libbuild all tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		509A79950F6188420032F449 /* CCSprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CCSprite.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		509A79950F6188420032F449 /* CCSprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CCSprite.h; sourceTree = "<group>"; };
 		509A79960F6188420032F449 /* CCSprite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CCSprite.m; sourceTree = "<group>"; };
 		509A7A970F61A2400032F449 /* grossini_dance_atlas.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = grossini_dance_atlas.png; sourceTree = "<group>"; };
 		509D0816101E4FCE007E1749 /* CCTMXTiledMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCTMXTiledMap.h; sourceTree = "<group>"; };

--- a/cocos2d/CCActionInterval.h
+++ b/cocos2d/CCActionInterval.h
@@ -198,6 +198,36 @@ Example:
 -(id) initWithDuration: (ccTime)duration position:(CGPoint)deltaPosition;
 @end
 
+/**  Moves a CCNode object x,y pixels by modifying it's position attribute.
+ x and y are relative to the position of the object.
+ Can be concurrently called.
+ @since v2.1beta2-custom
+ */
+@interface CCMoveByEx : CCActionInterval <NSCopying>
+{
+    CGPoint positionDelta_;
+    ccTime previousTick_;
+}
+/** creates the action */
++(id) actionWithDuration: (ccTime)duration position:(CGPoint)deltaPosition;
+/** initializes the action */
+-(id) initWithDuration: (ccTime)duration position:(CGPoint)deltaPosition;
+@end
+
+/** Moves a CCNode object to the position x,y. x and y are absolute coordinates by modifying it's position attribute.
+ Can be concurrently called.
+ @since v2.1beta2-custom
+ */
+@interface CCMoveToEx : CCMoveByEx
+{
+	CGPoint endPosition;
+}
+/** creates the action */
++(id) actionWithDuration:(ccTime)duration position:(CGPoint)position;
+/** initializes the action */
+-(id) initWithDuration:(ccTime)duration position:(CGPoint)position;
+@end
+
 /** Skews a CCNode object to given angles by modifying its skewX and skewY attributes
  @since v1.0
  */

--- a/cocos2d/CCActionInterval.h
+++ b/cocos2d/CCActionInterval.h
@@ -171,39 +171,13 @@ Example:
 -(id) initWithDuration: (ccTime) t angleX:(float) aX angleY:(float) aY;
 @end
 
-/** Moves a CCNode object to the position x,y. x and y are absolute coordinates by modifying its position attribute.
-*/
-@interface CCMoveTo : CCActionInterval <NSCopying>
-{
-	CGPoint endPosition_;
-	CGPoint startPosition_;
-	CGPoint delta_;
-}
-/** creates the action */
-+(id) actionWithDuration:(ccTime)duration position:(CGPoint)position;
-/** initializes the action */
--(id) initWithDuration:(ccTime)duration position:(CGPoint)position;
-@end
-
-/**  Moves a CCNode object x,y pixels by modifying its position attribute.
- x and y are relative to the position of the object.
- Duration is is seconds.
-*/
-@interface CCMoveBy : CCMoveTo <NSCopying>
-{
-}
-/** creates the action */
-+(id) actionWithDuration: (ccTime)duration position:(CGPoint)deltaPosition;
-/** initializes the action */
--(id) initWithDuration: (ccTime)duration position:(CGPoint)deltaPosition;
-@end
-
 /**  Moves a CCNode object x,y pixels by modifying it's position attribute.
  x and y are relative to the position of the object.
- Can be concurrently called.
+ Several CCMoveBy actions can be concurrently called, and the resulting
+ movement will be the sum of individual movements.
  @since v2.1beta2-custom
  */
-@interface CCMoveByEx : CCActionInterval <NSCopying>
+@interface CCMoveBy : CCActionInterval <NSCopying>
 {
     CGPoint positionDelta_;
     ccTime previousTick_;
@@ -215,10 +189,11 @@ Example:
 @end
 
 /** Moves a CCNode object to the position x,y. x and y are absolute coordinates by modifying it's position attribute.
- Can be concurrently called.
+ Several CCMoveTo actions can be concurrently called, and the resulting
+ movement will be the sum of individual movements.
  @since v2.1beta2-custom
  */
-@interface CCMoveToEx : CCMoveByEx
+@interface CCMoveTo : CCMoveBy
 {
 	CGPoint endPosition;
 }

--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -739,7 +739,7 @@
 -(void) startWithTarget:(CCNode *)aTarget
 {
 	[super startWithTarget:aTarget];
-	positionDelta_ = ccpSub( endPosition, [(CCNode*)target_ position] );
+	positionDelta_ = ccpSub( endPosition, [(CCNode*)_target position] );
 }
 
 @end
@@ -777,12 +777,12 @@
 
 -(CCActionInterval*) reverse
 {
-	return [[self class] actionWithDuration:duration_ position:ccp( -positionDelta_.x, -positionDelta_.y)];
+	return [[self class] actionWithDuration:_duration position:ccp( -positionDelta_.x, -positionDelta_.y)];
 }
 
 -(void) update: (ccTime) t
 {
-    [target_ moveBy:ccpMult(positionDelta_, t-previousTick_)];
+    [_target moveBy:ccpMult(positionDelta_, t-previousTick_)];
     //[target_ setPosition: ccpAdd(((CCNode*)target_).position, ccpMult(positionDelta_, t-previousTick_) )];
     previousTick_=t;
 }

--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -634,123 +634,12 @@
 @end
 
 //
-// MoveTo
-//
-#pragma mark - CCMoveTo
-
-@implementation CCMoveTo
-+(id) actionWithDuration: (ccTime) t position: (CGPoint) p
-{
-	return [[[self alloc] initWithDuration:t position:p ] autorelease];
-}
-
--(id) initWithDuration: (ccTime) t position: (CGPoint) p
-{
-	if( (self=[super initWithDuration: t]) )
-		endPosition_ = p;
-
-	return self;
-}
-
--(id) copyWithZone: (NSZone*) zone
-{
-	CCAction *copy = [[[self class] allocWithZone: zone] initWithDuration: [self duration] position: endPosition_];
-	return copy;
-}
-
--(void) startWithTarget:(CCNode *)aTarget
-{
-	[super startWithTarget:aTarget];
-	startPosition_ = [(CCNode*)_target position];
-	delta_ = ccpSub( endPosition_, startPosition_ );
-}
-
--(void) update: (ccTime) t
-{
-	[_target setPosition: ccp( (startPosition_.x + delta_.x * t ), (startPosition_.y + delta_.y * t ) )];
-}
-@end
-
-//
 // MoveBy
 //
-#pragma mark - CCMoveBy
+#pragma mark -
+#pragma mark MoveBy
 
 @implementation CCMoveBy
-+(id) actionWithDuration: (ccTime) t position: (CGPoint) p
-{
-	return [[[self alloc] initWithDuration:t position:p ] autorelease];
-}
-
--(id) initWithDuration: (ccTime) t position: (CGPoint) p
-{
-	if( (self=[super initWithDuration: t]) )
-		delta_ = p;
-
-	return self;
-}
-
--(id) copyWithZone: (NSZone*) zone
-{
-	CCAction *copy = [[[self class] allocWithZone: zone] initWithDuration: [self duration] position: delta_];
-	return copy;
-}
-
--(void) startWithTarget:(CCNode *)aTarget
-{
-	CGPoint dTmp = delta_;
-	[super startWithTarget:aTarget];
-	delta_ = dTmp;
-}
-
--(CCActionInterval*) reverse
-{
-	return [[self class] actionWithDuration:_duration position:ccp( -delta_.x, -delta_.y)];
-}
-@end
-
-//
-// MoveToEx
-//
-#pragma mark -
-#pragma mark MoveToEx
-
-@implementation CCMoveToEx
-+(id) actionWithDuration: (ccTime) t position: (CGPoint) p
-{
-	return [[[self alloc] initWithDuration:t position:p ] autorelease];
-}
-
--(id) initWithDuration: (ccTime) t position: (CGPoint) p
-{
-	if( (self=[super initWithDuration: t]) ) {
-		endPosition = p;
-    }
-
-	return self;
-}
-
--(id) copyWithZone: (NSZone*) zone
-{
-	CCAction *copy = [[[self class] allocWithZone: zone] initWithDuration: [self duration] position: endPosition];
-	return copy;
-}
-
--(void) startWithTarget:(CCNode *)aTarget
-{
-	[super startWithTarget:aTarget];
-	positionDelta_ = ccpSub( endPosition, [(CCNode*)_target position] );
-}
-
-@end
-
-//
-// MoveByEx
-//
-#pragma mark -
-#pragma mark MoveByEx
-
-@implementation CCMoveByEx
 +(id) actionWithDuration: (ccTime) t position: (CGPoint) p
 {
 	return [[[self alloc] initWithDuration:t position:p ] autorelease];
@@ -786,6 +675,41 @@
     //[target_ setPosition: ccpAdd(((CCNode*)target_).position, ccpMult(positionDelta_, t-previousTick_) )];
     previousTick_=t;
 }
+@end
+
+//
+// MoveTo
+//
+#pragma mark -
+#pragma mark MoveTo
+
+@implementation CCMoveTo
++(id) actionWithDuration: (ccTime) t position: (CGPoint) p
+{
+	return [[[self alloc] initWithDuration:t position:p ] autorelease];
+}
+
+-(id) initWithDuration: (ccTime) t position: (CGPoint) p
+{
+	if( (self=[super initWithDuration: t]) ) {
+		endPosition = p;
+    }
+
+	return self;
+}
+
+-(id) copyWithZone: (NSZone*) zone
+{
+	CCAction *copy = [[[self class] allocWithZone: zone] initWithDuration: [self duration] position: endPosition];
+	return copy;
+}
+
+-(void) startWithTarget:(CCNode *)aTarget
+{
+	[super startWithTarget:aTarget];
+	positionDelta_ = ccpSub( endPosition, [(CCNode*)_target position] );
+}
+
 @end
 
 //

--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -709,6 +709,84 @@
 }
 @end
 
+//
+// MoveToEx
+//
+#pragma mark -
+#pragma mark MoveToEx
+
+@implementation CCMoveToEx
++(id) actionWithDuration: (ccTime) t position: (CGPoint) p
+{
+	return [[[self alloc] initWithDuration:t position:p ] autorelease];
+}
+
+-(id) initWithDuration: (ccTime) t position: (CGPoint) p
+{
+	if( (self=[super initWithDuration: t]) ) {
+		endPosition = p;
+    }
+
+	return self;
+}
+
+-(id) copyWithZone: (NSZone*) zone
+{
+	CCAction *copy = [[[self class] allocWithZone: zone] initWithDuration: [self duration] position: endPosition];
+	return copy;
+}
+
+-(void) startWithTarget:(CCNode *)aTarget
+{
+	[super startWithTarget:aTarget];
+	positionDelta_ = ccpSub( endPosition, [(CCNode*)target_ position] );
+}
+
+@end
+
+//
+// MoveByEx
+//
+#pragma mark -
+#pragma mark MoveByEx
+
+@implementation CCMoveByEx
++(id) actionWithDuration: (ccTime) t position: (CGPoint) p
+{
+	return [[[self alloc] initWithDuration:t position:p ] autorelease];
+}
+
+-(id) initWithDuration: (ccTime) t position: (CGPoint) p
+{
+	if( (self=[super initWithDuration: t]) )
+		positionDelta_ = p;
+	return self;
+}
+
+-(id) copyWithZone: (NSZone*) zone
+{
+	CCAction *copy = [[[self class] allocWithZone: zone] initWithDuration: [self duration] position: positionDelta_];
+	return copy;
+}
+
+-(void) startWithTarget:(CCNode *)aTarget
+{
+    previousTick_ = 0;
+	[super startWithTarget:aTarget];
+}
+
+-(CCActionInterval*) reverse
+{
+	return [[self class] actionWithDuration:duration_ position:ccp( -positionDelta_.x, -positionDelta_.y)];
+}
+
+-(void) update: (ccTime) t
+{
+    [target_ moveBy:ccpMult(positionDelta_, t-previousTick_)];
+    //[target_ setPosition: ccpAdd(((CCNode*)target_).position, ccpMult(positionDelta_, t-previousTick_) )];
+    previousTick_=t;
+}
+@end
 
 //
 // SkewTo

--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -296,6 +296,12 @@ enum {
 /** initializes the node */
 -(id) init;
 
+// extra methods
+
+/**  Update position by the given position delta.
+ @since v2.1beta2-custom
+ */
+-(void) moveBy: (CGPoint)positionDelta;
 
 // scene management
 

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -248,6 +248,12 @@ static NSUInteger globalOrderOfArrival = 1;
 	isTransformDirty_ = isInverseDirty_ = YES;
 }
 
+-(void) moveBy: (CGPoint)positionDelta
+{
+    position_ = ccpAdd(position_, positionDelta);
+	isTransformDirty_ = isInverseDirty_ = YES;
+}
+
 -(void) setIgnoreAnchorPointForPosition: (BOOL)newValue
 {
 	if( newValue != ignoreAnchorPointForPosition_ ) {

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -698,6 +698,12 @@
 	SET_DIRTY_RECURSIVELY();
 }
 
+-(void)moveBy:(CGPoint)delta
+{
+	[super moveBy:delta];
+	SET_DIRTY_RECURSIVELY();
+}
+
 -(void)setRotation:(float)rot
 {
 	[super setRotation:rot];

--- a/tests/PerformanceTests/PerformanceSpriteTest/AppController.m
+++ b/tests/PerformanceTests/PerformanceSpriteTest/AppController.m
@@ -51,9 +51,9 @@
 	navController_.navigationBarHidden = YES;
 	
 	// set the Navigation Controller as the root view controller
-	//	[window_ setRootViewController:rootViewController_];
-	[window_ addSubview:navController_.view];
-	
+		[window_ setRootViewController:navController_];
+//	[window_ addSubview:navController_.view];
+
 	// make main window visible
 	[window_ makeKeyAndVisible];
 	

--- a/tests/PerformanceTests/PerformanceSpriteTest/CocosNodePerformance.h
+++ b/tests/PerformanceTests/PerformanceSpriteTest/CocosNodePerformance.h
@@ -14,4 +14,10 @@
 
 - (void)performanceActions;
 - (void)performanceActions20;
+
+- (void)performanceMoveByActions;
+- (void)performanceMoveToActions;
+
+- (void)performanceMoveByExActions;
+- (void)performanceMoveToExActions;
 @end

--- a/tests/PerformanceTests/PerformanceSpriteTest/CocosNodePerformance.h
+++ b/tests/PerformanceTests/PerformanceSpriteTest/CocosNodePerformance.h
@@ -18,6 +18,4 @@
 - (void)performanceMoveByActions;
 - (void)performanceMoveToActions;
 
-- (void)performanceMoveByExActions;
-- (void)performanceMoveToExActions;
 @end

--- a/tests/PerformanceTests/PerformanceSpriteTest/CocosNodePerformance.m
+++ b/tests/PerformanceTests/PerformanceSpriteTest/CocosNodePerformance.m
@@ -37,37 +37,6 @@
 	[self runAction:permanentMove];
 }
 
-- (void)performanceMoveByExActions
-{
-	CGSize size = [[CCDirector sharedDirector] winSize];
-	self.position = ccp(random() % (int)size.width, random() % (int)size.height);
-
-	float moveDuration = 0.5f + (random() % 1000) / 500.0f;
-    CGPoint moveDestination = ccp(-100 + random()%200, -100 + random()%200);
-
-	CCActionInterval *move = [CCMoveByEx actionWithDuration:moveDuration position:moveDestination];
-	CCAction *permanentMove = [CCRepeatForever actionWithAction:[CCSequence actionOne:move two:[move reverse]]];
-	[self runAction:permanentMove];
-}
-
-- (void)performanceMoveToExActions
-{
-	CGSize size = [[CCDirector sharedDirector] winSize];
-	self.position = ccp(random() % (int)size.width, random() % (int)size.height);
-    CGPoint moveDestination = ccp(random() % (int)size.width, random() % (int)size.height);
-
-	float moveDuration = 0.5f + (random() % 1000) / 500.0f;
-	CCActionInterval *move = [CCMoveToEx actionWithDuration:moveDuration
-                                                   position:moveDestination];
-	CCActionInterval *moveBack = [CCMoveToEx actionWithDuration:moveDuration
-                                                       position:self.position];
-	CCAction *permanentMove = [CCRepeatForever actionWithAction:
-                               [CCSequence actionOne:move
-                                                 two:moveBack]];
-	[self runAction:permanentMove];
-}
-
-
 - (void)performanceActions
 {
 	CGSize size = [[CCDirector sharedDirector] winSize];

--- a/tests/PerformanceTests/PerformanceSpriteTest/CocosNodePerformance.m
+++ b/tests/PerformanceTests/PerformanceSpriteTest/CocosNodePerformance.m
@@ -7,6 +7,67 @@
 
 @implementation CCNode (PerformanceTest)
 
+- (void)performanceMoveByActions
+{
+	CGSize size = [[CCDirector sharedDirector] winSize];
+	self.position = ccp(random() % (int)size.width, random() % (int)size.height);
+
+	float moveDuration = 0.5f + (random() % 1000) / 500.0f;
+    CGPoint moveDestination = ccp(-100 + random()%200, -100 + random()%200);
+
+	CCActionInterval *move = [CCMoveBy actionWithDuration:moveDuration position:moveDestination];
+	CCAction *permanentMove = [CCRepeatForever actionWithAction:[CCSequence actionOne:move two:[move reverse]]];
+	[self runAction:permanentMove];
+}
+
+- (void)performanceMoveToActions
+{
+	CGSize size = [[CCDirector sharedDirector] winSize];
+	self.position = ccp(random() % (int)size.width, random() % (int)size.height);
+    CGPoint moveDestination = ccp(random() % (int)size.width, random() % (int)size.height);
+
+	float moveDuration = 0.5f + (random() % 1000) / 500.0f;
+	CCActionInterval *move = [CCMoveTo actionWithDuration:moveDuration
+                                                 position:moveDestination];
+	CCActionInterval *moveBack = [CCMoveTo actionWithDuration:moveDuration
+                                                     position:self.position];
+	CCAction *permanentMove = [CCRepeatForever actionWithAction:
+                               [CCSequence actionOne:move
+                                                 two:moveBack]];
+	[self runAction:permanentMove];
+}
+
+- (void)performanceMoveByExActions
+{
+	CGSize size = [[CCDirector sharedDirector] winSize];
+	self.position = ccp(random() % (int)size.width, random() % (int)size.height);
+
+	float moveDuration = 0.5f + (random() % 1000) / 500.0f;
+    CGPoint moveDestination = ccp(-100 + random()%200, -100 + random()%200);
+
+	CCActionInterval *move = [CCMoveByEx actionWithDuration:moveDuration position:moveDestination];
+	CCAction *permanentMove = [CCRepeatForever actionWithAction:[CCSequence actionOne:move two:[move reverse]]];
+	[self runAction:permanentMove];
+}
+
+- (void)performanceMoveToExActions
+{
+	CGSize size = [[CCDirector sharedDirector] winSize];
+	self.position = ccp(random() % (int)size.width, random() % (int)size.height);
+    CGPoint moveDestination = ccp(random() % (int)size.width, random() % (int)size.height);
+
+	float moveDuration = 0.5f + (random() % 1000) / 500.0f;
+	CCActionInterval *move = [CCMoveToEx actionWithDuration:moveDuration
+                                                   position:moveDestination];
+	CCActionInterval *moveBack = [CCMoveToEx actionWithDuration:moveDuration
+                                                       position:self.position];
+	CCAction *permanentMove = [CCRepeatForever actionWithAction:
+                               [CCSequence actionOne:move
+                                                 two:moveBack]];
+	[self runAction:permanentMove];
+}
+
+
 - (void)performanceActions
 {
 	CGSize size = [[CCDirector sharedDirector] winSize];

--- a/tests/PerformanceTests/PerformanceSpriteTest/MainScene.h
+++ b/tests/PerformanceTests/PerformanceSpriteTest/MainScene.h
@@ -65,11 +65,5 @@ Class nextAction();
 @interface PerformanceTest9 : MainScene
 {}
 @end
-@interface PerformanceTest10 : MainScene
-{}
-@end
-@interface PerformanceTest11 : MainScene
-{}
-@end
 
 

--- a/tests/PerformanceTests/PerformanceSpriteTest/MainScene.h
+++ b/tests/PerformanceTests/PerformanceSpriteTest/MainScene.h
@@ -59,4 +59,17 @@ Class nextAction();
 @interface PerformanceTest7 : MainScene
 {}
 @end
+@interface PerformanceTest8 : MainScene
+{}
+@end
+@interface PerformanceTest9 : MainScene
+{}
+@end
+@interface PerformanceTest10 : MainScene
+{}
+@end
+@interface PerformanceTest11 : MainScene
+{}
+@end
+
 

--- a/tests/PerformanceTests/PerformanceSpriteTest/MainScene.m
+++ b/tests/PerformanceTests/PerformanceSpriteTest/MainScene.m
@@ -25,6 +25,10 @@ static NSString *transitions[] = {
 		@"PerformanceTest5",
 		@"PerformanceTest6",
 		@"PerformanceTest7",
+        @"PerformanceTest8",
+        @"PerformanceTest9",
+        @"PerformanceTest10",
+        @"PerformanceTest11",
 };
 
 Class nextAction()
@@ -565,4 +569,54 @@ Class restartAction()
 }
 @end
 
+#pragma mark Test 8
+@implementation PerformanceTest8
+-(NSString*) title
+{
+	return [NSString stringWithFormat:@"H (%d) moveBy action", subtestNumber];
+}
 
+-(void) doTest:(id) sprite
+{
+	[sprite performanceMoveByActions];
+}
+@end
+
+#pragma mark Test 9
+@implementation PerformanceTest9
+-(NSString*) title
+{
+	return [NSString stringWithFormat:@"I (%d) moveTo action", subtestNumber];
+}
+
+-(void) doTest:(id) sprite
+{
+	[sprite performanceMoveToActions];
+}
+@end
+
+#pragma mark Test 10
+@implementation PerformanceTest10
+-(NSString*) title
+{
+	return [NSString stringWithFormat:@"J (%d) moveByEx action", subtestNumber];
+}
+
+-(void) doTest:(id) sprite
+{
+	[sprite performanceMoveByExActions];
+}
+@end
+
+#pragma mark Test 11
+@implementation PerformanceTest11
+-(NSString*) title
+{
+	return [NSString stringWithFormat:@"K (%d) moveToEx action", subtestNumber];
+}
+
+-(void) doTest:(id) sprite
+{
+	[sprite performanceMoveToExActions];
+}
+@end

--- a/tests/PerformanceTests/PerformanceSpriteTest/MainScene.m
+++ b/tests/PerformanceTests/PerformanceSpriteTest/MainScene.m
@@ -27,8 +27,6 @@ static NSString *transitions[] = {
 		@"PerformanceTest7",
         @"PerformanceTest8",
         @"PerformanceTest9",
-        @"PerformanceTest10",
-        @"PerformanceTest11",
 };
 
 Class nextAction()
@@ -592,31 +590,5 @@ Class restartAction()
 -(void) doTest:(id) sprite
 {
 	[sprite performanceMoveToActions];
-}
-@end
-
-#pragma mark Test 10
-@implementation PerformanceTest10
--(NSString*) title
-{
-	return [NSString stringWithFormat:@"J (%d) moveByEx action", subtestNumber];
-}
-
--(void) doTest:(id) sprite
-{
-	[sprite performanceMoveByExActions];
-}
-@end
-
-#pragma mark Test 11
-@implementation PerformanceTest11
--(NSString*) title
-{
-	return [NSString stringWithFormat:@"K (%d) moveToEx action", subtestNumber];
-}
-
--(void) doTest:(id) sprite
-{
-	[sprite performanceMoveToExActions];
 }
 @end

--- a/tests/PerformanceTests/cocos2d-ios-PerformanceTests.xcodeproj/project.pbxproj
+++ b/tests/PerformanceTests/cocos2d-ios-PerformanceTests.xcodeproj/project.pbxproj
@@ -517,6 +517,7 @@
 		A0F6EAA114152322008F01A1 /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F48B0C1045AD2F00755CFB /* Icon.png */; };
 		A0F6EAA214152323008F01A1 /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F48B0C1045AD2F00755CFB /* Icon.png */; };
 		A0F6EAA314152323008F01A1 /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F48B0C1045AD2F00755CFB /* Icon.png */; };
+		BC4B9E8516663355004692EE /* libcocos2d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BC4B9E8416663355004692EE /* libcocos2d.a */; };
 		E037D9AA1280E402003D39D7 /* texture1024x1024_rgba4444.pvr.gz in Resources */ = {isa = PBXBuildFile; fileRef = E037D9A81280E402003D39D7 /* texture1024x1024_rgba4444.pvr.gz */; };
 		E0B0E63211F8C3BB00414246 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 50F48B0B1045AD2F00755CFB /* Default.png */; };
 		E0B0E63311F8C3BB00414246 /* fire-grayscale.png in Resources */ = {isa = PBXBuildFile; fileRef = 501F0DE311527BC6002BB7F1 /* fire-grayscale.png */; };
@@ -781,8 +782,8 @@
 		A0DA98E61644D16000D882F7 /* CCActionGrid3D.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCActionGrid3D.m; sourceTree = "<group>"; };
 		A0DA98E71644D16000D882F7 /* CCActionInstant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionInstant.h; sourceTree = "<group>"; };
 		A0DA98E81644D16000D882F7 /* CCActionInstant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCActionInstant.m; sourceTree = "<group>"; };
-		A0DA98E91644D16000D882F7 /* CCActionInterval.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionInterval.h; sourceTree = "<group>"; };
-		A0DA98EA1644D16000D882F7 /* CCActionInterval.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCActionInterval.m; sourceTree = "<group>"; };
+		A0DA98E91644D16000D882F7 /* CCActionInterval.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionInterval.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		A0DA98EA1644D16000D882F7 /* CCActionInterval.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCActionInterval.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		A0DA98EB1644D16000D882F7 /* CCActionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionManager.h; sourceTree = "<group>"; };
 		A0DA98EC1644D16000D882F7 /* CCActionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCActionManager.m; sourceTree = "<group>"; };
 		A0DA98ED1644D16000D882F7 /* CCActionPageTurn3D.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionPageTurn3D.h; sourceTree = "<group>"; };
@@ -972,6 +973,7 @@
 		A0F6EA8A14152314008F01A1 /* Icon-Small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Icon-Small.png"; path = "../../Resources/Icon-Small.png"; sourceTree = "<group>"; };
 		A0F6EA8B14152314008F01A1 /* Icon-Small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Icon-Small@2x.png"; path = "../../Resources/Icon-Small@2x.png"; sourceTree = "<group>"; };
 		A0F6EA8C14152314008F01A1 /* Icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Icon@2x.png"; path = "../../Resources/Icon@2x.png"; sourceTree = "<group>"; };
+		BC4B9E8416663355004692EE /* libcocos2d.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcocos2d.a; path = "../../build/Release-iphoneos/libcocos2d.a"; sourceTree = "<group>"; };
 		E037D9A81280E402003D39D7 /* texture1024x1024_rgba4444.pvr.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; name = texture1024x1024_rgba4444.pvr.gz; path = ../../Resources/Images/texture1024x1024_rgba4444.pvr.gz; sourceTree = SOURCE_ROOT; };
 		E054558C135475A0003F7F4C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../../Resources/Info.plist; sourceTree = "<group>"; };
 		E0B0E64E11F8C3BB00414246 /* PerformanceTest-Texture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PerformanceTest-Texture.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1029,6 +1031,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC4B9E8516663355004692EE /* libcocos2d.a in Frameworks */,
 				5030943510447C15005F7AFC /* libcocos2d libraries.a in Frameworks */,
 				50671B5311B95977006C0061 /* CoreGraphics.framework in Frameworks */,
 				50671B5411B95977006C0061 /* OpenGLES.framework in Frameworks */,
@@ -1103,6 +1106,7 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
+				BC4B9E8416663355004692EE /* libcocos2d.a */,
 				A0DA98DA1644D16000D882F7 /* cocos2d */,
 				A037D1C5141510EB0091B5C7 /* kazmath */,
 				A08D161614DD186E0036D9CC /* MemoryAllocationTest */,
@@ -1865,9 +1869,9 @@
 			productReference = 506719FF11B956ED006C0061 /* PerformanceTest-Particle.app */;
 			productType = "com.apple.product-type.application";
 		};
-		506EE05D10304ED200A389B3 /* cocos2d libraries */ = {
+		506EE05D10304ED200A389B3 /* cocos2d */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 506EE06410304F0100A389B3 /* Build configuration list for PBXNativeTarget "cocos2d libraries" */;
+			buildConfigurationList = 506EE06410304F0100A389B3 /* Build configuration list for PBXNativeTarget "cocos2d" */;
 			buildPhases = (
 				506EE05A10304ED200A389B3 /* Headers */,
 				506EE05B10304ED200A389B3 /* Sources */,
@@ -1877,7 +1881,7 @@
 			);
 			dependencies = (
 			);
-			name = "cocos2d libraries";
+			name = cocos2d;
 			productName = "cocos2d libraries";
 			productReference = 506EE05E10304ED200A389B3 /* libcocos2d libraries.a */;
 			productType = "com.apple.product-type.library.static";
@@ -1940,7 +1944,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				506EE05D10304ED200A389B3 /* cocos2d libraries */,
+				506EE05D10304ED200A389B3 /* cocos2d */,
 				5030942C10447C09005F7AFC /* PerformanceTest-Sprite */,
 				506719FE11B956ED006C0061 /* PerformanceTest-Particle */,
 				5006BA3511BBF4DB00E488BD /* PerformanceTest-ChildrenNode */,
@@ -2442,27 +2446,27 @@
 /* Begin PBXTargetDependency section */
 		5006BA3611BBF4DB00E488BD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 506EE05D10304ED200A389B3 /* cocos2d libraries */;
+			target = 506EE05D10304ED200A389B3 /* cocos2d */;
 			targetProxy = 5006BA3711BBF4DB00E488BD /* PBXContainerItemProxy */;
 		};
 		5030943410447C11005F7AFC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 506EE05D10304ED200A389B3 /* cocos2d libraries */;
+			target = 506EE05D10304ED200A389B3 /* cocos2d */;
 			targetProxy = 5030943310447C11005F7AFC /* PBXContainerItemProxy */;
 		};
 		50671A0611B95702006C0061 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 506EE05D10304ED200A389B3 /* cocos2d libraries */;
+			target = 506EE05D10304ED200A389B3 /* cocos2d */;
 			targetProxy = 50671A0511B95702006C0061 /* PBXContainerItemProxy */;
 		};
 		A08D158D14DD17B60036D9CC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 506EE05D10304ED200A389B3 /* cocos2d libraries */;
+			target = 506EE05D10304ED200A389B3 /* cocos2d */;
 			targetProxy = A08D158E14DD17B60036D9CC /* PBXContainerItemProxy */;
 		};
 		E0B0E62D11F8C3BB00414246 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 506EE05D10304ED200A389B3 /* cocos2d libraries */;
+			target = 506EE05D10304ED200A389B3 /* cocos2d */;
 			targetProxy = E0B0E62E11F8C3BB00414246 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -2817,7 +2821,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		506EE06410304F0100A389B3 /* Build configuration list for PBXNativeTarget "cocos2d libraries" */ = {
+		506EE06410304F0100A389B3 /* Build configuration list for PBXNativeTarget "cocos2d" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				506EE05F10304ED500A389B3 /* Debug */,

--- a/tests/PerformanceTests/cocos2d-ios-PerformanceTests.xcodeproj/xcshareddata/xcschemes/cocos2d libraries.xcscheme
+++ b/tests/PerformanceTests/cocos2d-ios-PerformanceTests.xcodeproj/xcshareddata/xcschemes/cocos2d libraries.xcscheme
@@ -15,7 +15,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "506EE05D10304ED200A389B3"
                BuildableName = "libcocos2d libraries.a"
-               BlueprintName = "cocos2d libraries"
+               BlueprintName = "cocos2d"
                ReferencedContainer = "container:cocos2d-ios-PerformanceTests.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/tests/SpriteTest.h
+++ b/tests/SpriteTest.h
@@ -19,6 +19,11 @@
 -(void) addNewSpriteWithCoords:(CGPoint)p;
 @end
 
+@interface SpriteMove : SpriteDemo
+{}
+-(void) addNewSpriteWithCoords:(CGPoint)p;
+@end
+
 @interface SpriteBatchNode1 : SpriteDemo
 {}
 -(void) addNewSpriteWithCoords:(CGPoint)p;

--- a/tests/SpriteTest.m
+++ b/tests/SpriteTest.m
@@ -12,8 +12,8 @@
 
 static int sceneIdx=-1;
 static NSString *transitions[] = {
-    @"SpriteRenderTextureBug",
 	@"Sprite1",
+	@"SpriteMove",
 	@"SpriteBatchNode1",
 	@"SpriteFrameTest",
 	@"SpriteFrameAliasNameTest",
@@ -284,6 +284,108 @@ Class restartAction()
 	return @"Sprite (tap screen)";
 }
 @end
+
+#pragma mark -
+#pragma mark Example Sprite Move
+
+
+@implementation SpriteMove
+
+-(id) init
+{
+	if( (self=[super init]) ) {
+
+#ifdef __CC_PLATFORM_IOS
+		self.touchEnabled = YES;
+#elif defined(__CC_PLATFORM_MAC)
+		self.mouseEnabled = YES;
+#endif
+
+		CGSize s = [[CCDirector sharedDirector] winSize];
+		[self addNewSpriteWithCoords:ccp(s.width/2, s.height/2)];
+	}
+	return self;
+}
+
+-(void) addNewSpriteWithCoords:(CGPoint)p
+{
+	int idx = CCRANDOM_0_1() * 1400 / 100;
+	int x = (idx%5) * 85;
+	int y = (idx/5) * 121;
+
+
+	CCSprite *sprite = [CCSprite spriteWithFile:@"grossini_dance_atlas.png" rect:CGRectMake(x,y,85,121)];
+
+	sprite.position = p;
+	[self addChild:sprite];
+
+	[sprite runAction:
+     [CCRepeatForever actionWithAction:
+      [CCSequence actions:
+       [CCMoveBy actionWithDuration:6 position:ccp(200, 0)],
+       [CCMoveBy actionWithDuration:6 position:ccp(-200, 0)],
+       nil]]];
+
+	[sprite runAction:
+     [CCRepeatForever actionWithAction:
+      [CCSequence actions:
+       [CCDelayTime actionWithDuration:1],
+       [CCMoveBy actionWithDuration:2 position:ccp(0, 100)],
+       [CCDelayTime actionWithDuration:1],
+       [CCMoveBy actionWithDuration:2 position:ccp(0, -100)],
+       nil]]];
+
+    sprite = [CCSprite spriteWithFile:@"grossinis_sister1.png"];
+
+    sprite.position = p;
+	[self addChild:sprite];
+
+	[sprite runAction:
+     [CCRepeatForever actionWithAction:
+      [CCSequence actions:
+       [CCMoveTo actionWithDuration:6 position:ccpSub(p, ccp(200, 0))],
+       [CCMoveTo actionWithDuration:6 position:p],
+       nil]]];
+
+	[sprite runAction:
+     [CCRepeatForever actionWithAction:
+      [CCSequence actions:
+       [CCDelayTime actionWithDuration:1],
+       [CCMoveBy actionWithDuration:2 position:ccp(0, -100)],
+       [CCDelayTime actionWithDuration:1],
+       [CCMoveBy actionWithDuration:2 position:ccp(0, 100)],
+       nil]]];
+
+}
+
+#ifdef __CC_PLATFORM_IOS
+- (void)ccTouchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
+{
+	for( UITouch *touch in touches ) {
+		CGPoint location = [touch locationInView: [touch view]];
+
+		location = [[CCDirector sharedDirector] convertToGL: location];
+
+		[self addNewSpriteWithCoords: location];
+	}
+}
+#elif defined(__CC_PLATFORM_MAC)
+-(BOOL) ccMouseUp:(NSEvent *)event
+{
+	CGPoint location = [[CCDirector sharedDirector] convertEventToGL:event];
+	[self addNewSpriteWithCoords: location];
+
+	return YES;
+
+}
+#endif
+
+-(NSString *) title
+{
+	return @"Stacked CCMoveBy/To actions (tap scr.)";
+}
+@end
+
 
 @implementation SpriteBatchNode1
 


### PR DESCRIPTION
I have rewritten the CCMoveBy and CCMoveTo actions so they are stackable.
### Description

This means that you can now run two simultaneous CCMoveBy/CCMoveTo actions on the same CCNode, and the node will perform a movement equal to the result of applying both movements at the same time.
### Uses

This allows for several cool effects. Some examples:
- Have a looping CCMoveBy action constantly running inside a CCRepeatForever action, and still be able to move the node around the screen with additional CCMoveBy actions (think, for example, of a balloon that has a looping floating animation and also moves around the screen).
- Having a character being affected by different move forces (think of a character affected by the wind and by the player controlled movement at the same time).
### Performance

I added CCMoveBy/CCMoveTo tests to the PerformanceTest-Sprite target. I ran tests comparing the new implementation to the previous one. The new implementation doesn't affect performance whatsoever.

You can compare performance of both sets of actions by checking out commit 3eceb6831f6151cfda1e2beb618e47fa3284145e (in this commit, my implementations are called CCMoveByEx and CCMoveToEx).
### Additional comments
#### Details

In order to make movement actions stackable, CCMoveBy must be the base action. The new implementation makes CCMoveBy the base action, and CCMoveTo a child of CCMoveBy. CCMoveTo just calculates a CCMoveBy based on the current node position. The old implementation was the other way around. 

The new CCMoveBy implementation uses a new CCNode helper method called

```
- (void)moveBy:(CGPoint)positionDelta {
    position_ = ccpAdd(position_, positionDelta);
    isTransformDirty_ = isInverseDirty_ = YES;
}
```

which also allows for writing cleaner code regarding positioning of CCNodes that usually do relative (as opposed to absolute) movements.
#### Previous behaviour

The previous behaviour when executing two CCMoveBy actions at the same time was that only the latest executed action affected the sprite. This resulted in a somewhat awkward behaviour when, for example, there was a very long CCMoveBy action being run and you executed a new shorter CCMoveBy action without stopping the previous one first. In this case, the longer action would stop being applied while the new shorter one was running, but then it would weirdly resume after the new one finished.
