### PR TITLE
Fixed 64bit build with kazmath

### DIFF
--- a/external/kazmath/src/mat4.c
+++ b/external/kazmath/src/mat4.c
@@ -215,7 +215,7 @@ kmMat4* const kmMat4Transpose(kmMat4* pOut, const kmMat4* pIn)
  */
 kmMat4* const kmMat4Multiply(kmMat4* pOut, const kmMat4* pM1, const kmMat4* pM2)
 {
-#if defined(__ARM_NEON__)
+#if defined(_ARM_ARCH_7)
 
 	float mat[16];
 


### PR DESCRIPTION
There was one more preprocessor macro failing the 64bit build. 
Everything builds and runs for me on 64bit simulator (both iPad, iPhone) and device (iPhone 5S).
