### PR TITLE
Fixed issue #536

### DIFF
--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -605,11 +605,8 @@ GetPositionFromBody(CCNode *node, CCPhysicsBody *body)
 -(CCNode*) getChildByName:(NSString *)name recursively:(bool)isRecursive
 {
 	NSAssert(name, @"name is NULL");
-	if([self.name isEqualToString:name]){
-		return self;
-	}
-	
-  for (CCNode* node in _children) {
+
+  	for (CCNode* node in _children) {
 		if(isRecursive){
 			// Recurse:
 			CCNode* n = [node getChildByName:name recursively:isRecursive];


### PR DESCRIPTION
getChildByName now does not check if the CCNode itself has the name we're looking for.

This needs review form the core team to make sure that this change does not break anything else though.
