### PR TITLE
When the TextureTest is run and exited back to the list of tests the file search paths are left incorrect

### DIFF
--- a/cocos2d-ui-tests/tests/TextureTest.m
+++ b/cocos2d-ui-tests/tests/TextureTest.m
@@ -22,7 +22,19 @@
 {
 	[self.contentNode removeAllChildren];
 	[CCTextureCache purgeSharedTextureCache];
-	[[CCFileUtils sharedFileUtils] setSearchPath: @[ @"Images", kCCFileUtilsDefaultSearchPath] ];
+	NSMutableArray *newSearchPaths = [[[CCFileUtils sharedFileUtils] searchPath] mutableCopy];
+	[newSearchPaths insertObject:@"Images" atIndex:0];
+	[[CCFileUtils sharedFileUtils] setSearchPath: newSearchPaths ];
+}
+
+- (void) pressedBack:(id)sender
+{
+	[super pressedBack:sender];
+	
+	// Restore the FileUtils search path(s) to what they were before we added "Images"
+	NSMutableArray *oldSearchPaths = [[[CCFileUtils sharedFileUtils] searchPath] mutableCopy];
+	[oldSearchPaths removeObject:@"Images"];
+	[[CCFileUtils sharedFileUtils] setSearchPath:oldSearchPaths];
 }
 
 - (CCSprite *) loadAndDisplayImageNamed:(NSString*) fileName withTitle:(NSString*) title{


### PR DESCRIPTION
The setup method of the TextureTest purges the shared texture cache and the sets the CCFIleUtils search paths to "Images" and the DefaultSearchPath (which is ""). On exiting the test it does not restore the previous setting of the search paths.

This causes problems:
1) the search paths are initially "Resources-shared" and "" - so once the paths are changed the UI interface files can't be loaded
2) Once the test exits no other tests can load/access things like the Interface.png texture

The fix:
1) Pre-pend the "Images" path to the existing search paths
2) Remove the "Images" path on exiting the test (pressedBack method)

NB: The ParticleTest and ColorTest also do the same overwrite of the search paths but suffer less bad effects as they don't purge the texture cache. They should still also be fixed to correct the problem I think.
