### PR TITLE
Bug Fix: CCTargetedAction now sets its _target ivar correctly.

### DIFF
--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -1568,7 +1568,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, ccTime t )
 
 - (void) startWithTarget:(id)aTarget
 {
-	[super startWithTarget:_target];
+	[super startWithTarget:aTarget];
 	[_action startWithTarget:_forcedTarget];
 }
 


### PR DESCRIPTION
Issue 1488:
https://code.google.com/p/cocos2d-iphone/issues/detail?id=1488
