### PR TITLE
Adds support for dynamically loading TTF fonts on iOS

### DIFF
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -35,6 +35,7 @@
 
 #ifdef __CC_PLATFORM_IOS
 #import "Platforms/iOS/CCDirectorIOS.h"
+#import <CoreText/CoreText.h>
 #endif
 
 #if CC_USE_LA88_LABELS
@@ -147,7 +148,6 @@
 
 - (NSString*) getFontName:(NSString*)fontName
 {
-#ifdef __CC_PLATFORM_MAC
 	// Custom .ttf file ?
     if ([[fontName lowercaseString] hasSuffix:@".ttf"])
     {
@@ -158,7 +158,6 @@
 
 		return [[fontFile lastPathComponent] stringByDeletingPathExtension];
     }
-#endif //
 
     return fontName;
 }


### PR DESCRIPTION
This pull requests adds support for dynamically loading TTF fonts on iOS without the need of adding the file names to info.plist.

To make this work the CoreText.framework needs to be included in the right places (project, build libraries, templates etc - I wasn't sure which places it is needed so I left this part out).
