### PR TITLE
Develop v2 ease exponential

### DIFF
--- a/cocos2d/CCActionEase.h
+++ b/cocos2d/CCActionEase.h
@@ -2,6 +2,7 @@
  * cocos2d for iPhone: http://www.cocos2d-iphone.org
  *
  * Copyright (c) 2008-2009 Jason Booth
+ * Copyright (c) 2013 Nader Eloshaiker
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -58,7 +59,7 @@
 /** CCEaseIn action with a rate
  */
 @interface CCEaseIn : CCEaseRateAction <NSCopying>
-{} 
+{}
 // Needed for BridgeSupport
 -(void) update: (ccTime) t;
 @end
@@ -79,9 +80,26 @@
 -(void) update: (ccTime) t;
 @end
 
+/** CCEase Exponential abstract class
+ @since v2.1
+ */
+@interface CCEaseExponential : CCActionEase <NSCopying> {
+@protected
+    NSUInteger _polynomialOrder;
+    CGFloat _intersetValue; //Used for InOut mid point
+    BOOL _hasInflection; //odd numbered polynomial orders will display a point of inflection where the curve will invert
+}
+/** Used to determine the steepness of the timing curve.
+ As the value increases, so does the steepness of the curve.
+ Default value is 6  ; gives a close representation to a log2 curve,
+ @warning Value must be greater than 1
+ */
+@property (nonatomic, readwrite, assign) NSUInteger polynomialOrder;
+@end
+
 /** CCEase Exponential In
  */
-@interface CCEaseExponentialIn : CCActionEase <NSCopying>
+@interface CCEaseExponentialIn : CCEaseExponential <NSCopying>
 {}
 // Needed for BridgeSupport
 -(void) update: (ccTime) t;
@@ -89,7 +107,7 @@
 
 /** Ease Exponential Out
  */
-@interface CCEaseExponentialOut : CCActionEase <NSCopying>
+@interface CCEaseExponentialOut : CCEaseExponential <NSCopying>
 {}
 // Needed for BridgeSupport
 -(void) update: (ccTime) t;
@@ -97,7 +115,7 @@
 
 /** Ease Exponential InOut
  */
-@interface CCEaseExponentialInOut : CCActionEase <NSCopying>
+@interface CCEaseExponentialInOut : CCEaseExponential <NSCopying>
 {}
 // Needed for BridgeSupport
 -(void) update: (ccTime) t;
@@ -176,7 +194,7 @@
 
 /** CCEaseBounce abstract class.
  @since v0.8.2
-*/
+ */
 @interface CCEaseBounce : CCActionEase <NSCopying>
 {}
 // Needed for BridgeSupport
@@ -186,7 +204,7 @@
 /** CCEaseBounceIn action.
  @warning This action doesn't use a bijective function. Actions like Sequence might have an unexpected result when used with this action.
  @since v0.8.2
-*/
+ */
 @interface CCEaseBounceIn : CCEaseBounce <NSCopying>
 {}
 // Needed for BridgeSupport


### PR DESCRIPTION
Please ignore my previous pull request, it was going to the wrong branch.... Sorry, not an experienced user of github.
https://github.com/cocos2d/cocos2d-iphone/pull/297

**\* Description of issue and solution ***

The issue with exponential functions is that they exhibit asymptotes. 
The effects of the asymptotes become visible when performing large changes over a short time.
i.e. rotate 10000 degrees in 2.5 seconds with an exponential ease out, the effect is that as it comes to a stop, it jumps to its final position.

ExponentialEaseOut will asymptote at newT = 1 while ExponentialEaseIn will asymptote at newT = 0, hence the original version hard coded these values for newT.

I have replaced the exponential mathematical routine with a nth order polynomial which resembles an exponential curve for values of 0 <= t <= 1 and an order of 6.
The advantage of using polynomial curves is that they do not asymptote.
I have allowed for odd and even values of polynomial orders as odd values will exhibit an inflection in the curve.

As a feature of this curve, you can now control the acceleration at which it eases in or out by adjusting the polynomial value, polynomial must be greater than 1.

**\* Demonstration of theory ***

The attached image shows the following:
Purple curve = Exponential Curve for EaseOut, asymptotes at y = 1
Red curve = 6th order polynomial for EaseOut, y =1 when x = 1
Green curve = Exponential Curve for EaseIn, asymptotes at y = 0
Dark Blue curve = 6th order polynomial for EaseIn, y =0 when x = 0
Brown and light blue curve represent an EaseInOut 6th order polynomial were y = 0 when x = 0 and y = 1 when x = 1.
![CCEasePolynomial](https://f.cloud.github.com/assets/1904325/229034/bdb7d616-8692-11e2-88ca-f3a2f4e652ff.png)

**\* Code Details ***
- added an abstract class called CCEaseExponential where it will store polynomial order, inflection attribute and intersect point for InOut action based on the polynomial order
- added property for abstract class to change the order of the polynomial to control acceleration of the ease function
- Modified CCEaseExponentialIn to use polynomial curves of newT = t^n  where n > 1
- Modified CCEaseExponentialOut to use polynomial curves of newT = (t - 1)^n + 1  where n > 1 and is an odd integer, newT = -( (t - 1)^n ) + 1  where n > 1 and is an even integer
- Modified CCEaseExponentialInOut (for 0 <= t < 0.5) to use polynomial curves of newT = (t \* intersect)^n  where n > 1,
- Modified CCEaseExponentialInOut (for 0.5 <= t <= 1) to use polynomial curves of newT = ( (t - 1) \* intersect)^n + 1  where n > 1 and is an odd integer, newT = -( ( (t - 1) \* \* intersect ) ^n ) + 1  where n > 1 and is an even integer
