### PR TITLE
More options for primitives to draw in CCDrawingPrimitives

### DIFF
--- a/cocos2d/CCDrawingPrimitives.h
+++ b/cocos2d/CCDrawingPrimitives.h
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2008-2010 Ricardo Quesada
  * Copyright (c) 2011 Zynga Inc.
+ * Copyright (c) 2013 Nader Eloshaiker
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +63,8 @@ extern "C" {
   - ccDrawLine
   - ccDrawRect, ccDrawSolidRect
   - ccDrawPoly, ccDrawSolidPoly
-  - ccDrawCircle
+  - ccDrawCircle, ccDrawSolidCircle 
+  - ccDrawArc, ccDrawSolidArc
   - ccDrawQuadBezier
   - ccDrawCubicBezier
   - ccDrawCatmullRom
@@ -114,6 +116,15 @@ void ccDrawSolidPoly( const CGPoint *poli, NSUInteger numberOfPoints, ccColor4F 
     
 /** draws a circle given the center, radius and number of segments measured in points */
 void ccDrawCircle( CGPoint center, float radius, float angle, NSUInteger segments, BOOL drawLineToCenter);
+
+/** draws a solid circle given the center, radius and number of segments measured in points */
+void ccDrawSolidCircle( CGPoint center, float radius, NSUInteger segments);
+    
+/** draws a arc given the center, radius, arc length and number of segments measured in points */
+void ccDrawArc(CGPoint center, CGFloat r, CGFloat a, CGFloat arcLength, NSUInteger segs, BOOL drawLineToCenter);
+
+/** draws a solid arc given the center, radius, arc length and number of segments measured in points */
+void ccDrawSolidArc(CGPoint center, CGFloat r, CGFloat a, CGFloat arcLength, NSUInteger segs);
 
 /** draws a quad bezier path measured in points.
  @warning This function could be pretty slow. Use it only for debugging purposes.

--- a/cocos2d/CCDrawingPrimitives.m
+++ b/cocos2d/CCDrawingPrimitives.m
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2008-2010 Ricardo Quesada
  * Copyright (c) 2011 Zynga Inc.
+ * Copyright (c) 2013 Nader Eloshaiker
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -281,6 +282,127 @@ void ccDrawCircle( CGPoint center, float r, float a, NSUInteger segs, BOOL drawL
 	free( vertices );
 	
 	CC_INCREMENT_GL_DRAWS(1);
+}
+
+void ccDrawSolidCircle( CGPoint center, float r, NSUInteger segs)
+{
+	lazy_init();
+    
+	int additionalSegment = 1;
+    
+	const float coef = 2.0f * (float)M_PI/segs;
+    
+	GLfloat *vertices = calloc( sizeof(GLfloat)*2*(segs+2), 1);
+	if( ! vertices )
+		return;
+    
+	for(NSUInteger i = 0;i <= segs; i++) {
+		float rads = i*coef;
+		GLfloat j = r * cosf(rads) + center.x;
+		GLfloat k = r * sinf(rads) + center.y;
+        
+		vertices[i*2] = j;
+		vertices[i*2+1] = k;
+	}
+	vertices[(segs+1)*2] = center.x;
+	vertices[(segs+1)*2+1] = center.y;
+    
+	[shader_ use];
+	[shader_ setUniformsForBuiltins];
+	[shader_ setUniformLocation:colorLocation_ with4fv:(GLfloat*) &color_.r count:1];
+    
+	ccGLEnableVertexAttribs( kCCVertexAttribFlag_Position );
+    
+	glVertexAttribPointer(kCCVertexAttrib_Position, 2, GL_FLOAT, GL_FALSE, 0, vertices);
+	glDrawArrays(GL_TRIANGLE_FAN, 0, (GLsizei) segs+additionalSegment);
+    
+	free( vertices );
+	
+	CC_INCREMENT_GL_DRAWS(1);
+}
+
+void ccDrawArc(CGPoint center, CGFloat r, CGFloat a, CGFloat arcLength, NSUInteger segs, BOOL drawLineToCenter)
+{
+	lazy_init();
+    
+	int additionalSegment = 1;
+	if (drawLineToCenter)
+		additionalSegment++;
+    
+    const float coef = arcLength / segs;
+    
+    GLfloat *vertices = calloc( sizeof(GLfloat)*2*(segs+2), 1);
+    if( ! vertices )
+        return;
+    
+	for(NSUInteger i = 0;i <= segs; i++) {
+		float rads = i*coef;
+		GLfloat j = r * cosf(rads + a) + center.x;
+		GLfloat k = r * sinf(rads + a) + center.y;
+        
+		vertices[i*2] = j;
+		vertices[i*2+1] = k;
+	}
+	vertices[(segs+1)*2] = center.x;
+	vertices[(segs+1)*2+1] = center.y;
+    
+    vertices[(segs+1)*2] = center.x;
+	vertices[(segs+1)*2+1] = center.y;
+    
+	[shader_ use];
+	[shader_ setUniformsForBuiltins];
+	[shader_ setUniformLocation:colorLocation_ with4fv:(GLfloat*) &color_.r count:1];
+    
+	ccGLEnableVertexAttribs( kCCVertexAttribFlag_Position );
+    
+	glVertexAttribPointer(kCCVertexAttrib_Position, 2, GL_FLOAT, GL_FALSE, 0, vertices);
+	glDrawArrays(GL_LINE_STRIP, 0, (GLsizei) segs+additionalSegment);
+    
+	free( vertices );
+	
+	CC_INCREMENT_GL_DRAWS(1);
+    
+}
+
+void ccDrawSolidArc(CGPoint center, CGFloat r, CGFloat a, CGFloat arcLength, NSUInteger segs)
+{
+    if (arcLength == 0.0) return;
+    
+    const int additionalSegment = 2;
+    
+    const float coef = arcLength / segs;
+    
+    GLfloat *vertices = calloc( sizeof(GLfloat)*2*(segs+2), 1);
+    if( ! vertices )
+        return;
+    
+	for(NSUInteger i = 0;i <= segs; i++) {
+		float rads = i*coef;
+		GLfloat j = r * cosf(rads + a) + center.x;
+		GLfloat k = r * sinf(rads + a) + center.y;
+        
+		vertices[i*2] = j;
+		vertices[i*2+1] = k;
+	}
+	vertices[(segs+1)*2] = center.x;
+	vertices[(segs+1)*2+1] = center.y;
+    
+    vertices[(segs+1)*2] = center.x;
+	vertices[(segs+1)*2+1] = center.y;
+    
+	[shader_ use];
+	[shader_ setUniformsForBuiltins];
+	[shader_ setUniformLocation:colorLocation_ with4fv:(GLfloat*) &color_.r count:1];
+    
+	ccGLEnableVertexAttribs( kCCVertexAttribFlag_Position );
+    
+	glVertexAttribPointer(kCCVertexAttrib_Position, 2, GL_FLOAT, GL_FALSE, 0, vertices);
+	glDrawArrays(GL_TRIANGLE_FAN, 0, (GLsizei) segs+additionalSegment);
+    
+	free( vertices );
+	
+	CC_INCREMENT_GL_DRAWS(1);
+    
 }
 
 void ccDrawQuadBezier(CGPoint origin, CGPoint control, CGPoint destination, NSUInteger segments)

--- a/tests/drawPrimitivesTest.m
+++ b/tests/drawPrimitivesTest.m
@@ -208,6 +208,27 @@ Class restartAction()
 
 	CHECK_GL_ERROR_DEBUG();
 
+	// draw a green Arc with 50 segments without line to center
+	glLineWidth(2);
+	ccDrawColor4B(0, 255, 255, 255);
+	ccDrawArc( ccp(s.width-105, s.height/2-105), 100, CC_DEGREES_TO_RADIANS(90), CC_DEGREES_TO_RADIANS(90), 50, NO);
+    
+	CHECK_GL_ERROR_DEBUG();
+    
+	// draw a green solid Arc with 50 segments without line to center
+	glLineWidth(2);
+	ccDrawColor4B(0, 255, 255, 255);
+	ccDrawSolidArc( ccp(s.width-105, s.height/2+105), 100, CC_DEGREES_TO_RADIANS(90), CC_DEGREES_TO_RADIANS(90), 50);
+    
+	CHECK_GL_ERROR_DEBUG();
+    
+	// draw a green solid circle with 50 segments with line to center
+	glLineWidth(1);
+	ccDrawColor4B(0, 255, 255, 255);
+	ccDrawSolidCircle( ccp(105, s.height/2), 100, 50);
+    
+	CHECK_GL_ERROR_DEBUG();
+    
 	// open yellow poly
 	ccDrawColor4B(255, 255, 0, 255);
 	glLineWidth(10);


### PR DESCRIPTION
Added the following primitives to CCDrawingPrimitives:
- void ccDrawSolidCircle( CGPoint center, float radius, NSUInteger segments);
- void ccDrawArc(CGPoint center, CGFloat r, CGFloat a, CGFloat arcLength, NSUInteger segs, BOOL drawLineToCenter);
- void ccDrawSolidArc(CGPoint center, CGFloat r, CGFloat a, CGFloat arcLength, NSUInteger segs);
