### PR TITLE
Implemented CCEasePolynomial Action.

### DIFF
--- a/cocos2d/CCActionEase.h
+++ b/cocos2d/CCActionEase.h
@@ -2,6 +2,7 @@
  * cocos2d for iPhone: http://www.cocos2d-iphone.org
  *
  * Copyright (c) 2008-2009 Jason Booth
+ * Copyright (c) 2013 Nader Eloshaiker
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -98,6 +99,52 @@
 /** Ease Exponential InOut
  */
 @interface CCEaseExponentialInOut : CCActionEase <NSCopying>
+{}
+// Needed for BridgeSupport
+-(void) update: (ccTime) t;
+@end
+
+/** CCEase Polynomial abstract class
+ @since v2.1
+ */
+@interface CCEasePolynomial : CCActionEase <NSCopying> {
+@protected
+    NSUInteger _polynomialOrder;
+    CGFloat _intersetValue; //Used for InOut mid point time calculation
+    BOOL _hasInflection; //odd numbered polynomial orders will display a point of inflection where the curve will invert
+}
+/** Used to determine the steepness of the timing curve.
+ As the value increases, so does the steepness/rate of the curve.
+ Default value is 6, gives a similar curve to EaseExponential.
+ Values less than 6, produces a softer ease action.
+ Values greater than 6, produces a more pronounced action.
+ @warning Value must be greater than 1
+ */
+@property (nonatomic, readwrite, assign) NSUInteger polynomialOrder;
+@end
+
+/** CCEase Polynomial In
+ @since v2.1
+ */
+@interface CCEasePolynomialIn : CCEasePolynomial <NSCopying>
+{}
+// Needed for BridgeSupport
+-(void) update: (ccTime) t;
+@end
+
+/** Ease Polynomial Out
+ @since v2.1
+ */
+@interface CCEasePolynomialOut : CCEasePolynomial <NSCopying>
+{}
+// Needed for BridgeSupport
+-(void) update: (ccTime) t;
+@end
+
+/** Ease Polynomial InOut
+ @since v2.1
+ */
+@interface CCEasePolynomialInOut : CCEasePolynomial <NSCopying>
 {}
 // Needed for BridgeSupport
 -(void) update: (ccTime) t;

--- a/tests/ActionsEaseTest.h
+++ b/tests/ActionsEaseTest.h
@@ -38,6 +38,14 @@
 {}
 @end
 
+@interface SpriteEasePolynomial : SpriteDemo
+{}
+@end
+
+@interface SpriteEasePolynomialInOut : SpriteDemo
+{}
+@end
+
 @interface SpriteEaseSine : SpriteDemo
 {}
 @end

--- a/tests/ActionsEaseTest.m
+++ b/tests/ActionsEaseTest.m
@@ -12,6 +12,8 @@ static NSString *transitions[] = {
 				@"SpriteEaseInOut",
 				@"SpriteEaseExponential",
 				@"SpriteEaseExponentialInOut",
+                @"SpriteEasePolynomial",
+                @"SpriteEasePolynomialInOut",
 				@"SpriteEaseSine",
 				@"SpriteEaseSineInOut",
 				@"SpriteEaseElastic",
@@ -380,6 +382,78 @@ Class restartAction()
 -(NSString *) title
 {
 	return @"EaseExponentialInOut action";
+}
+@end
+
+#pragma mark SpriteEasePolynomial
+
+@implementation SpriteEasePolynomial
+-(void) onEnter
+{
+	[super onEnter];
+    
+	CGSize s = [[CCDirector sharedDirector] winSize];
+    
+	id move = [CCMoveBy actionWithDuration:3 position:ccp(s.width-130,0)];
+
+	CCEasePolynomialIn *move_ease_in_order_3 = [CCEasePolynomialIn actionWithAction:[[move copy] autorelease]];
+    move_ease_in_order_3.polynomialOrder = 3;
+	id move_ease_in_back_order_3 = [move_ease_in_order_3 reverse];
+    
+	id move_ease_in_order_6 = [CCEasePolynomialIn actionWithAction:[[move copy] autorelease]];
+	id move_ease_in_back_order_6 = [move_ease_in_order_6 reverse];
+    
+	CCEasePolynomialIn *move_ease_in_order_9 = [CCEasePolynomialIn actionWithAction:[[move copy] autorelease]];
+    move_ease_in_order_9.polynomialOrder = 9;
+	id move_ease_in_back_order_9 = [move_ease_in_order_9 reverse];
+    
+	id delay = [CCDelayTime actionWithDuration:0.25f];
+    
+	id seq1 = [CCSequence actions: move_ease_in_order_3, CCCA(delay), move_ease_in_back_order_9, CCCA(delay), nil];
+	id seq2 = [CCSequence actions: move_ease_in_order_6, CCCA(delay), move_ease_in_back_order_6, CCCA(delay), nil];
+	id seq3 = [CCSequence actions: move_ease_in_order_9, CCCA(delay), move_ease_in_back_order_3, CCCA(delay), nil];
+    
+    
+	[grossini runAction: [CCRepeatForever actionWithAction:seq1]];
+	[tamara runAction: [CCRepeatForever actionWithAction:seq2]];
+	[kathia runAction: [CCRepeatForever actionWithAction:seq3]];
+}
+-(NSString *) title
+{
+	return @"PolyIn - PolyOut actions with orders 3, 6 and 9";
+}
+@end
+
+#pragma mark SpriteEasePolynomialInOut
+
+@implementation SpriteEasePolynomialInOut
+-(void) onEnter
+{
+	[super onEnter];
+    
+	CGSize s = [[CCDirector sharedDirector] winSize];
+    
+	id move = [CCMoveBy actionWithDuration:3 position:ccp(s.width-130,0)];
+	id move_back = [move reverse];
+    
+	CCEasePolynomialInOut *move_ease = [CCEasePolynomialInOut actionWithAction:[[move copy] autorelease]];
+    move_ease.polynomialOrder = 4;
+	id move_ease_back = [move_ease reverse];
+    
+	id delay = [CCDelayTime actionWithDuration:0.25f];
+    
+	id seq1 = [CCSequence actions: move, delay, move_back, CCCA(delay), nil];
+	id seq2 = [CCSequence actions: move_ease, CCCA(delay), move_ease_back, CCCA(delay), nil];
+    
+    
+	[self positionForTwo];
+    
+	[grossini runAction: [CCRepeatForever actionWithAction:seq1]];
+	[tamara runAction: [CCRepeatForever actionWithAction:seq2]];
+}
+-(NSString *) title
+{
+	return @"PolynomialInOut action with order 4";
 }
 @end
 


### PR DESCRIPTION
- Developed a replacement for exponential mathematical routine with a nth order polynomial which resembles an exponential curve for values of 0 <= t <= 1 and an order of 6.
- Advantage of using polynomial curves is that they do not asymptote.
- Developers can control the acceleration at which it eases in or out by adjusting the polynomial value, polynomial must be greater than 1.
- Allowed for odd and even values of polynomial orders as odd values will exhibit an inflection in the curve.

The attached image shows the timing curves for the following:
- Purple = Ease In Polynomial order 3
- Green = Ease In Polynomial order 9
- Blue   = Ease In Polynomial order 6
- Red    = Ease In Exponential

![ccactionease](https://f.cloud.github.com/assets/1904325/468729/e49953c2-b69e-11e2-8f17-21dcfedb8066.png)
