### PR TITLE
Protect CCConfiguration accessor with sync lock

### DIFF
--- a/cocos2d/CCConfiguration.m
+++ b/cocos2d/CCConfiguration.m
@@ -55,9 +55,10 @@ static char * glExtensions;
 
 + (CCConfiguration *)sharedConfiguration
 {
-	if (!_sharedConfiguration)
-		_sharedConfiguration = [[self alloc] init];
-
+	@synchronized(self)     {
+		if (!_sharedConfiguration)
+			_sharedConfiguration = [[self alloc] init];
+	}
 	return _sharedConfiguration;
 }
 


### PR DESCRIPTION
i ran into a race condition where two invocations of [CCConfiguration init] were running in two threads. because i was calling [CCGLView viewWithFrame: ...] and using CCFileUtils in a background thread. the later tries to use [CCConfiguration sharedConfiguration]. but CCConfiguration's singleton initializer is not protected by a lock, so there is chance that both thread try to create an instance of it.
