### PR TITLE
Added support for font shadow capacity, which is collected but not implemented.

### DIFF
--- a/cocos2d/CCFontDefinition.h
+++ b/cocos2d/CCFontDefinition.h
@@ -73,6 +73,8 @@
 -(CGSize)  shadowOffset;
 -(void)    setShadowBlur:(CGFloat)blur;
 -(CGFloat) shadowBlur;
+-(void)    setShadowOpacity:(CGFloat)opacity;
+-(CGFloat) shadowOpacity;
 
 // stroke
 -(void)     enableStroke:(bool) strokeEnabled;

--- a/cocos2d/CCFontDefinition.m
+++ b/cocos2d/CCFontDefinition.m
@@ -91,6 +91,16 @@
     return _shadow.m_shadowBlur;
 }
 
+-(void) setShadowOpacity:(CGFloat)opacity
+{
+    _shadow.m_shadowOpacity = opacity;
+}
+
+-(CGFloat) shadowOpacity
+{
+    return _shadow.m_shadowOpacity;
+}
+
 -(void) enableStroke:(bool) strokeEnabled
 {
     _stroke.m_strokeEnabled = strokeEnabled;

--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -531,6 +531,7 @@
         {
             [retDefinition enableShadow:true];
             [retDefinition setShadowBlur:_shadowBlur];
+            [retDefinition setShadowOpacity:_shadowOpacity];
             
             if (resAdjust)
             {

--- a/cocos2d/CCTexture2D.m
+++ b/cocos2d/CCTexture2D.m
@@ -590,10 +590,16 @@ static CCTexture2DPixelFormat defaultAlphaPixel_format = kCCTexture2DPixelFormat
     // take care of shadow if needed
     if ( [definition shadowEnabled] )
     {
+    	colorspace = CGColorSpaceCreateDeviceRGB();
+        CGFloat shadowColorValues[] = { 0, 0, 0, [definition shadowOpacity]};
+        CGColorRef shadowColor = CGColorCreate( colorSpace, shadowColorValues );
         CGSize offset;
         offset.height = [definition shadowOffset].height;
         offset.width  = [definition shadowOffset].width;
-        CGContextSetShadow(context, offset, [definition shadowBlur]);
+        CGContextSetShadowWithColor(context, offset, [definition shadowBlur], shadowColor);
+        
+        CGColorRelease(shadowColor);
+        CGColorSpaceRelease(colorSpace);
     }
     
     float textOriginX  = 0.0;


### PR DESCRIPTION
Added support for opacity value supplied in -enableShadowWithOffset:opacity:blur:updateImage. Default shadow color of 0,0,0 (black) is preserved. Opacity is made part of CCFontDefinition and put to use in CCTexture2D.
