### PR TITLE
implemented support for Tiled  tileset offset feature

### DIFF
--- a/cocos2d/CCTMXLayer.m
+++ b/cocos2d/CCTMXLayer.m
@@ -323,14 +323,19 @@ int compareInts (const void * a, const void * b);
 {
 	[sprite setPosition: [self positionAt:pos]];
 	[sprite setVertexZ: [self vertexZForPos:pos]];
-	sprite.anchorPoint = CGPointZero;
+	//sprite.anchorPoint = CGPointZero; // was the default
 	[sprite setOpacity:_opacity];
 	
 	//issue 1264, flip can be undone as well
 	sprite.flipX = NO;
 	sprite.flipY = NO;
 	sprite.rotation = 0;
-	sprite.anchorPoint = ccp(0,0);
+	//sprite.anchorPoint = ccp(0,0); // was the default
+	
+	// All tile sprites in the layer should have the same anchorpoint.
+	// The default anchor point is defined in the TMX file (within the tileset node) and stored in the
+	// CCTMXTilesetInfo* property of the CCTMXLayer.
+	sprite.anchorPoint = _tileset.tileAnchorPoint;
 	
 	// Rotation in tiled is achieved using 3 flipped states, flipping across the horizontal, vertical, and diagonal axes of the tiles.
 	if (gid & kCCTMXTileDiagonalFlag)

--- a/cocos2d/CCTMXXMLParser.h
+++ b/cocos2d/CCTMXXMLParser.h
@@ -119,6 +119,15 @@ typedef enum ccTMXTileFlags_ {
 	CGSize			_tileSize;
 	unsigned int	_spacing;
 	unsigned int	_margin;
+	
+	//	Offset of tiles. New TMX XML node introduced here: https://github.com/bjorn/tiled/issues/16 .
+	//	Node structure:
+	//	(...) <tileset firstgid="1" name="mytileset-ipad" tilewidth="40" tileheight="40" spacing="1" margin="1">
+	//			  <tileoffset x="0" y="10"/>
+	//			  <image source="mytileset-ipad.png" width="256" height="256"/>
+	//	(...)
+	CGPoint         _tileOffset;
+	CGPoint			_tileAnchorPoint; //normalized anchor point	
 
 	// filename containing the tiles (should be spritesheet / texture atlas)
 	NSString	*_sourceImage;
@@ -133,6 +142,8 @@ typedef enum ccTMXTileFlags_ {
 @property (nonatomic,readwrite,assign) unsigned int margin;
 @property (nonatomic,readwrite,retain) NSString *sourceImage;
 @property (nonatomic,readwrite,assign) CGSize imageSize;
+@property (nonatomic,readwrite,assign) CGPoint tileOffset; //setter has a custom implementation
+@property (nonatomic,readonly,assign) CGPoint tileAnchorPoint; //set automatically when tileOffset changes
 
 -(CGRect) rectForGID:(unsigned int)gid;
 @end


### PR DESCRIPTION
The Tiled Map Editor (www.mapeditor.org) has implemented support for tileset offsets: https://github.com/bjorn/tiled/issues/16
(there is a screenshot in the above link that makes the feature very clear)

The Property is defined in this form (should be doubled for retina):

```
<tileset firstgid="1" name="mytileset-ipad" tilewidth="100" tileheight="100" spacing="1" margin="1">
    <tileoffset x="0" y="15"/>
    <image source="mytileset-ipad.png" width="256" height="256"/>
    (...)
```

Cocos2d, however, doesn't pick up that property from the TMX file format.

Some workarounds are:
- Add the offset to GL touch coordinates when working with tiles (hit tests, etc)
- Add the offset to the `CCTMXTiledMap` node's position
- Add the offset to other sprites' positions if they need to be centered on the tiles
- etc...

I've added few lines (≈ 20, excluding comments) to the CCTMX related files, so that Cocos2d can read that new TMX property and adjust tile sprites' positions accordingly.
The Commit: https://github.com/tompave/cocos2d-iphone/commit/5232cce1a492f0ca4816858cc16e127d3ecf5785

The `CCTMXXMLParser` now reads that information and stores the offset (as pixels) in a `CGPoint` property of the `CCTMXTilesetInfo` class.
Upon setting the property, the custom setter calculates the relative anchorPoint (as range `0.0f - 1.0f`) and stores it in another `CGPoint` property of the `CCTMXTilesetInfo` class.
Finally, the `CCTMXLayer` instance (owning the `CCTMXTilesetInfo` instance) uses the information to set the anchorPoint of individual tile sprites.

Comments:
- The process is automatic and, if the TMX file doesn't indicate any tileset offset, it defaults to the standard `CGPointZero`.
- The "map grid" stays in place.
- All map functions keep working as usual, e.g. hit testing a tile with touch coordinates.
- All TileMap tests within the cocos2d repository still pass.
- I'm not sure if applying the offset to the tile sprites' `position` (rather than the `anchorPoint`) would be better. Suggestions would be welcome.

As an example, look at this picture:
![tile_comparison](https://f.cloud.github.com/assets/2141406/326862/b267388c-9b51-11e2-9658-458d41f043b0.png)
iPad simulator, non-retina.
The map is placed at the precise center of the display rect.
Map Properties:
- Grid tile dimesions: 100 x 50 pixels
- Tileset tile dimesions: 100 x 100 pixels (they have vertical decorative elements)
- **Tileset tile offset: x=0 y=15, the tile sprites are shifted 15px down**
- **The grid should be aligned with the top of the "grass" tiles. Water should be lower, stone should be higher**

The red line (aligned with the home button):
- indicates the half-height of the display
- overlaps the leftmost corner of the tilemap (tile coords: 0,9 for a 10x10 map)
- should orizontally bisect tiles of the central orizontal row

Without the optimization descibed above, the tile sprites of the `CCTMXTileMap` are rendered "normally" and **appear 15px above the actual tile grid**.
With the optimization tile sprites are rendered according to the offset declared in the TMX file, and the map grid overlaps with tile edges as expected.

Needless to say, the tileset offset should be based on the sprites' art.
