### PR TITLE
touchSwallow property in CCLayer

### DIFF
--- a/cocos2d/CCLayer.h
+++ b/cocos2d/CCLayer.h
@@ -59,6 +59,7 @@ typedef enum {
 	BOOL _touchEnabled;
 	NSInteger _touchPriority;
 	BOOL _touchMode;
+    BOOL _touchSwallow;
 	
 	BOOL _accelerometerEnabled;
 }
@@ -84,6 +85,9 @@ typedef enum {
  */
 @property(nonatomic, assign) ccTouchesMode touchMode;
 
+/** whether touch events are swallowed (in kCCTouchesOneByOne mode) */
+@property(nonatomic, assign) BOOL touchSwallow;
+
 /** sets the accelerometer's update frequency. A value of 1/2 means that the callback is going to be called twice per second.
  @since v2.1
  */
@@ -104,7 +108,8 @@ typedef enum {
 	BOOL		_touchEnabled;
 	NSInteger	_touchPriority;
 	NSInteger	_touchMode;
-    
+    BOOL        _touchSwallow;
+
 	BOOL		_gestureEnabled;
 	NSInteger	_gesturePriority;
 }

--- a/cocos2d/CCLayer.m
+++ b/cocos2d/CCLayer.m
@@ -73,6 +73,7 @@
 		_touchEnabled = NO;
 		_touchPriority = 0;
 		_touchMode = kCCTouchesAllAtOnce;
+        _touchSwallow = YES;
 
 #ifdef __CC_PLATFORM_IOS
 		_accelerometerEnabled = NO;
@@ -97,7 +98,7 @@
 	if( _touchMode == kCCTouchesAllAtOnce )
 		[[director touchDispatcher] addStandardDelegate:self priority:_touchPriority];
 	else /* one by one */
-		[[director touchDispatcher] addTargetedDelegate:self priority:_touchPriority swallowsTouches:YES];
+		[[director touchDispatcher] addTargetedDelegate:self priority:_touchPriority swallowsTouches:_touchSwallow];
 }
 
 -(BOOL) isAccelerometerEnabled
@@ -167,6 +168,21 @@
 {
 	if( _touchMode != touchMode ) {
 		_touchMode = touchMode;
+		if( _touchEnabled) {
+			[self setTouchEnabled:NO];
+			[self setTouchEnabled:YES];
+		}
+	}
+}
+
+-(BOOL) touchSwallow
+{
+	return _touchSwallow;
+}
+-(void) setTouchSwallow:(BOOL)touchSwallow
+{
+	if( _touchSwallow != touchSwallow ) {
+		_touchSwallow = touchSwallow;
 		if( _touchEnabled) {
 			[self setTouchEnabled:NO];
 			[self setTouchEnabled:YES];


### PR DESCRIPTION
I added a **touchSwallow** property in CCLayer to set the value of **swallowsTouches** parameter (currently forced to **YES**) in the **registerTouchDispatcher** method.
