### PR TITLE
add loop sound effect support for simple audio engine

### DIFF
--- a/CocosDenshion/SimpleAudioEngine.h
+++ b/CocosDenshion/SimpleAudioEngine.h
@@ -77,6 +77,8 @@
 -(void) stopEffect:(ALuint) soundId;
 /** plays an audio effect with a file path, pitch, pan and gain */
 -(ALuint) playEffect:(NSString*) filePath pitch:(Float32) pitch pan:(Float32) pan gain:(Float32) gain;
+/** plays an audio effect with a file path and loops it until you call stopEffect with the returned soundid*/
+- (ALuint)playEffectWithLoop:(NSString*)filePath;
 /** preloads an audio effect */
 -(void) preloadEffect:(NSString*) filePath;
 /** unloads an audio effect from memory */

--- a/CocosDenshion/SimpleAudioEngine.m
+++ b/CocosDenshion/SimpleAudioEngine.m
@@ -138,6 +138,16 @@ static CDBufferManager *bufferManager = nil;
 	}
 }
 
+- (ALuint)playEffectWithLoop:(NSString*)filePath
+{
+	int soundId = [bufferManager bufferForFile:filePath create:YES];
+	if (soundId != kCDNoBuffer) {
+		return [soundEngine playSound:soundId sourceGroupId:0 pitch:1.0f pan:0.0f gain:1.0f loop:true];
+	} else {
+		return CD_MUTE;
+	}
+}
+
 -(void) stopEffect:(ALuint) soundId {
 	[soundEngine stopSound:soundId];
 }


### PR DESCRIPTION
This enables the simple audio engine to play sound effects in a loop until you call stopEffect: with the returned sound id.
