### PR TITLE
fixes memory leak in CCActionManager

### DIFF
--- a/cocos2d/CCActionManager.m
+++ b/cocos2d/CCActionManager.m
@@ -81,13 +81,13 @@
 
 -(void) actionAllocWithHashElement:(tHashElement*)element
 {
-    NSMutableArray* aObj = [[NSMutableArray alloc] init];
-    void* a = (__bridge void*) aObj;
-    CFRetain(a);
-    
 	// 4 actions per Node by default
-	if( element->actions == nil )
+	if( element->actions == nil ) {
+        NSMutableArray* aObj = [[NSMutableArray alloc] init];
+        void* a = (__bridge void*) aObj;
+        CFRetain(a);
 		element->actions = aObj;
+    }
 }
 
 -(void) removeActionAtIndex:(NSUInteger)index hashElement:(tHashElement*)element

--- a/cocos2d/CCActionManager.m
+++ b/cocos2d/CCActionManager.m
@@ -81,7 +81,7 @@
 
 -(void) actionAllocWithHashElement:(tHashElement*)element
 {
-	// 4 actions per Node by default
+	// if actions array doesn't exist yet, create one
 	if( element->actions == nil ) {
         NSMutableArray* aObj = [[NSMutableArray alloc] init];
         void* a = (__bridge void*) aObj;


### PR DESCRIPTION
Fixes a memory leak in CCActionManager. With the old implementation, if the _actions_ array already existed a NSMutableArray would be initialized and retained but the pointer to this array would not be assigned to anyone, resulting in a dangling retained object and a memory leak.
