### PR TITLE
CCColor Fixes

### DIFF
--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -1236,13 +1236,10 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 {
 	id<CCRGBAProtocol> tn = (id<CCRGBAProtocol>) _target;
     
-    CGFloat fr, fg, fb, fa;
-    [_from getRed:&fr green:&fg blue:&fb alpha:&fa];
+    ccColor4F fc = _from.ccColor4f;
+    ccColor4F tc = _to.ccColor4f;
     
-    CGFloat tr, tg, tb, ta;
-    [_to getRed:&tr green:&tg blue:&tb alpha:&ta];
-    
-	[tn setColor:[CCColor colorWithRed:fr + (tr - fr) * t green:fg + (tg - fg) * t blue:fb + (tb - fb) * t alpha:1]];
+	[tn setColor:[CCColor colorWithRed:fc.r + (tc.r - fc.r) * t green:fc.g + (tc.g - fc.g) * t blue:fc.b + (tc.b - fc.b) * t alpha:1]];
 }
 @end
 
@@ -1278,12 +1275,9 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 	id<CCRGBAProtocol> tn = (id<CCRGBAProtocol>) _target;
 	CCColor* color = [tn color];
     
-    CGFloat r, g, b, a;
-    [color getRed:&r green:&g blue:&b alpha:&a];
-    
-	_fromR = r;
-	_fromG = g;
-	_fromB = b;
+	_fromR = color.red;
+	_fromG = color.green;
+	_fromB = color.blue;
 }
 
 -(void) update: (CCTime) t

--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -943,12 +943,10 @@ void FNTConfigRemoveCache( void )
 
 - (void)updateDisplayedColor:(CCColor*)parentColor
 {
-    CGFloat r,g,b,a;
-    [parentColor getRed:&r green:&g blue:&b alpha:&a];
-    
-	_displayedColor.r = _realColor.r * r;
-	_displayedColor.g = _realColor.g * g;
-	_displayedColor.b = _realColor.b * b;
+
+	_displayedColor.r = _realColor.r * parentColor.red;
+	_displayedColor.g = _realColor.g * parentColor.green;
+	_displayedColor.b = _realColor.b * parentColor.blue;
 
 	for (CCSprite* item in _children) {
 		[item updateDisplayedColor:[CCColor colorWithCcColor3b:_displayedColor]];

--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -400,10 +400,7 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
             useFullColor = YES;
         }
         
-        CGFloat r,g,b,a;
-        [_fontColor getRed:&r green:&g blue:&b alpha:&a];
-        
-        NSColor* color = [NSColor colorWithCalibratedRed:r green:g blue:b alpha:a];
+        NSColor* color = [NSColor colorWithCalibratedRed:_fontColor.red green:_fontColor.green blue:_fontColor.blue alpha:_fontColor.alpha];
         
         [formattedAttributedString addAttribute:NSForegroundColorAttributeName value:color range:fullRange];
     }
@@ -688,10 +685,8 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
         
         if (hasShadow)
         {
-            CGFloat r, g, b, a;
-            [_shadowColor getRed:&r green:&g blue:&b alpha:&a];
-            
-            NSColor* color = [NSColor colorWithCalibratedRed:r green:g blue:b alpha:a];
+
+            NSColor* color = [NSColor colorWithCalibratedRed:_shadowColor.red green:_shadowColor.green blue:_shadowColor.blue alpha:_shadowColor.alpha];
             
             CGContextSetShadowWithColor(context, CGSizeMake(shadowOffset.x/retinaFix, shadowOffset.y/retinaFix), shadowBlurRadius/retinaFix, [color CGColor]);
         }
@@ -703,10 +698,7 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
             CGContextSetLineWidth(context, outlineWidth * 2);
             CGContextSetLineJoin(context, kCGLineJoinRound);
             
-            CGFloat r, g, b, a;
-            [_outlineColor getRed:&r green:&g blue:&b alpha:&a];
-            
-            NSColor* color = [NSColor colorWithCalibratedRed:r green:g blue:b alpha:a];
+            NSColor* color = [NSColor colorWithCalibratedRed:_outlineColor.red green:_outlineColor.green blue:_outlineColor.blue alpha:_outlineColor.alpha];
             
             [effectsString addAttribute:NSForegroundColorAttributeName value:color range:NSMakeRange(0, effectsString.length)];
             
@@ -948,12 +940,11 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
     // Handle outline
     if (hasOutline)
     {
-        float r, g, b, a;
-        [_outlineColor getRed:&r green:&g blue:&b alpha:&a];
+        ccColor4F outlineColor = _outlineColor.ccColor4f;
         
         CGContextSetTextDrawingMode(context, kCGTextFillStroke);
-        CGContextSetRGBStrokeColor(context, r, g, b, a);
-        CGContextSetRGBFillColor(context, r, g, b, a);
+        CGContextSetRGBStrokeColor(context, outlineColor.r, outlineColor.g, outlineColor.b, outlineColor.a);
+        CGContextSetRGBFillColor(context, outlineColor.r, outlineColor.g, outlineColor.b, outlineColor.a);
         CGContextSetLineWidth(context, outlineWidth * 2);
         CGContextSetLineJoin(context, kCGLineJoinRound);
         
@@ -972,10 +963,7 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
     }
     
     // Handle font color
-    float r, g, b, a;
-    [_fontColor getRed:&r green:&g blue:&b alpha:&a];
-    
-    UIColor* color = [UIColor colorWithRed:r green:g blue:b alpha:a];
+    UIColor* color = [UIColor colorWithRed:_fontColor.red green:_fontColor.green blue:_fontColor.blue alpha:_fontColor.alpha];
     [color set];
     
     [string drawInRect:drawArea withFont:font lineBreakMode:0 alignment:(int)_horizontalAlignment];

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -1584,12 +1584,9 @@ RecursivelyIncrementPausedAncestors(CCNode *node, int increment)
 
 - (void)updateDisplayedColor:(CCColor*)parentColor
 {
-    CGFloat r, g, b, a;
-    [parentColor getRed:&r green:&g blue:&b alpha:&a];
-    
-	_displayedColor.r = _realColor.r * r;
-	_displayedColor.g = _realColor.g * g;
-	_displayedColor.b = _realColor.b * b;
+	_displayedColor.r = _realColor.r * parentColor.red;
+	_displayedColor.g = _realColor.g * parentColor.green;
+	_displayedColor.b = _realColor.b * parentColor.blue;
 
     if (_cascadeColorEnabled) {
         for (id<CCRGBAProtocol> item in _children) {


### PR DESCRIPTION
Methods that call 'CCColor getRed:...' in iOS can't assume the Colorspace is RGB and will not work as expected (a few things will default to whiteColor which is in Mono Space).
In OSX this method should be fine however I refactored usage for consistency.
