### PR TITLE
Added lazy_init call to ccDrawSolidArc

### DIFF
--- a/cocos2d/CCDrawingPrimitives.m
+++ b/cocos2d/CCDrawingPrimitives.m
@@ -366,6 +366,8 @@ void ccDrawArc(CGPoint center, CGFloat r, CGFloat a, CGFloat arcLength, NSUInteg
 
 void ccDrawSolidArc(CGPoint center, CGFloat r, CGFloat a, CGFloat arcLength, NSUInteger segs)
 {
+    lazy_init();
+    
     if (arcLength == 0.0) return;
     
     const int additionalSegment = 2;


### PR DESCRIPTION
Added a call to lazy_init in ccDrawSolidArc to initialize uniforms etc. as already done in the other functions in the file.
