### PR TITLE
Fix for using Objective-Chipmunk with CC_PHYSICS_INTEGRATION.

### DIFF
--- a/cocos2d/ccConfig.h
+++ b/cocos2d/ccConfig.h
@@ -36,7 +36,11 @@
  @since v2.1
  */
 #ifndef CC_ENABLE_CHIPMUNK_INTEGRATION
-#define CC_ENABLE_CHIPMUNK_INTEGRATION 0
+#define CC_ENABLE_CHIPMUNK_INTEGRATION 1
+
+// If you are using Objective-Chipmunk/ChipmunkPro, you'll need to change this to "ObjectiveChipmunk.h"
+#define CC_CHIPMUNK_IMPORT "chipmunk.h"
+//#define CC_CHIPMUNK_IMPORT "ObjectiveChipmunk.h"
 #endif
 
 /** @def CC_ENABLE_BOX2D_INTEGRATION

--- a/cocos2d/cocos2d.h
+++ b/cocos2d/cocos2d.h
@@ -126,6 +126,7 @@
 // Physics integration
 // Box2d integration should include these 2 files manually
 #if CC_ENABLE_CHIPMUNK_INTEGRATION
+#import CC_CHIPMUNK_IMPORT
 #import "CCPhysicsSprite.h"
 #import "CCPhysicsDebugNode.h"
 #endif


### PR DESCRIPTION
I've been telling people to work around this issue for a while, but I came up with a much simpler fix that shouldn't interfere with the JS binding generator.
