### PR TITLE
Enable [CCFileUtils removeSuffixFromFile:] on Mac.

### DIFF
--- a/cocos2d/CCTextureCache.m
+++ b/cocos2d/CCTextureCache.m
@@ -151,11 +151,9 @@ static CCTextureCache *sharedTextureCache;
 
 	// optimization
 	__block CCTexture2D * tex;
-
-#ifdef __CC_PLATFORM_IOS
+	
 	path = [[CCFileUtils sharedFileUtils] removeSuffixFromFile:path];
-#endif
-
+	
 	dispatch_sync(_dictQueue, ^{
 		tex = [textures_ objectForKey:path];
 	});
@@ -214,9 +212,7 @@ static CCTextureCache *sharedTextureCache;
 	// optimization
 	__block CCTexture2D * tex;
 
-#ifdef __CC_PLATFORM_IOS
 	path = [[CCFileUtils sharedFileUtils] removeSuffixFromFile:path];
-#endif
 
 	dispatch_sync(_dictQueue, ^{
 		tex = [textures_ objectForKey:path];
@@ -278,9 +274,7 @@ static CCTextureCache *sharedTextureCache;
 	__block CCTexture2D * tex = nil;
 
 	// remove possible -HD suffix to prevent caching the same image twice (issue #1040)
-#ifdef __CC_PLATFORM_IOS
 	path = [[CCFileUtils sharedFileUtils] removeSuffixFromFile: path];
-#endif
 
 	dispatch_sync(_dictQueue, ^{
 		tex = [textures_ objectForKey: path];
@@ -448,9 +442,7 @@ static CCTextureCache *sharedTextureCache;
 	__block CCTexture2D * tex;
 
 	// remove possible -HD suffix to prevent caching the same image twice (issue #1040)
-#ifdef __CC_PLATFORM_IOS
 	path = [[CCFileUtils sharedFileUtils] removeSuffixFromFile: path];
-#endif
 
 	dispatch_sync(_dictQueue, ^{
 		tex = [textures_ objectForKey:path];

--- a/cocos2d/Support/CCFileUtils.h
+++ b/cocos2d/Support/CCFileUtils.h
@@ -240,20 +240,16 @@ enum {
  */
 -(NSString*) fullPathFromRelativePathIgnoringResolutions:(NSString*)relPath;
 
-
-
-#ifdef __CC_PLATFORM_IOS
-
 /** removes the suffix from a path
  * On iPhone RetinaDisplay it will remove the -hd suffix
  * On iPad it will remove the -ipad suffix
  * On iPad RetinaDisplay it will remove the -ipadhd suffix
-
- Only valid on iOS. Not valid for OS X.
-
+ 
  @since v0.99.5
  */
 -(NSString *)removeSuffixFromFile:(NSString*) path;
+
+#ifdef __CC_PLATFORM_IOS
 
 /** Returns whether or not a given path exists with the iPhone RetinaDisplay suffix.
  Only available on iOS. Not supported on OS X.


### PR DESCRIPTION
I tried out the new CCFileUtils features on Mac by putting this line in my app delegate:

``` objective-c
[[CCFileUtils sharedFileUtils].suffixesDict setObject:@"-hd" forKey:kCCFileUtilsMac];
```

It crashed; long story short, the CCSpriteFrame was referencing the full texture path with suffix, whereas normally it is cached without the suffix. So the texture was being loaded twice. On iPhone the removeSuffixFromFile: function resolves this issue. Unless there's some side-effect I haven't thought of, it should be the same on Mac.
