### PR TITLE
Added support for multitouch processing by grouping touches before calling CCResponder callbacks 

### DIFF
--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -560,6 +560,7 @@
 		50F9E8160E1AA34E000E7616 /* ccTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ccTypes.h; sourceTree = "<group>"; };
 		50FBB2D8117613F500150761 /* CCActionTween.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionTween.h; sourceTree = "<group>"; };
 		50FBB2D9117613F500150761 /* CCActionTween.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCActionTween.m; sourceTree = "<group>"; };
+		62EED1331850EE80008B17A7 /* CCResponder_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CCResponder_Private.h; sourceTree = "<group>"; };
 		6F305B5D0FB9D2790052E700 /* TransformUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransformUtils.h; sourceTree = "<group>"; };
 		6F305B5E0FB9D2790052E700 /* TransformUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TransformUtils.m; sourceTree = "<group>"; };
 		A003AC8B1657071100C7B792 /* ccFPSImages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ccFPSImages.h; sourceTree = "<group>"; };
@@ -1343,6 +1344,7 @@
 				A6A0734917C78EF3004343C8 /* CCResponder.m */,
 				A6A0734317C788EB004343C8 /* CCResponderManager.h */,
 				A6A0734417C788EB004343C8 /* CCResponderManager.m */,
+				62EED1331850EE80008B17A7 /* CCResponder_Private.h */,
 			);
 			name = "Touch & Mouse Handling";
 			sourceTree = "<group>";

--- a/cocos2d.xcworkspace/xcshareddata/cocos2d.xccheckout
+++ b/cocos2d.xcworkspace/xcshareddata/cocos2d.xccheckout
@@ -5,46 +5,34 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>65934411-A8FC-483C-9087-2B510C218633</string>
+	<string>1AEFA80C-D8A9-4711-8C5F-B5E212F89C49</string>
 	<key>IDESourceControlProjectName</key>
 	<string>cocos2d</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>22BDDCFA-A236-4BAD-8A8F-CDB18C92BE5C</key>
-		<string>https://github.com/slembcke/Chipmunk2D.git</string>
-		<key>E97FC784-0BE9-43F2-A9AA-C28B7E25CE5D</key>
-		<string>https://github.com/cocos2d/cocos2d-iphone.git</string>
+		<key>2B7AAFF8-6F66-4E13-89F2-3F0A8BB3F8AD</key>
+		<string>https://github.com/Ben-G/cocos2d-iphone.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>cocos2d.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>22BDDCFA-A236-4BAD-8A8F-CDB18C92BE5C</key>
-		<string>../external/Chipmunk</string>
-		<key>E97FC784-0BE9-43F2-A9AA-C28B7E25CE5D</key>
+		<key>2B7AAFF8-6F66-4E13-89F2-3F0A8BB3F8AD</key>
 		<string>..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/cocos2d/cocos2d-iphone.git</string>
+	<string>https://github.com/Ben-G/cocos2d-iphone.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>E97FC784-0BE9-43F2-A9AA-C28B7E25CE5D</string>
+	<string>2B7AAFF8-6F66-4E13-89F2-3F0A8BB3F8AD</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>22BDDCFA-A236-4BAD-8A8F-CDB18C92BE5C</string>
-			<key>IDESourceControlWCCName</key>
-			<string>Chipmunk</string>
-		</dict>
-		<dict>
-			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
-			<string>public.vcs.git</string>
-			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>E97FC784-0BE9-43F2-A9AA-C28B7E25CE5D</string>
+			<string>2B7AAFF8-6F66-4E13-89F2-3F0A8BB3F8AD</string>
 			<key>IDESourceControlWCCName</key>
 			<string>cocos2d-iphone</string>
 		</dict>

--- a/cocos2d/CCResponder.m
+++ b/cocos2d/CCResponder.m
@@ -28,6 +28,7 @@
  */
 
 #import "CCResponder.h"
+#import "CCResponder_Private.h"
 #import "CCDirector.h"
 #import "CCDirector_Private.h"
 
@@ -63,6 +64,7 @@
     _userInteractionEnabled = userInteractionEnabled;
     [[[CCDirector sharedDirector] responderManager] markAsDirty];
 }
+
 
 // -----------------------------------------------------------------
 #pragma mark - iOS
@@ -149,5 +151,70 @@
 #endif
 
 // -----------------------------------------------------------------
+#pragma mark - Touch Queueing
+// -----------------------------------------------------------------
+
+- (void)performQueuedTouchesWithEvent:(UIEvent*)event {
+    if (_queuedTouchesBegan && [_queuedTouchesBegan count] > 0)
+    {
+        [self touchesBegan:_queuedTouchesBegan withEvent:event];
+        [_queuedTouchesBegan removeAllObjects];
+    }
+    
+    if (_queuedTouchesMoved && [_queuedTouchesMoved count] > 0)
+    {
+        [self touchesMoved:_queuedTouchesMoved withEvent:event];
+        [_queuedTouchesMoved removeAllObjects];
+    }
+    
+    if (_queuedTouchesEnded && [_queuedTouchesEnded count] > 0)
+    {
+        [self touchesEnded:_queuedTouchesEnded withEvent:event];
+        [_queuedTouchesEnded removeAllObjects];
+    }
+    
+    if (_queuedTouchesCancelled && [_queuedTouchesCancelled count] > 0)
+    {
+        [self touchesCancelled:_queuedTouchesCancelled withEvent:event];
+        [_queuedTouchesCancelled removeAllObjects];
+    }
+}
+
+- (NSMutableSet*)queuedTouchesBegan {
+    if (_queuedTouchesBegan != nil) {
+        return _queuedTouchesBegan;
+    } else {
+        _queuedTouchesBegan = [[NSMutableSet alloc] init];
+        return _queuedTouchesBegan;
+    }
+}
+
+- (NSMutableSet*)queuedTouchesMoved {
+    if (_queuedTouchesMoved != nil) {
+        return _queuedTouchesMoved;
+    } else {
+        _queuedTouchesMoved = [[NSMutableSet alloc] init];
+        return _queuedTouchesMoved;
+    }
+}
+
+- (NSMutableSet*)queuedTouchesCancelled {
+    if (_queuedTouchesCancelled != nil) {
+        return _queuedTouchesCancelled;
+    } else {
+        _queuedTouchesCancelled = [[NSMutableSet alloc] init];
+        return _queuedTouchesCancelled;
+    }
+}
+
+- (NSMutableSet*)queuedTouchesEnded {
+    if (_queuedTouchesEnded != nil) {
+        return _queuedTouchesEnded;
+    } else {
+        _queuedTouchesEnded = [[NSMutableSet alloc] init];
+        return _queuedTouchesEnded;
+    }
+}
+
 
 @end

--- a/cocos2d/CCResponder_Private.h
+++ b/cocos2d/CCResponder_Private.h
@@ -1,0 +1,38 @@
+//
+//  CCResponder__Private.h
+//  cocos2d-ios
+//
+//  Created by Benjamin Encz on 05/12/13.
+//
+//
+
+#import "CCResponder.h"
+
+@interface CCResponder ()
+
+/* Stores queued & grouped touches for the touchesBegan event. Touches will be queued & grouped if multitouch is enabled on a CCResponder and multiple touches occur.
+ @since v3.0
+ */
+@property (nonatomic, strong) NSMutableSet* queuedTouchesBegan;
+
+/* Stores queued & grouped touches for the touchesMoved event. Touches will be queued & grouped if multitouch is enabled on a CCResponder and multiple touches occur.
+ @since v3.0
+ */
+@property (nonatomic, strong) NSMutableSet* queuedTouchesMoved;
+
+/* Stores queued & grouped touches for the touchesCancelled event. Touches will be queued & grouped if multitouch is enabled on a CCResponder and multiple touches occur.
+ @since v3.0
+ */
+@property (nonatomic, strong) NSMutableSet* queuedTouchesCancelled;
+
+/* Stores queued & grouped touches for the touchesEnded event. Touches will be queued & grouped if multitouch is enabled on a CCResponder and multiple touches occur.
+ @since v3.0
+ */
+@property (nonatomic, strong) NSMutableSet* queuedTouchesEnded;
+
+/* Performs all queued touch events. When this method is called the touch event methods (touchesMoved, etc.) will be called on the CCResponder.
+ @since v3.0
+ */
+- (void)performQueuedTouchesWithEvent:(UIEvent*)event;
+
+@end


### PR DESCRIPTION
**Multitouch capability for cocos2d**

In the current implementation on branch develop-v3, UITouches are always sent to CCResponders as single touches, even if multipleTouchEnabled is set to TRUE.

This happens because the current implementation iterates over all touches in the UIEvent and sends them immediately. This change implements a grouping & queueing of touches before in CCResponders before the touch method callbacks are called. 

With this implementation a CCResponder can check how many touches it received and determine if it is handling a single or multitouch.

Example implementation that uses my forked cocos2d: 
https://github.com/MakeGamesWithUs/Tutorial-Touch-Handling/tree/multitouch-cocos2d-test

_Please Note: calls to `- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event` in `CCResponderManager` are currently not grouped, since this would require larger changes in `CCResponderManager`. Suggestions how to solve this are welcome._ 
