### PR TITLE
Fix the templates for CCNodeColor changes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@
 # ----------------------------------------------------
 # Variables setup
 # ----------------------------------------------------
-SCRIPT_VER="v0.9.4"
+SCRIPT_VER="v0.9.5"
 COCOS2D_VER="cocos2d-v3.0"
 COCOS2D_DST_DIR="cocos2d v3.x"
 SCRIPT_DIR="$(dirname $0)"
@@ -285,45 +285,15 @@ if $INSTALL ; then
 	tar -xf "$DOWNLOAD_DIR/Chipmunk_tarball.zip" -C "${DOWNLOAD_DIR}/Chipmunk/" --strip-components=1 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
 	check_status	
 	printf " ${GREEN}✔${COLOREND}\n"
-	
-	# Building Chipmunk (fat static lib)
-	echo -n "...bulding Chipmunk fat static lib, please wait"
-	xcodebuild -project "${DOWNLOAD_DIR}/Chipmunk/xcode/Chipmunk7.xcodeproj" -configuration Release -target ObjectiveChipmunk -sdk iphonesimulator SYM_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" DST_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" CONFIGURATION_TEMP_DIR="${DOWNLOAD_DIR}/Chipmunk/xcode/build/" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
-	check_status	
-	echo -n "."
-	xcodebuild -project "${DOWNLOAD_DIR}/Chipmunk/xcode/Chipmunk7.xcodeproj" -configuration Release -target ObjectiveChipmunk -sdk iphoneos SYM_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" DST_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" CONFIGURATION_TEMP_DIR="${DOWNLOAD_DIR}/Chipmunk/xcode/build/" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
-	check_status	
-	echo -n "."	
-	xcodebuild -project "${DOWNLOAD_DIR}/Chipmunk/xcode/Chipmunk7.xcodeproj" -configuration Release -target ObjectiveChipmunk -sdk macosx SYM_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" DST_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" CONFIGURATION_TEMP_DIR="${DOWNLOAD_DIR}/Chipmunk/xcode/build/" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
-	check_status	
-	echo -n "."	
-	lipo -create "${DOWNLOAD_DIR}/Chipmunk/xcode/build/Release-iphoneos/libObjectiveChipmunk.a" "${DOWNLOAD_DIR}/Chipmunk/xcode/build/Release-iphonesimulator/libObjectiveChipmunk.a" "${DOWNLOAD_DIR}/Chipmunk/xcode/build/Release/libObjectiveChipmunk.a" -output "${DOWNLOAD_DIR}/Chipmunk/xcode/build/libObjectiveChipmunk.a" 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
-	check_status	
-	printf " ${GREEN}✔${COLOREND}\n"
-	
+		
 	# Copy Chipmunk files
 	echo -n "...copying Chipmunk files"
 	LIBS_DIR="$DST_DIR/Support/Libraries/lib_chipmunk.xctemplate/Libraries/"
 	copy_files "external/Chipmunk_download/Chipmunk/objectivec/include" "$LIBS_DIR/Chipmunk/objectivec"
-	copy_files "external/Chipmunk_download/Chipmunk/xcode/build/libObjectiveChipmunk.a" "$LIBS_DIR/Chipmunk/objectivec"
+	copy_files "external/Chipmunk_download/Chipmunk/objectivec/src" "$LIBS_DIR/Chipmunk/objectivec"
 	copy_files "external/Chipmunk_download/Chipmunk/include" "$LIBS_DIR/Chipmunk/chipmunk"
 	copy_files "external/Chipmunk_download/Chipmunk/src" "$LIBS_DIR/Chipmunk/chipmunk"
 	copy_files "external/Chipmunk_download/Chipmunk/LICENSE.txt" "$LIBS_DIR/Chipmunk"
-	printf " ${GREEN}✔${COLOREND}\n"
-		
-	# Clean after Chipmunk
-	echo -n "...cleaning after Chipmunk"
-	xcodebuild -project "${DOWNLOAD_DIR}/Chipmunk/xcode/Chipmunk7.xcodeproj" -configuration Release -target ObjectiveChipmunk -sdk iphoneos SYM_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" DST_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" clean 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
-	check_status
-	echo -n "."
-	xcodebuild -project "${DOWNLOAD_DIR}/Chipmunk/xcode/Chipmunk7.xcodeproj" -configuration Release -target ObjectiveChipmunk -sdk iphonesimulator SYM_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" DST_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" clean 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"
-	check_status
-	echo -n "."	
-	xcodebuild -project "${DOWNLOAD_DIR}/Chipmunk/xcode/Chipmunk7.xcodeproj" -configuration Release -target ObjectiveChipmunk -sdk macosx SYM_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" DST_ROOT="${DOWNLOAD_DIR}/Chipmunk/xcode/" clean 1>>"${ERROR_LOG}" 2>>"${ERROR_LOG}"	
-	check_status
-	echo -n "."	
-	rm -rf "${DOWNLOAD_DIR}" 1>/dev/null 2>>"${ERROR_LOG}"
-	check_status
 	printf " ${GREEN}✔${COLOREND}\n"
 
 	# Copy ObjectAL files

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@
 # ----------------------------------------------------
 # Variables setup
 # ----------------------------------------------------
-SCRIPT_VER="v0.9.3"
+SCRIPT_VER="v0.9.4"
 COCOS2D_VER="cocos2d-v3.0"
 COCOS2D_DST_DIR="cocos2d v3.x"
 SCRIPT_DIR="$(dirname $0)"

--- a/templates/Support/Base/base.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Base/base.xctemplate/TemplateInfo.plist
@@ -111,6 +111,8 @@
 			<string>___PACKAGENAME___</string>
 			<key>SharedSettings</key>
 			<dict>
+				<key>ARCHS</key>
+				<string>$(ARCHS_STANDARD)</string>
 				<key>ALWAYS_SEARCH_USER_PATHS</key>
 				<string>NO</string>
 				<key>PRODUCT_NAME</key>
@@ -150,6 +152,39 @@
 			</dict>
 			<key>ProductType</key>
 			<string>com.apple.product-type.application</string>
+		</dict>
+		<dict>
+			<key>Name</key>
+			<string>ObjectiveChipmunk</string>
+			<key>ProductType</key>
+			<string>com.apple.product-type.library.static</string>
+			<key>SharedSettings</key>
+			<dict>
+				<key>ARCHS</key>
+				<string>$(ARCHS_STANDARD)</string>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>EXECUTABLE_PREFIX</key>
+				<string>lib</string>
+				<key>EXECUTABLE_EXTENSION</key>
+				<string>a</string>
+				<key>HEADER_SEARCH_PATHS</key>
+                <array>
+                	<string>"$(PROJECT_NAME)/Libraries/Chipmunk/chipmunk/include"</string>
+                	<string>"$(PROJECT_NAME)/Libraries/Chipmunk/objectivec/include"</string>
+                </array>
+                <key>CLANG_ENABLE_OBJC_ARC</key>
+                <string>NO</string>
+			</dict>
+			<key>BuildPhases</key>
+			<array>
+				<dict>
+					<key>Class</key>
+					<string>Sources</string>
+				</dict>
+			</array>
 		</dict>
 	</array>
 </dict>

--- a/templates/Support/Base/base_ios.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Base/base_ios.xctemplate/TemplateInfo.plist
@@ -99,7 +99,7 @@
                     <string>-lz</string>
                     <string>-lsqlite3</string>
                     <string>-ObjC</string>
-					<string>-weak_library $PROJECT_NAME/Libraries/Chipmunk/objectivec/libObjectiveChipmunk.a</string>					
+					<string>-weak_library $BUILT_PRODUCTS_DIR/libObjectiveChipmunk.a</string>					
                 </array>
 			</dict>
 			<key>Configurations</key>
@@ -110,6 +110,10 @@
 					<string>YES</string>
 				</dict>
 			</dict>
+			<key>Dependencies</key>
+			<array>
+				<integer>1</integer>
+			</array>
 		</dict>
 	</array>
 	<key>Definitions</key>

--- a/templates/Support/Libraries/lib_ccbreader.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Libraries/lib_ccbreader.xctemplate/TemplateInfo.plist
@@ -34,6 +34,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/CCBReader/CCBAnimationManager.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/CCBReader/CCBKeyframe.h</key>
          <dict>
@@ -58,6 +62,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/CCBReader/CCBKeyframe.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/CCBReader/CCBReader.h</key>
          <dict>
@@ -82,6 +90,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/CCBReader/CCBReader.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/CCBReader/CCBSequence.h</key>
          <dict>
@@ -106,6 +118,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/CCBReader/CCBsequence.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/CCBReader/CCBSequenceProperty.h</key>
          <dict>
@@ -130,6 +146,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/CCBReader/CCBSequenceProperty.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/CCBReader/CCBLocalizationManager.h</key>
          <dict>
@@ -154,6 +174,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/CCBReader/CCBLocalizationManager.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/CCBReader/CCBuilderReader.h</key>
          <dict>

--- a/templates/Support/Libraries/lib_chipmunk.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Libraries/lib_chipmunk.xctemplate/TemplateInfo.plist
@@ -396,6 +396,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/chipmunk.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpArbiter.c</key>
          <dict>
@@ -408,6 +412,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpArbiter.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpArray.c</key>
          <dict>
@@ -420,6 +428,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpArray.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpBBTree.c</key>
          <dict>
@@ -432,6 +444,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpBBTree.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpBody.c</key>
          <dict>
@@ -444,6 +460,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpBody.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpCollision.c</key>
          <dict>
@@ -456,6 +476,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpCollision.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpConstraint.c</key>
          <dict>
@@ -468,6 +492,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpConstraint.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpDampedRotarySpring.c</key>
          <dict>
@@ -480,6 +508,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpDampedRotarySpring.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpDampedSpring.c</key>
          <dict>
@@ -492,6 +524,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpDampedSpring.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpGearJoint.c</key>
          <dict>
@@ -504,6 +540,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpGearJoint.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpGrooveJoint.c</key>
          <dict>
@@ -516,6 +556,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpGrooveJoint.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpHashSet.c</key>
          <dict>
@@ -528,6 +572,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpHashSet.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpPinJoint.c</key>
          <dict>
@@ -540,6 +588,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpPinJoint.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpPivotJoint.c</key>
          <dict>
@@ -552,6 +604,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpPivotJoint.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpPolyShape.c</key>
          <dict>
@@ -564,6 +620,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpPolyShape.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpRatchetJoint.c</key>
          <dict>
@@ -576,6 +636,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpRatchetJoint.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpRotaryLimitJoint.c</key>
          <dict>
@@ -588,6 +652,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpRotaryLimitJoint.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpShape.c</key>
          <dict>
@@ -600,6 +668,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpShape.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSimpleMotor.c</key>
          <dict>
@@ -612,6 +684,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSimpleMotor.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSlideJoint.c</key>
          <dict>
@@ -624,6 +700,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSlideJoint.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSpace.c</key>
          <dict>
@@ -636,6 +716,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSpace.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSpaceComponent.c</key>
          <dict>
@@ -648,6 +732,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSpaceComponent.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSpaceDebug.c</key>
          <dict>
@@ -660,6 +748,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSpaceDebug.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSpaceHash.c</key>
          <dict>
@@ -672,6 +764,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSpaceHash.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSpaceQuery.c</key>
          <dict>
@@ -684,6 +780,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSpaceQuery.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSpaceStep.c</key>
          <dict>
@@ -696,6 +796,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSpaceStep.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSpatialIndex.c</key>
          <dict>
@@ -708,6 +812,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSpatialIndex.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/cpSweep1D.c</key>
          <dict>
@@ -720,6 +828,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/Chipmunk/chipmunk/src/cpSweep1D.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/Chipmunk/chipmunk/src/prime.h</key>
          <dict>
@@ -840,18 +952,85 @@
             <key>TargetIndices</key>
             <array />
          </dict>
-         <key>Libraries/Chipmunk/objectivec/libObjectiveChipmunk.a</key>		 
+         <key>Libraries/Chipmunk/objectivec/src/ChipmunkBody.m</key>
          <dict>
             <key>Group</key>
             <array>
                <string>Libraries</string>
                <string>Chipmunk</string>
                <string>objectivec</string>
+               <string>src</string>
             </array>
             <key>Path</key>
-            <string>Libraries/Chipmunk/objectivec/libObjectiveChipmunk.a</string>
+            <string>Libraries/Chipmunk/objectivec/src/ChipmunkBody.m</string>
             <key>TargetIndices</key>
-            <array />
+            <array>
+               <integer>1</integer>
+            </array>
+         </dict>
+         <key>Libraries/Chipmunk/objectivec/src/ChipmunkConstraint.m</key>
+         <dict>
+            <key>Group</key>
+            <array>
+               <string>Libraries</string>
+               <string>Chipmunk</string>
+               <string>objectivec</string>
+               <string>src</string>
+            </array>
+            <key>Path</key>
+            <string>Libraries/Chipmunk/objectivec/src/ChipmunkConstraint.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
+         </dict>
+         <key>Libraries/Chipmunk/objectivec/src/ChipmunkMultiGrab.m</key>
+         <dict>
+            <key>Group</key>
+            <array>
+               <string>Libraries</string>
+               <string>Chipmunk</string>
+               <string>objectivec</string>
+               <string>src</string>
+            </array>
+            <key>Path</key>
+            <string>Libraries/Chipmunk/objectivec/src/ChipmunkMultiGrab.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
+         </dict>        
+         <key>Libraries/Chipmunk/objectivec/src/ChipmunkShape.m</key>
+         <dict>
+            <key>Group</key>
+            <array>
+               <string>Libraries</string>
+               <string>Chipmunk</string>
+               <string>objectivec</string>
+               <string>src</string>
+            </array>
+            <key>Path</key>
+            <string>Libraries/Chipmunk/objectivec/src/ChipmunkShape.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
+         </dict>
+         <key>Libraries/Chipmunk/objectivec/src/ChipmunkSpace.m</key>
+         <dict>
+            <key>Group</key>
+            <array>
+               <string>Libraries</string>
+               <string>Chipmunk</string>
+               <string>objectivec</string>
+               <string>src</string>
+            </array>
+            <key>Path</key>
+            <string>Libraries/Chipmunk/objectivec/src/ChipmunkSpace.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>1</integer>
+            </array>
          </dict>
          <key>Libraries/LICENSE_Chipmunk.txt</key>
          <dict>
@@ -926,7 +1105,11 @@
          <string>Libraries/Chipmunk/objectivec/include/ObjectiveChipmunk/ChipmunkShape.h</string>
          <string>Libraries/Chipmunk/objectivec/include/ObjectiveChipmunk/ChipmunkSpace.h</string>
          <string>Libraries/Chipmunk/objectivec/include/ObjectiveChipmunk/ObjectiveChipmunk.h</string>
-		 <string>Libraries/Chipmunk/objectivec/libObjectiveChipmunk.a</string>
+         <string>Libraries/Chipmunk/objectivec/src/ChipmunkBody.m</string>
+         <string>Libraries/Chipmunk/objectivec/src/ChipmunkConstraint.m</string>
+         <string>Libraries/Chipmunk/objectivec/src/ChipmunkMultiGrab.m</string>
+         <string>Libraries/Chipmunk/objectivec/src/ChipmunkShape.m</string>
+         <string>Libraries/Chipmunk/objectivec/src/ChipmunkSpace.m</string>
          <string>Libraries/LICENSE_Chipmunk.txt</string>
       </array>
       <key>Targets</key>

--- a/templates/Support/Libraries/lib_cocos2d-ui.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Libraries/lib_cocos2d-ui.xctemplate/TemplateInfo.plist
@@ -42,6 +42,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCBReader/CCBAnimationManager.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCBReader/CCBKeyframe.h</key>
          <dict>
@@ -64,6 +68,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCBReader/CCBKeyframe.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCBReader/CCBLocalizationManager.h</key>
          <dict>
@@ -86,6 +94,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCBReader/CCBLocalizationManager.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCBReader/CCBReader.h</key>
          <dict>
@@ -108,6 +120,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCBReader/CCBReader.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCBReader/CCBSequence.h</key>
          <dict>
@@ -130,6 +146,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCBReader/CCBsequence.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCBReader/CCBSequenceProperty.h</key>
          <dict>
@@ -152,6 +172,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCBReader/CCBSequenceProperty.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCBReader/CCBuilderReader.h</key>
          <dict>
@@ -186,6 +210,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCButton.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCControl.h</key>
          <dict>
@@ -208,6 +236,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCControl.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCControlSubclass.h</key>
          <dict>
@@ -242,6 +274,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCControlTextureFactory.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCScrollView.h</key>
          <dict>
@@ -264,6 +300,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCScrollView.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCSlider.h</key>
          <dict>
@@ -286,6 +326,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCSlider.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCTableView.h</key>
          <dict>
@@ -308,6 +352,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCTableView.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/CCTextField.h</key>
          <dict>
@@ -330,6 +378,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d-ui/CCTextField.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d-ui/cocos2d-ui.h</key>
          <dict>

--- a/templates/Support/Libraries/lib_cocos2d.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Libraries/lib_cocos2d.xctemplate/TemplateInfo.plist
@@ -33,6 +33,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCAction.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCActionCatmullRom.h</key>
          <dict>
@@ -57,6 +61,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCActionCatmullRom.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCActionEase.h</key>
          <dict>
@@ -81,6 +89,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCActionEase.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCActionInstant.h</key>
          <dict>
@@ -105,6 +117,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCActionInstant.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCActionInterval.h</key>
          <dict>
@@ -129,6 +145,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCActionInterval.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCActionManager.h</key>
          <dict>
@@ -153,6 +173,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCActionManager.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCActionProgressTimer.h</key>
          <dict>
@@ -177,6 +201,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCActionProgressTimer.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCActionTween.h</key>
          <dict>
@@ -201,6 +229,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCActionTween.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCAnimation.h</key>
          <dict>
@@ -225,6 +257,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCAnimation.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCAnimationCache.h</key>
          <dict>
@@ -249,6 +285,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCAnimationCache.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCAtlasNode.h</key>
          <dict>
@@ -273,6 +313,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCAtlasNode.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCClippingNode.h</key>
          <dict>
@@ -297,6 +341,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCClippingNode.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/ccConfig.h</key>
          <dict>
@@ -331,6 +379,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCConfiguration.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/ccDeprecated.h</key>
          <dict>
@@ -353,6 +405,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/ccDeprecated.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCDirector_Private.h</key>
          <dict>
@@ -387,6 +443,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCDirector.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCDrawingPrimitives.h</key>
          <dict>
@@ -411,6 +471,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCDrawingPrimitives.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCDrawNode.h</key>
          <dict>
@@ -435,6 +499,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCDrawNode.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/ccFPSImages.h</key>
          <dict>
@@ -457,6 +525,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/ccFPSImages.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCGLProgram.h</key>
          <dict>
@@ -481,6 +553,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCGLProgram.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/ccGLStateCache.h</key>
          <dict>
@@ -505,6 +581,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/ccGLStateCache.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCLabelAtlas.h</key>
          <dict>
@@ -529,6 +609,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCLabelAtlas.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCLabelBMFont_Private.h</key>
          <dict>
@@ -566,6 +650,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCLabelBMFont.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCLabelTTF.h</key>
          <dict>
@@ -590,6 +678,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCLabelTTF.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCNodeColor.h</key>
          <dict>
@@ -614,6 +706,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCNodeColor.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCLayout.h</key>
          <dict>
@@ -638,6 +734,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCLayout.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCLayoutBox.h</key>
          <dict>
@@ -662,6 +762,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCLayoutBox.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/ccMacros.h</key>
          <dict>
@@ -698,6 +802,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCMotionStreak.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCNode_Private.h</key>
          <dict>
@@ -735,6 +843,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCNode.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCNode+Debug.h</key>
          <dict>
@@ -759,6 +871,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCNode+Debug.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCParallaxNode.h</key>
          <dict>
@@ -783,6 +899,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCParallaxNode.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCParticleBatchNode.h</key>
          <dict>
@@ -807,6 +927,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCParticleBatchNode.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCParticleExamples.h</key>
          <dict>
@@ -831,6 +955,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCParticleExamples.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCParticleSystem_Private.h</key>
          <dict>
@@ -868,6 +996,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCParticleSystem.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCParticleSystemQuad_Private.h</key>
          <dict>
@@ -905,6 +1037,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCParticleSystemQuad.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCPhysics+ObjectiveChipmunk.h</key>
          <dict>
@@ -942,6 +1078,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCPhysicsBody.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCPhysicsJoint.h</key>
          <dict>
@@ -966,6 +1106,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCPhysicsJoint.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCPhysicsNode.h</key>
          <dict>
@@ -990,6 +1134,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCPhysicsNode.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCPhysicsShape.h</key>
          <dict>
@@ -1014,6 +1162,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCPhysicsShape.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCProgressNode_Private.h</key>
          <dict>
@@ -1051,6 +1203,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCProgressNode.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCProtocols.h</key>
          <dict>
@@ -1087,6 +1243,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCRenderTexture.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCResponder.h</key>
          <dict>
@@ -1111,6 +1271,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCResponder.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCResponderManager.h</key>
          <dict>
@@ -1135,6 +1299,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCResponderManager.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCScene.h</key>
          <dict>
@@ -1159,6 +1327,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCScene.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCScheduler.h</key>
          <dict>
@@ -1181,6 +1353,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCScheduler.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/ccShader_Position_uColor_frag.h</key>
          <dict>
@@ -1400,6 +1576,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCShaderCache.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/ccShaders.h</key>
          <dict>
@@ -1424,6 +1604,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/ccShaders.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCSprite_Private.h</key>
          <dict>
@@ -1461,6 +1645,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCSprite.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCSprite9Slice.h</key>
          <dict>
@@ -1485,6 +1673,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCSprite9Slice.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCSpriteBatchNode_Private.h</key>
          <dict>
@@ -1522,6 +1714,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCSpriteBatchNode.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCSpriteFrame.h</key>
          <dict>
@@ -1546,6 +1742,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCSpriteFrame.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCSpriteFrameCache.h</key>
          <dict>
@@ -1570,6 +1770,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCSpriteFrameCache.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCTexture_Private.h</key>
          <dict>
@@ -1607,6 +1811,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCTexture.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCTextureAtlas.h</key>
          <dict>
@@ -1631,6 +1839,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCTextureAtlas.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCTextureCache.h</key>
          <dict>
@@ -1655,6 +1867,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCTextureCache.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCTexturePVR.h</key>
          <dict>
@@ -1679,6 +1895,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCTexturePVR.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCTiledMap.h</key>
          <dict>
@@ -1703,6 +1923,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCTiledMap.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCTiledMapLayer_Private.h</key>
          <dict>
@@ -1740,6 +1964,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCTiledMapLayer.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCTiledMapObjectGroup.h</key>
          <dict>
@@ -1764,6 +1992,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCTiledMapObjectGroup.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCTMXXMLParser.h</key>
          <dict>
@@ -1788,6 +2020,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCTMXXMLParser.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/CCTransition.h</key>
          <dict>
@@ -1812,6 +2048,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/CCTransition.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/ccTypes.h</key>
          <dict>
@@ -1846,6 +2086,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/cocos2d.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Platforms/CCGL.h</key>
          <dict>
@@ -1898,6 +2142,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Platforms/iOS/CCDirectorIOS.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Platforms/iOS/CCES2Renderer.h</key>
          <dict>
@@ -1924,6 +2172,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Platforms/iOS/CCES2Renderer.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Platforms/iOS/CCESRenderer.h</key>
          <dict>
@@ -1964,6 +2216,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Platforms/iOS/CCGLView.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Platforms/iOS/UITouch+CC.h</key>
          <dict>
@@ -1990,6 +2246,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Platforms/iOS/UITouch+CC.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Platforms/Mac/CCDirectorMac.h</key>
          <dict>
@@ -2016,6 +2276,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Platforms/Mac/CCDirectorMac.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Platforms/Mac/CCGLView.h</key>
          <dict>
@@ -2042,6 +2306,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Platforms/Mac/CCGLView.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Platforms/Mac/CCWindow.h</key>
          <dict>
@@ -2068,6 +2336,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Platforms/Mac/CCWindow.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Platforms/Mac/NSEvent+CC.h</key>
          <dict>
@@ -2094,6 +2366,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Platforms/Mac/NSEvent+CC.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/base64.c</key>
          <dict>
@@ -2105,6 +2381,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/base64.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/base64.h</key>
          <dict>
@@ -2142,6 +2422,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/CCFileUtils.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/CCProfiling.h</key>
          <dict>
@@ -2168,6 +2452,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/CCProfiling.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/ccUtils.c</key>
          <dict>
@@ -2179,6 +2467,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/ccUtils.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/ccUtils.h</key>
          <dict>
@@ -2218,6 +2510,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/CCVertex.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/CGPointExtension.h</key>
          <dict>
@@ -2244,6 +2540,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/CGPointExtension.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/NSAttributedString+CCAdditions.h</key>
          <dict>
@@ -2268,6 +2568,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/NSAttributedString+CCAdditions.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/NSThread+performBlock.h</key>
          <dict>
@@ -2292,6 +2596,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/NSThread+performBlock.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/OpenGL_Internal.h</key>
          <dict>
@@ -2332,6 +2640,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/TGAlib.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/TransformUtils.h</key>
          <dict>
@@ -2358,6 +2670,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/TransformUtils.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/cocos2d/Support/uthash.h</key>
          <dict>
@@ -2410,6 +2726,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/cocos2d/Support/ZipUtils.m</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/LICENSE_cocos2d.txt</key>
          <dict>

--- a/templates/Support/Libraries/lib_cocos2d.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Libraries/lib_cocos2d.xctemplate/TemplateInfo.plist
@@ -591,29 +591,29 @@
             <key>Path</key>
             <string>Libraries/cocos2d/CCLabelTTF.m</string>
          </dict>
-         <key>Libraries/cocos2d/CCLayer.h</key>
+         <key>Libraries/cocos2d/CCNodeColor.h</key>
          <dict>
             <key>Group</key>
             <array>
                <string>Libraries</string>
                <string>cocos2d</string>
-               <string>Layers, Scenes, Transition Nodes</string>
+               <string>Misc Nodes</string>
             </array>
             <key>Path</key>
-            <string>Libraries/cocos2d/CCLayer.h</string>
+            <string>Libraries/cocos2d/CCNodeColor.h</string>
             <key>TargetIndices</key>
             <array />
          </dict>
-         <key>Libraries/cocos2d/CCLayer.m</key>
+         <key>Libraries/cocos2d/CCNodeColor.m</key>
          <dict>
             <key>Group</key>
             <array>
                <string>Libraries</string>
                <string>cocos2d</string>
-               <string>Layers, Scenes, Transition Nodes</string>
+               <string>Misc Nodes</string>
             </array>
             <key>Path</key>
-            <string>Libraries/cocos2d/CCLayer.m</string>
+            <string>Libraries/cocos2d/CCNodeColor.m</string>
          </dict>
          <key>Libraries/cocos2d/CCLayout.h</key>
          <dict>
@@ -2472,8 +2472,8 @@
          <string>Libraries/cocos2d/CCLabelBMFont.m</string>
          <string>Libraries/cocos2d/CCLabelTTF.h</string>
          <string>Libraries/cocos2d/CCLabelTTF.m</string>
-         <string>Libraries/cocos2d/CCLayer.h</string>
-         <string>Libraries/cocos2d/CCLayer.m</string>
+         <string>Libraries/cocos2d/CCNodeColor.h</string>
+         <string>Libraries/cocos2d/CCNodeColor.m</string>
          <string>Libraries/cocos2d/CCLayout.h</string>
          <string>Libraries/cocos2d/CCLayout.m</string>
          <string>Libraries/cocos2d/CCLayoutBox.h</string>

--- a/templates/Support/Libraries/lib_kazmath.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Libraries/lib_kazmath.xctemplate/TemplateInfo.plist
@@ -218,6 +218,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/aabb.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/ChangeLog</key>
          <dict>
@@ -241,6 +245,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/GL/mat4stack.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/GL/matrix.c</key>
          <dict>
@@ -253,6 +261,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/GL/matrix.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/mat3.c</key>
          <dict>
@@ -264,6 +276,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/mat3.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/mat4.c</key>
          <dict>
@@ -275,6 +291,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/mat4.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/neon_matrix_impl.c</key>
          <dict>
@@ -286,6 +306,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/neon_matrix_impl.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/plane.c</key>
          <dict>
@@ -297,6 +321,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/plane.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/quaternion.c</key>
          <dict>
@@ -308,6 +336,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/quaternion.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/ray2.c</key>
          <dict>
@@ -319,6 +351,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/ray2.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/utility.c</key>
          <dict>
@@ -330,6 +366,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/utility.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/vec2.c</key>
          <dict>
@@ -341,6 +381,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/vec2.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/vec3.c</key>
          <dict>
@@ -352,6 +396,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/vec3.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/kazmath/src/vec4.c</key>
          <dict>
@@ -363,6 +411,10 @@
             </array>
             <key>Path</key>
             <string>Libraries/kazmath/src/vec4.c</string>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
          </dict>
          <key>Libraries/LICENSE_Kazmath.txt</key>
          <dict>

--- a/templates/Support/Libraries/lib_objectal.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Libraries/lib_objectal.xctemplate/TemplateInfo.plist
@@ -47,7 +47,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Actions/OALAction.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Actions/OALActionManager.h</key>
 		<dict>
 			<key>Group</key>
@@ -71,7 +75,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Actions/OALActionManager.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Actions/OALAudioActions.h</key>
 		<dict>
 			<key>Group</key>
@@ -95,7 +103,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Actions/OALAudioActions.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Actions/OALUtilityActions.h</key>
 		<dict>
 			<key>Group</key>
@@ -119,7 +131,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Actions/OALUtilityActions.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/AudioTrack/OALAudioTrack.h</key>
 		<dict>
 			<key>Group</key>
@@ -143,7 +159,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/AudioTrack/OALAudioTrack.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/AudioTrack/OALAudioTrackNotifications.h</key>
 		<dict>
 			<key>Group</key>
@@ -167,7 +187,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/AudioTrack/OALAudioTrackNotifications.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/AudioTrack/OALAudioTracks.h</key>
 		<dict>
 			<key>Group</key>
@@ -191,7 +215,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/AudioTrack/OALAudioTracks.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OALSimpleAudio.h</key>
 		<dict>
 			<key>Group</key>
@@ -213,7 +241,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OALSimpleAudio.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/ObjectAL.h</key>
 		<dict>
 			<key>Group</key>
@@ -261,7 +293,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/ALBuffer.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OpenAL/ALCaptureDevice.h</key>
 		<dict>
 			<key>Group</key>
@@ -285,7 +321,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/ALCaptureDevice.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OpenAL/ALChannelSource.h</key>
 		<dict>
 			<key>Group</key>
@@ -309,7 +349,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/ALChannelSource.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OpenAL/ALContext.h</key>
 		<dict>
 			<key>Group</key>
@@ -333,7 +377,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/ALContext.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OpenAL/ALDevice.h</key>
 		<dict>
 			<key>Group</key>
@@ -357,7 +405,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/ALDevice.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OpenAL/ALListener.h</key>
 		<dict>
 			<key>Group</key>
@@ -381,7 +433,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/ALListener.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OpenAL/ALSoundSource.h</key>
 		<dict>
 			<key>Group</key>
@@ -418,7 +474,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/ALSoundSourcePool.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OpenAL/ALSource.h</key>
 		<dict>
 			<key>Group</key>
@@ -442,7 +502,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/ALSource.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OpenAL/ALTypes.h</key>
 		<dict>
 			<key>Group</key>
@@ -479,7 +543,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/ALWrapper.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/OpenAL/OpenALManager.h</key>
 		<dict>
 			<key>Group</key>
@@ -503,7 +571,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/OpenAL/OpenALManager.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Session/OALAudioSession.h</key>
 		<dict>
 			<key>Group</key>
@@ -527,7 +599,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Session/OALAudioSession.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Session/OALSuspendHandler.h</key>
 		<dict>
 			<key>Group</key>
@@ -551,7 +627,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Session/OALSuspendHandler.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Support/ARCSafe_MemMgmt.h</key>
 		<dict>
 			<key>Group</key>
@@ -588,7 +668,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Support/IOSVersion.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Support/mach_timing.c</key>
 		<dict>
 			<key>Group</key>
@@ -599,6 +683,10 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Support/mach_timing.c</string>
+			<key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
 		</dict>
 		<key>Libraries/ObjectAL/Support/mach_timing.h</key>
 		<dict>
@@ -636,7 +724,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Support/NSMutableArray+WeakReferences.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Support/NSMutableDictionary+WeakReferences.h</key>
 		<dict>
 			<key>Group</key>
@@ -660,7 +752,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Support/NSMutableDictionary+WeakReferences.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Support/OALAudioFile.h</key>
 		<dict>
 			<key>Group</key>
@@ -684,7 +780,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Support/OALAudioFile.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Support/OALNotifications.h</key>
 		<dict>
 			<key>Group</key>
@@ -721,7 +821,11 @@
 			</array>
 			<key>Path</key>
 			<string>Libraries/ObjectAL/Support/OALTools.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Libraries/ObjectAL/Support/ObjectALMacros.h</key>
 		<dict>
 			<key>Group</key>

--- a/templates/cocos2d iOS.xctemplate/Classes/AppDelegate.m
+++ b/templates/cocos2d iOS.xctemplate/Classes/AppDelegate.m
@@ -103,19 +103,18 @@
 	// Display FSP and SPF
 	[_director setDisplayStats:YES];
 	
-	// set FPS at 60
+	// Set FPS at 60
 	[_director setAnimationInterval:1.0/60];
 	
-	// attach the openglView to the director
+	// Attach the openglView to the director
 	[_director setView:glView];
 	
 	// 2D projection
 	[_director setProjection:CCDirectorProjection2D];
-	//	[director setProjection:kCCDirectorProjection3D];
+	// [director setProjection:kCCDirectorProjection3D];
 	
-	// Enables High Res mode (Retina Display) on iPhone 4 and maintains low res on all other devices
-	if(![_director enableRetinaDisplay:YES])
-    CCLOG(@"Retina Display Not supported");
+	// Enable "Retina" mode
+	glView.contentScaleFactor = [UIScreen mainScreen].scale;
 	
 	// Default texture format for PNG/BMP/TIFF/JPEG/GIF images
 	// It can be RGBA8888, RGBA4444, RGB5_A1, RGB565

--- a/templates/cocos2d iOS.xctemplate/Classes/IntroScene.m
+++ b/templates/cocos2d iOS.xctemplate/Classes/IntroScene.m
@@ -43,7 +43,7 @@ Do not use for new development";
     // Here is where custom code for the scene starts
     
     // create a colored background
-    CCLayerColor *background = [CCLayerColor layerWithColor:(ccColor4B){200, 200, 200, 255}];
+    CCNodeColor *background = [CCNodeColor nodeWithColor:(ccColor4B){200, 200, 200, 255}];
     [self addChild:background];
     
     // create a string with preview text

--- a/templates/cocos2d iOS.xctemplate/TemplateInfo.plist
+++ b/templates/cocos2d iOS.xctemplate/TemplateInfo.plist
@@ -36,7 +36,11 @@
 			<string>Supporting Files</string>
 			<key>Path</key>
 			<string>Supporting Files/main.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Classes/HelloWorldScene.h</key>
 		<dict>
 			<key>Group</key>
@@ -52,7 +56,11 @@
 			<string>Classes</string>
 			<key>Path</key>
 			<string>Classes/HelloWorldScene.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Classes/IntroScene.h</key>
 		<dict>
 			<key>Group</key>
@@ -68,7 +76,11 @@
 			<string>Classes</string>
 			<key>Path</key>
 			<string>Classes/IntroScene.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 		<key>Classes/AppDelegate.h</key>
 		<dict>
 			<key>Group</key>
@@ -84,7 +96,11 @@
 			<string>Classes</string>
 			<key>Path</key>
 			<string>Classes/AppDelegate.m</string>
-		</dict>
+            <key>TargetIndices</key>
+            <array>
+               <integer>0</integer>
+            </array>
+         </dict>
 	</dict>
 	<key>Description</key>
 	<string>This template provides a starting point for an application that uses cocos2d-v3.0 for iOS. It also includes Chipmunk, kazmath and CCBReader.</string>


### PR DESCRIPTION
Fixes in the templates for the changes that were made recently.

Specifically:
- CCLayerColor was renamed to CCNodeColor and its methods were changed
- Retina mode is now set differently (using content scale factor)
