### PR TITLE
Fixed screen size mode.

### DIFF
--- a/cocos2d/Platforms/iOS/CCAppDelegate.h
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.h
@@ -56,7 +56,7 @@ NSString* const CCSetupTabletScale2X;
 /**
  *  Most Cocos2d apps should override the CCAppDelegate, it serves as the apps starting point. By the very least, the startScene method should be overridden to return the first scene the app should display. To further customize the behavior of Cocos2d, such as the screen mode of pixel format, override the applicaton:didFinishLaunchingWithOptions: method.
  */
-@interface CCAppDelegate : NSObject <UIApplicationDelegate>
+@interface CCAppDelegate : NSObject <UIApplicationDelegate, CCDirectorDelegate>
 {
     UIWindow *window_;
 	CCNavigationController *navController_;

--- a/cocos2d/Platforms/iOS/CCAppDelegate.h
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.h
@@ -13,36 +13,24 @@
 #import <UIKit/UIKit.h>
 #import "CCDirectorIOS.h"
 
-/**
- *  The screen mode defines how different types of screens and resolutions are handled.
- */
-typedef NS_ENUM(unsigned char, CCScreenMode)
-{
-    /// The flexible screen mode is Cocos2d's default. It will give you an area that can vary slightly in size. In landscape mode the height will be 320 points for mobiles and 384 points for tablets. The width of the area can vary from 480 to 568 points.
-    CCScreenModeFlexible,
-    
-    /// The fixed screen mode will setup the working area to be 568 x 384 points. Depending on the device, the outer edges may be cropped. The safe area, that will be displayed on all sorts of devices, is 480 x 320 points and placed in the center of the working area.
-    CCScreenModeFixed,
-};
-
-/**
- *  The screen orientation defines in which orientation the app is displaying.
- */
-typedef NS_ENUM(unsigned char, CCScreenOrientation)
-{
-    /// Landscape screen orientation
-    CCScreenOrientationLandscape,
-    
-    /// Portrait screen orientation
-    CCScreenOrientationPortrait,
-};
-
 NSString* const CCSetupPixelFormat;
-NSString* const CCSetpScreenMode;
+NSString* const CCSetupScreenMode;
 NSString* const CCSetupScreenOrientation;
 NSString* const CCSetupAnimationInterval;
 NSString* const CCSetupHideDebugStats;
 NSString* const CCSetupTabletScale2X;
+
+
+/// Landscape screen orientation. Used with CCSetupScreenOrientation.
+NSString* const CCScreenOrientationLandscape;
+/// Portrait screen orientation.  Used with CCSetupScreenOrientation.
+NSString* const CCScreenOrientationPortrait;
+
+
+/// The flexible screen mode is Cocos2d's default. It will give you an area that can vary slightly in size. In landscape mode the height will be 320 points for mobiles and 384 points for tablets. The width of the area can vary from 480 to 568 points.
+NSString* const CCScreenModeFlexible;
+/// The fixed screen mode will setup the working area to be 568 x 384 points. Depending on the device, the outer edges may be cropped. The safe area, that will be displayed on all sorts of devices, is 480 x 320 points and placed in the center of the working area.
+NSString* const CCScreenModeFixed;
 
 
 @class CCAppDelegate;
@@ -98,10 +86,11 @@ NSString* const CCSetupTabletScale2X;
  *  Currently supported keys for the configuration dictionary are:
  *
  *  - CCSetupPixelFormat NSString with the pixel format, normally kEAGLColorFormatRGBA8 or kEAGLColorFormatRGB565. The RGB565 option is faster, but will allow less colors.
- *  - CCSetupScreenMode NSNumber with int specifying which CCScreenMode to use, CCScreenModeFlexible is the default option.
+ *  - CCSetupScreenMode NSString value that accepts either CCScreenModeFlexible or CCScreenModeFixed.
+ *  - CCSetupScreenOrientation NSString value that accepts either CCScreenOrientationLandscape or CCScreenOrientationPortrait.
  *  - CCSetupAnimationInterval NSNumber with double. Specifies the interval between animation frames. Supported values are 1.0/60 and 1.0/30.
  *  - CCSetupHideDebugStats NSNumber with bool. Specifies if the stats (FPS, frame time and draw call count) should be hidden when running in debug mode.
- *  - CCSetupTabletScale2X NSNumber with bool. If true, the iPad will be setup to act like it has a 512x384 "retina" screen. This makes it much easier to make universal iOS games.
+ *  - CCSetupTabletScale2X NSNumber with bool. If true, the iPad will be setup to act like it has a 512x384 "retina" screen. This makes it much easier to make universal iOS games. This value is overriden when using the fixed screen mode.
  *
  *  @param config Dictionary with options for configuring Cocos2d.
  */

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -67,6 +67,23 @@ NSString* const CCSetupTabletScale2X = @"CCSetupTabletScale2X";
     }
 }
 
+// Projection delegate is only used if the fixed resolution mode is enabled
+-(void)updateProjection
+{
+	CGSize sizePoint = [CCDirector sharedDirector].viewSize;
+	NSLog(@"viewSize: %@", NSStringFromCGSize(sizePoint));
+	
+	kmGLMatrixMode(KM_GL_PROJECTION);
+	kmGLLoadIdentity();
+	
+	kmMat4 orthoMatrix;
+	kmMat4OrthographicProjection(&orthoMatrix, 0, sizePoint.width, 0, sizePoint.height, -1024, 1024 );
+	kmGLMultMatrix( &orthoMatrix );
+	
+	kmGLMatrixMode(KM_GL_MODELVIEW);
+	kmGLLoadIdentity();
+}
+
 // This is needed for iOS4 and iOS5 in order to ensure
 // that the 1st scene has the correct dimensions
 // This is not needed on iOS6 and could be added to the application:didFinish...
@@ -92,23 +109,6 @@ NSString* const CCSetupTabletScale2X = @"CCSetupTabletScale2X";
 }
 
 CGSize FIXED_SIZE = {568, 384};
-
-// Projection delegate is only used if the fixed resolution mode is enabled
--(void)updateProjection
-{
-	CGSize sizePoint = [CCDirector sharedDirector].viewSize;
-	NSLog(@"viewSize: %@", NSStringFromCGSize(sizePoint));
-	
-	kmGLMatrixMode(KM_GL_PROJECTION);
-	kmGLLoadIdentity();
-	
-	kmMat4 orthoMatrix;
-	kmMat4OrthographicProjection(&orthoMatrix, 0, sizePoint.width, 0, sizePoint.height, -1024, 1024 );
-	kmGLMultMatrix( &orthoMatrix );
-	
-	kmGLMatrixMode(KM_GL_MODELVIEW);
-	kmGLLoadIdentity();
-}
 
 - (void) setupCocos2dWithOptions:(NSDictionary*)config
 {
@@ -203,9 +203,8 @@ CGSize FIXED_SIZE = {568, 384};
 	}
 	
 	// Use the default 2D projection unless the fixed resolution mode is enabled.
-//	[director setProjection:CCDirectorProjection2D];
-	director.delegate = self;
-	[director setProjection:CCDirectorProjectionCustom];
+	[director setProjection:CCDirectorProjection2D];
+//	[director setProjection:CCDirectorProjectionCustom];
 	
 	// Default texture format for PNG/BMP/TIFF/JPEG/GIF images
 	// It can be RGBA8888, RGBA4444, RGB5_A1, RGB565

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -13,6 +13,9 @@
 #import "CCTexture.h"
 #import "CCFileUtils.h"
 
+#import "kazmath/kazmath.h"
+#import "kazmath/GL/matrix.h"
+
 NSString* const CCSetupPixelFormat = @"CCSetupPixelFormat";
 NSString* const CCSetupScreenMode = @"CCSetupScreenMode";
 NSString* const CCSetupScreenOrientation = @"CCSetupScreenOrientation";
@@ -86,6 +89,25 @@ NSString* const CCSetupTabletScale2X = @"CCSetupTabletScale2X";
 {
     NSAssert(NO, @"Override CCAppDelegate and implement the startScene method");
     return NULL;
+}
+
+CGSize FIXED_SIZE = {568, 384};
+
+// Projection delegate is only used if the fixed resolution mode is enabled
+-(void)updateProjection
+{
+	CGSize sizePoint = [CCDirector sharedDirector].viewSize;
+	NSLog(@"viewSize: %@", NSStringFromCGSize(sizePoint));
+	
+	kmGLMatrixMode(KM_GL_PROJECTION);
+	kmGLLoadIdentity();
+	
+	kmMat4 orthoMatrix;
+	kmMat4OrthographicProjection(&orthoMatrix, 0, sizePoint.width, 0, sizePoint.height, -1024, 1024 );
+	kmGLMultMatrix( &orthoMatrix );
+	
+	kmGLMatrixMode(KM_GL_MODELVIEW);
+	kmGLLoadIdentity();
 }
 
 - (void) setupCocos2dWithOptions:(NSDictionary*)config
@@ -180,9 +202,10 @@ NSString* const CCSetupTabletScale2X = @"CCSetupTabletScale2X";
 		[[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
 	}
 	
-	// 2D projection
-	[director setProjection:CCDirectorProjection2D];
-	//	[director setProjection:kCCDirectorProjection3D];
+	// Use the default 2D projection unless the fixed resolution mode is enabled.
+//	[director setProjection:CCDirectorProjection2D];
+	director.delegate = self;
+	[director setProjection:CCDirectorProjectionCustom];
 	
 	// Default texture format for PNG/BMP/TIFF/JPEG/GIF images
 	// It can be RGBA8888, RGBA4444, RGB5_A1, RGB565


### PR DESCRIPTION
Basically done. Still not sure what to do about the viewSize problem mentioned in #413 though. If a dev is using the fixed size mode, there is no way of getting the correct screen size other than hard coding it. Maybe I should just expose the FIXED_SIZE variable and they just need to know to use that instead of CCDirector.viewSize? The default sizes of CCScenes and a few other nodes will be wrong too.

Also, it searches for the smallest power of two that will cover the screen. I'm not convinced this is the best solution, since it will pick a 4x content scale on a 1280x720 Android tablet and cut off a _lot_ of content (1/3 of the width and over half the height). Either the dev needs to ship the game with 3x art (terrible option), or we need to add some letterboxing to avoid severe cropping like this.

I did change some of the enums to NSStrings since this is intended to be used with an NSDictionary. Apple almost always uses strings for dictionary config parameters since wrapping enums in NSNumbers is a little tedious.
