### PR TITLE
Adding a "designSize" property to CCDirector for the fixed size mode.

### DIFF
--- a/cocos2d-ui-tests/tests/CCLabelTTFTest.m
+++ b/cocos2d-ui-tests/tests/CCLabelTTFTest.m
@@ -77,7 +77,7 @@ static int vAlignCount = sizeof(verticalAlignment) / sizeof(*verticalAlignment);
 {
   self.subTitle = @"Test alignment and fonts (click next a bunch of times)";
   
-  CGSize s = [[CCDirector sharedDirector] viewSize];
+  CGSize s = [CCDirector sharedDirector].designSize;
   CGSize blockSize = CGSizeMake(s.width/3, 150);
   CGFloat fontSize = 13;
   

--- a/cocos2d-ui-tests/tests/ParticleTest.m
+++ b/cocos2d-ui-tests/tests/ParticleTest.m
@@ -126,7 +126,7 @@
 -(void) setupMultipleSystems
 {
 
-  CGSize s = [[CCDirector sharedDirector] viewSize];
+  CGSize s = [CCDirector sharedDirector].designSize;
 
   for (int i = 0; i<5; i++) {
     CCParticleSystem *particleSystem = [CCParticleSystem particleWithFile:@"Particles/Flower.plist"];
@@ -218,7 +218,7 @@
   self.emitter.angleVar = 0;
   
   // emitter position
-  CGSize winSize = [[CCDirector sharedDirector] viewSize];
+  CGSize winSize = [CCDirector sharedDirector].designSize;
   self.emitter.position = ccp(winSize.width/2, winSize.height/2);
   self.emitter.posVar = CGPointZero;
   
@@ -251,7 +251,7 @@
   
   self.userInteractionEnabled = TRUE;
   
-  CGSize s = [[CCDirector sharedDirector] viewSize];
+  CGSize s = [CCDirector sharedDirector].designSize;
   
   background = [CCSprite spriteWithImageNamed:@"Images/background3.png"];
   [self.contentNode addChild:background z:5];

--- a/cocos2d-ui/CCBReader/CCBReader.m
+++ b/cocos2d-ui/CCBReader/CCBReader.m
@@ -95,7 +95,7 @@
     loadedSpriteSheets = [[NSMutableSet alloc] init];
     
     // Setup resolution scale and default container size
-    animationManager.rootContainerSize = [[CCDirector sharedDirector] viewSize];
+    animationManager.rootContainerSize = [CCDirector sharedDirector].designSize;
     
     return self;
 }
@@ -1160,7 +1160,7 @@ static inline float readFloat(CCBReader *self)
     
     owner = o;
     
-    self.animationManager.rootContainerSize = [[CCDirector sharedDirector] viewSize];
+    self.animationManager.rootContainerSize = [CCDirector sharedDirector].designSize;
     self.animationManager.owner = owner;
     
     NSMutableDictionary* animationManagers = [NSMutableDictionary dictionary];
@@ -1199,12 +1199,12 @@ static inline float readFloat(CCBReader *self)
 
 - (CCNode*) load:(NSString*) file owner:(id)o
 {
-    return [self nodeGraphFromFile:file owner:o parentSize:[[CCDirector sharedDirector] viewSize]];
+    return [self nodeGraphFromFile:file owner:o parentSize:[CCDirector sharedDirector].designSize];
 }
 
 - (CCNode*) load:(NSString*) file
 {
-    return [self nodeGraphFromFile:file owner:NULL parentSize:[[CCDirector sharedDirector] viewSize]];
+    return [self nodeGraphFromFile:file owner:NULL parentSize:[CCDirector sharedDirector].designSize];
 }
 
 +(void) setResourcePath:(NSString *)searchPath
@@ -1221,7 +1221,7 @@ static inline float readFloat(CCBReader *self)
 
 + (CCNode*) load:(NSString*) file owner:(id)owner
 {
-    return [CCBReader load:file owner:owner parentSize:[[CCDirector sharedDirector] viewSize]];
+    return [CCBReader load:file owner:owner parentSize:[CCDirector sharedDirector].designSize];
 }
 
 + (CCNode*) nodeGraphFromData:(NSData*) data owner:(id)owner parentSize:(CGSize)parentSize
@@ -1241,7 +1241,7 @@ static inline float readFloat(CCBReader *self)
 
 + (CCScene*) loadAsScene:(NSString *)file owner:(id)owner
 {
-    return [CCBReader sceneWithNodeGraphFromFile:file owner:owner parentSize:[[CCDirector sharedDirector] viewSize]];
+    return [CCBReader sceneWithNodeGraphFromFile:file owner:owner parentSize:[CCDirector sharedDirector].designSize];
 }
 
 + (CCScene*) sceneWithNodeGraphFromFile:(NSString *)file owner:(id)owner parentSize:(CGSize)parentSize

--- a/cocos2d/CCDirector.h
+++ b/cocos2d/CCDirector.h
@@ -200,13 +200,17 @@ and when to execute the Scenes.
  */
 @property (nonatomic,readwrite,assign) float UIScaleFactor;
 
+/// User definable value that is used for default contentSizes of many node types (CCScene, CCNodeColor, etc).
+/// Defaults to the view size.
+@property(nonatomic, assign) CGSize designSize;
+
 /** returns a shared instance of the director */
 +(CCDirector*)sharedDirector;
 
 
 #pragma mark Director - Stats
 
-#pragma mark Director - Win Size
+#pragma mark Director - View Size
 /** returns the size of the OpenGL view in points */
 - (CGSize) viewSize;
 

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -431,6 +431,12 @@ GLToClipTransform(kmMat4 *transformOut)
 	return _winSizeInPixels;
 }
 
+-(CGSize)designSize
+{
+	// Return the viewSize unless designSize has been set.
+	return (CGSizeEqualToSize(_designSize, CGSizeZero) ? self.viewSize : _designSize);
+}
+
 -(void) reshapeProjection:(CGSize)newWindowSize
 {
 	_winSizeInPixels = newWindowSize;

--- a/cocos2d/CCNodeColor.m
+++ b/cocos2d/CCNodeColor.m
@@ -80,7 +80,7 @@
 
 -(id) init
 {
-	CGSize s = [[CCDirector sharedDirector] viewSize];
+	CGSize s = [CCDirector sharedDirector].designSize;
 	return [self initWithColor:[CCColor clearColor] width:s.width height:s.height];
 }
 
@@ -114,7 +114,7 @@
 
 - (id) initWithColor:(CCColor*)color
 {
-	CGSize s = [[CCDirector sharedDirector] viewSize];
+	CGSize s = [CCDirector sharedDirector].designSize;
 	return [self initWithColor:color width:s.width height:s.height];
 }
 

--- a/cocos2d/CCScene.m
+++ b/cocos2d/CCScene.m
@@ -41,7 +41,7 @@
 
 -( id )init {
 	if((self = [ super init ])){
-		CGSize s = [[CCDirector sharedDirector] viewSize];
+		CGSize s = [CCDirector sharedDirector].designSize;
 		_anchorPoint = ccp(0.0f, 0.0f);
 		[self setContentSize:s];
 	}

--- a/cocos2d/CCTransition.m
+++ b/cocos2d/CCTransition.m
@@ -110,7 +110,7 @@ typedef NS_ENUM(NSInteger, CCTransitionFixedFunction)
     _outgoingOverIncoming = NO;
     
     // find out where the outgoing scene will end (if it is a transition with movement)
-    CGSize size = [CCDirector sharedDirector].viewSize;
+    CGSize size = [CCDirector sharedDirector].designSize;
     switch (direction) {
         case CCTransitionDirectionDown: _outgoingDestination = CGPointMake(0, -size.height); break;
         case CCTransitionDirectionLeft: _outgoingDestination = CGPointMake(-size.width, 0); break;
@@ -182,7 +182,7 @@ typedef NS_ENUM(NSInteger, CCTransitionFixedFunction)
 
     // create render textures
     // get viewport size
-    CGSize size = [CCDirector sharedDirector].viewSize;
+    CGSize size = [CCDirector sharedDirector].designSize;
 
     // create texture for outgoing scene
     _outgoingTexture = [CCRenderTexture renderTextureWithWidth:size.width / _outgoingDownScale

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -184,6 +184,7 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 		// TODO not 100% certain this is correct in all the weird edge cases.
 		[[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:scaleFactor*2.0];
 		
+		director.designSize = FIXED_SIZE;
 		[director setProjection:CCDirectorProjectionCustom];
 	} else {
 		// Setup tablet scaling if it was requested.


### PR DESCRIPTION
Directly related to the discussion in https://github.com/cocos2d/cocos2d-iphone/issues/413 and https://github.com/cocos2d/cocos2d-iphone/pull/424.

Basically it adds a user definable CCDirector.designSize property that defaults to the value of CCDirector.viewSize. If we add this I really think we should make CCDirector.viewSizeInPixels private so there aren't so many methods that do nearly the same thing.
