### PR TITLE
Fixing a typo in comments in onEnter in two Scene files in the new project template

### DIFF
--- a/cocos2d/CCTransition.h
+++ b/cocos2d/CCTransition.h
@@ -68,11 +68,17 @@ typedef NS_ENUM(NSInteger, CCTransitionDirection)
 
 
 /**
- *  Will downscale incoming and outgoing scene.
+ *  Will downscale outgoing scene.
  *  Can be used as an effect, or to decrease render time on complex scenes.
  *  Default 1.0.
  */
 @property (nonatomic, assign) float outgoingDownScale;
+
+/**
+ *  Will downscale incoming scene.
+ *  Can be used as an effect, or to decrease render time on complex scenes.
+ *  Default 1.0.
+ */
 @property (nonatomic, assign) float incomingDownScale;
 
 /**
@@ -89,10 +95,15 @@ typedef NS_ENUM(NSInteger, CCTransitionDirection)
 @property (nonatomic, assign) CCTexturePixelFormat transitionPixelFormat;
 
 /**
- *  Defines whether incoming and outgoing scene will be animated during transition.
+ *  Defines whether outgoing scene will be animated during transition.
  *  Default NO.
  */
 @property (nonatomic, getter = isOutgoingSceneAnimated) BOOL outgoingSceneAnimated;
+
+/**
+ *  Defines whether incoming scene will be animated during transition.
+ *  Default NO.
+ */
 @property (nonatomic, getter = isIncomingSceneAnimated) BOOL incomingSceneAnimated;
 
 /** The actual transition runtime in seconds. */

--- a/templates/cocos2d iOS.xctemplate/Classes/HelloWorldScene.m
+++ b/templates/cocos2d iOS.xctemplate/Classes/HelloWorldScene.m
@@ -82,7 +82,7 @@
     
     // In pre-v3, touch enable and scheduleUpdate was called here
     // In v3, touch is enabled by setting userInterActionEnabled for the individual nodes
-    // Pr frame update is automatically enabled, if update is overridden
+    // Per frame update is automatically enabled, if update is overridden
     
 }
 

--- a/templates/cocos2d iOS.xctemplate/Newton/NewtonScene.m
+++ b/templates/cocos2d iOS.xctemplate/Newton/NewtonScene.m
@@ -189,7 +189,7 @@
     
     // In pre-v3, touch enable and scheduleUpdate was called here
     // In v3, touch is enabled by setting userInterActionEnabled for the individual nodes
-    // Pr frame update is automatically enabled, if update is overridden
+    // Per frame update is automatically enabled, if update is overridden
     
     // Basically this will result in fewer having the need to override onEnter and onExit, but for clarity, it is shown
 }


### PR DESCRIPTION
Both NewtonScene.m and HelloWorldScene.m have 'Pr' rather than 'Per' in a comment in the onEnter method.
