### PR TITLE
Use glClear to clear the stencil buffer.

### DIFF
--- a/cocos2d/CCClippingNode.m
+++ b/cocos2d/CCClippingNode.m
@@ -215,17 +215,15 @@ static void setProgram(CCNode *n, CCGLProgram *p) {
     ///////////////////////////////////
     // CLEAR STENCIL BUFFER
     
-    // manually clear the stencil buffer by drawing a fullscreen rectangle on it
     // setup the stencil test func like this:
-    // for each pixel in the fullscreen rectangle
+    // for each pixel in the stencil buffer
     //     never draw it into the frame buffer
     //     if not in inverted mode: set the current layer value to 0 in the stencil buffer
     //     if in inverted mode: set the current layer value to 1 in the stencil buffer
     glStencilFunc(GL_NEVER, mask_layer, mask_layer);
+    glClearStencil(!_inverted ? 0 : ~0);
     glStencilOp(!_inverted ? GL_ZERO : GL_REPLACE, GL_KEEP, GL_KEEP);
-    
-    // draw a fullscreen solid rectangle to clear the stencil buffer
-    ccDrawSolidRect(CGPointZero, ccpFromSize([[CCDirector sharedDirector] winSize]), ccc4f(1, 1, 1, 1));
+    glClear(GL_STENCIL_BUFFER_BIT);
     
     ///////////////////////////////////
     // DRAW CLIPPING STENCIL

--- a/cocos2d/CCClippingNode.m
+++ b/cocos2d/CCClippingNode.m
@@ -220,10 +220,42 @@ static void setProgram(CCNode *n, CCGLProgram *p) {
     //     never draw it into the frame buffer
     //     if not in inverted mode: set the current layer value to 0 in the stencil buffer
     //     if in inverted mode: set the current layer value to 1 in the stencil buffer
+#if defined(__CC_PLATFORM_MAC)
+    // There is a bug in some ATI drivers where glStencilMask does not affect glClear.
+    // Draw a full screen rectangle to clear the stencil buffer.
     glStencilFunc(GL_NEVER, mask_layer, mask_layer);
-    glClearStencil(!_inverted ? 0 : ~0);
     glStencilOp(!_inverted ? GL_ZERO : GL_REPLACE, GL_KEEP, GL_KEEP);
+
+    int viewport[4];
+    glGetIntegerv(GL_VIEWPORT, viewport);
+
+    int x = viewport[0];
+    int y = viewport[1];
+    int width = viewport[2];
+    int height = viewport[3];
+
+    kmGLMatrixMode(KM_GL_PROJECTION);
+    kmGLPushMatrix();
+    kmGLLoadIdentity();
+
+    kmMat4 orthoMatrix;
+    kmMat4OrthographicProjection(&orthoMatrix, x, width, y, height, -1, 1);
+    kmGLMultMatrix( &orthoMatrix );
+
+    kmGLMatrixMode(KM_GL_MODELVIEW);
+    kmGLPushMatrix();
+    kmGLLoadIdentity();
+
+    ccDrawSolidRect(ccp(x, y), ccp(width, height), ccc4f(1, 1, 1, 1));
+
+    kmGLMatrixMode(KM_GL_PROJECTION);
+    kmGLPopMatrix();
+    kmGLMatrixMode(KM_GL_MODELVIEW);
+    kmGLPopMatrix();
+#else
+    glClearStencil(!_inverted ? 0 : ~0);
     glClear(GL_STENCIL_BUFFER_BIT);
+#endif
     
     ///////////////////////////////////
     // DRAW CLIPPING STENCIL

--- a/tests/ClippingNodeTest.h
+++ b/tests/ClippingNodeTest.h
@@ -64,6 +64,9 @@
 @interface ScrollViewDemo : BaseClippingNodeTest
 @end
 
+@interface NegativeCoordinateTest : BaseClippingNodeTest
+@end
+
 #if COCOS2D_DEBUG > 1
 
 @interface RawStencilBufferTest : BaseClippingNodeTest

--- a/tests/ClippingNodeTest.m
+++ b/tests/ClippingNodeTest.m
@@ -33,6 +33,7 @@ static NSString *transitions[] = {
     @"SpriteNoAlphaTest",
 	@"SpriteInvertedTest",
     @"NestedTest",
+    @"NegativeCoordinateTest",
 #if COCOS2D_DEBUG > 1
 	@"RawStencilBufferTest",
     @"RawStencilBufferTest2",
@@ -661,6 +662,44 @@ Class restartAction()
 }
 
 #endif
+
+@end
+
+#pragma mark - NegativeCoordinateTest
+
+@implementation NegativeCoordinateTest
+
+-(NSString*) title
+{
+	return @"Negative Coordinate Test";
+}
+
+-(NSString*) subtitle
+{
+	return @"Rotating square should be cut out of center";
+}
+
+- (void)setup
+{
+    CCLayerColor *stencil = [CCLayerColor layerWithColor:ccc4(0, 0, 0, 255) width:50 height:50];
+    stencil.position = ccp(-25, -25);
+    CCLayerColor *square = [CCLayerColor layerWithColor:ccc4(255, 255, 255, 255) width:100 height:100];
+    square.position = ccp(-50, -50);
+
+    CCClippingNode *clipper = [CCClippingNode clippingNode];
+    clipper.position = ccp(0, 0);
+    clipper.stencil = stencil;
+    clipper.inverted = YES;
+    [clipper addChild:square];
+
+    CCNode *parent = [CCNode node];
+    parent.position = ccp(self.contentSize.width / 2, self.contentSize.height / 2);
+
+    [parent addChild:clipper];
+    [self addChild: parent];
+
+    [stencil runAction:[CCRepeatForever actionWithAction:[CCRotateBy actionWithDuration:1 angle:90]]];
+}
 
 @end
 


### PR DESCRIPTION
Use glClear instead of drawing a rectange so that current layer's mask
for the entire stencil buffer is cleared. This fixes clipping when
drawn to a texture larger than the screen size or when the stencil or
clipping node's children contain vertices with negative coordinates.

Fixes issue 1463  http://code.google.com/p/cocos2d-iphone/issues/detail?id=1463
(CCClippingNode does not clear the stencil buffer properly)

I've checked the clipping tests and they look ok.
