### PR TITLE
getChildByTagRecursive in CCNode

### DIFF
--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -394,6 +394,11 @@ enum {
  */
 -(CCNode*) getChildByTag:(NSInteger) tag;
 
+/** Recursively gets a child from the container given its tag
+ @return returns a CCNode object
+ */
+-(CCNode*) getChildByTagRecursive:(NSInteger) tag;
+
 /** Reorders a child according to a new z value.
  * The child MUST be already added.
  */

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -345,6 +345,20 @@ static NSUInteger globalOrderOfArrival = 1;
 	return nil;
 }
 
+-(CCNode*) getChildByTagRecursive:(NSInteger) aTag
+{
+	CCNode* result = [self getChildByTag:aTag];
+ 
+	if(result == nil) {
+		for(CCNode* child in [self children]) {
+			result = [child getChildByTagRecursive:aTag];
+			if(result != nil) break;
+		}
+	}
+ 
+	return result;
+}
+
 /* "add" logic MUST only be on this method
  * If a class want's to extend the 'addChild' behaviour it only needs
  * to override this method


### PR DESCRIPTION
getChildByTagRecursive applies getChildByTag on the current node and all its descendants recursively until a node with the given tag is found
