### PR TITLE
OSX Template fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -293,7 +293,7 @@ if $INSTALL ; then
 	copy_files "external/Chipmunk_download/Chipmunk/objectivec/src" "$LIBS_DIR/Chipmunk/objectivec"
 	copy_files "external/Chipmunk_download/Chipmunk/include" "$LIBS_DIR/Chipmunk/chipmunk"
 	copy_files "external/Chipmunk_download/Chipmunk/src" "$LIBS_DIR/Chipmunk/chipmunk"
-	copy_files "external/Chipmunk_download/Chipmunk/LICENSE.txt" "$LIBS_DIR/Chipmunk"
+	copy_files "LICENSE_Chipmunk.txt" "$LIBS_DIR"
 	rm -rf "${DOWNLOAD_DIR}" 1>/dev/null 2>>"${ERROR_LOG}"
     check_status
 	printf " ${GREEN}✔${COLOREND}\n"

--- a/templates/Support/Base/base_osx.xctemplate/TemplateInfo.plist
+++ b/templates/Support/Base/base_osx.xctemplate/TemplateInfo.plist
@@ -45,9 +45,12 @@
 					<string>-lz</string>
 					<string>-lsqlite3</string>
 					<string>-ObjC</string>
-					<string>-weak_library $PROJECT_NAME/Libraries/Chipmunk/objectivec/libObjectiveChipmunk.a</string>						
 				</array>
 			</dict>
+			<key>ProductDependencies</key>
+			<array>
+				<integer>1</integer>
+			</array>
 			<key>Frameworks</key>
 			<array>
 				<string>QuartzCore</string>
@@ -69,10 +72,16 @@
 				</dict>
 				<key>Release</key>
 				<dict>
+					<key>VALIDATE_PRODUCT</key>
+					<string>YES</string>
 					<key>COPY_PHASE_STRIP</key>
 					<string>YES</string>
 				</dict>
 			</dict>
+			<key>Dependencies</key>
+			<array>
+				<integer>1</integer>
+			</array>
 		</dict>
 	</array>
 	<key>Platforms</key>

--- a/templates/cocos2d OS X.xctemplate/TemplateInfo.plist
+++ b/templates/cocos2d OS X.xctemplate/TemplateInfo.plist
@@ -38,6 +38,10 @@
 			<string>Supporting Files</string>
 			<key>Path</key>
 			<string>Supporting Files/main.m</string>
+			<key>TargetIndices</key>
+			<array>
+				<integer>0</integer>
+			</array>
 		</dict>
 		<key>Classes/HelloWorldLayer.h</key>
 		<dict>
@@ -54,6 +58,10 @@
 			<string>Classes</string>			
 			<key>Path</key>
 			<string>Classes/HelloWorldLayer.m</string>
+			<key>TargetIndices</key>
+			<array>
+				<integer>0</integer>
+			</array>
 		</dict>
 		<key>Classes/AppDelegate.h</key>
 		<dict>
@@ -70,6 +78,10 @@
 			<string>Classes</string>			
 			<key>Path</key>
 			<string>Classes/AppDelegate.m</string>
+			<key>TargetIndices</key>
+			<array>
+				<integer>0</integer>
+			</array>
 		</dict>
 	</dict>
 	<key>Nodes</key>


### PR DESCRIPTION
This fixes some of the template problems (mainly on OSX) I've noticed. Project from OS X template now builds with only three warnings regarding deprecation of "Gestalt()", otherwise builds fine.
