### PR TITLE
Fixes build on Xcode 4.2

### DIFF
--- a/cocos2d/CCTexture2D.m
+++ b/cocos2d/CCTexture2D.m
@@ -458,6 +458,20 @@ static CCTexture2DPixelFormat defaultAlphaPixel_format = kCCTexture2DPixelFormat
 
 #ifdef __CC_PLATFORM_IOS
 
+// get it running on Xcode versions prior to 4.4
+#if (defined(__clang__) && __has_feature(objc_default_synthesize_properties))
+#else
+     #define NSLineBreakByWordWrapping UILineBreakModeWordWrap
+     #define NSLineBreakByCharWrapping UILineBreakModeCharacterWrap
+     #define NSLineBreakByClipping UILineBreakModeClip
+     #define NSLineBreakByTruncatingHead UILineBreakModeHeadTruncation
+     #define NSLineBreakByTruncatingTail UILineBreakModeTailTruncation
+     #define NSLineBreakByTruncatingMiddle UILineBreakModeMiddleTruncation
+     #define NSTextAlignmentLeft UITextAlignmentLeft
+     #define NSTextAlignmentRight UITextAlignmentRight
+     #define NSTextAlignmentCenter UITextAlignmentCenter
+#endif
+
 - (id) initWithString:(NSString*)string fontDef:(CCFontDefinition *)definition
 {
 	// MUST have the same order declared on ccTypes


### PR DESCRIPTION
Cocos2d 2.1 introduces several build errors with Xcode 4.2 because NSLineBreakBy______ and NSTextAlignment______ are not defined. This uses the preprocessor to define them if the Xcode version is less than 4.4.

This is primarily for developers who are stuck on Mac OS X 10.6 because their hardware is too old (e.g Macbook Pro 1st gen). For those, the newest Xcode version available is 4.2.
