### PR TITLE
Change CCMenu default position

### DIFF
--- a/cocos2d/CCMenu.m
+++ b/cocos2d/CCMenu.m
@@ -115,7 +115,7 @@ enum {
 		CGRect r = [[UIApplication sharedApplication] statusBarFrame];
 		s.height -= r.size.height;
 #endif
-		self.position = ccp(s.width/2, s.height/2);
+		self.position = ccp(0, 0);
 		
 		int z=0;
 		


### PR DESCRIPTION
In general, you can put CCSprite and CCMenuItem in the same position (center of the screen) like *1.
But when you write like *2, CCMenuItemSprite's position will be the upper right corner of the screen.
That's because CCMenu also has position (s.width/2, s.height/2) by default.
I think it's not natural. It seems like CCSprite's start point is (0, 0) and CCMenuItem's one is (s.width/2, s.height/2).
Is there any reason why CCMenu's default position should be there?

*1: https://gist.github.com/ikstrm/cd08a93d41ff2d2d4039
*2: https://gist.github.com/ikstrm/ec417274544fe418bebf
