### PR TITLE
CCLayoutBox incorrectly positions children in vertical direction

### DIFF
--- a/cocos2d/CCActionEase.h
+++ b/cocos2d/CCActionEase.h
@@ -91,6 +91,30 @@
 
 @end
 
+#pragma mark - Ease Sine Actions
+/**
+ *  This action will start the specified action with an sine effect.
+ *
+ *  Note: This action doesn't use a bijective function, actions like CCActionSequence might have an unexpected result when used with this action.
+ */
+@interface CCActionEaseSineIn : CCActionEase <NSCopying>
+@end
+
+/**
+ *  This action will start the specified action with an sine effect.
+ *
+ *  Note: This action doesn't use a bijective function, actions like CCActionSequence might have an unexpected result when used with this action.
+ */
+@interface CCActionEaseSineOut : CCActionEase <NSCopying>
+@end
+
+/**
+ *  This action will start the specified action with an sine effect.
+ *
+ *  Note: This action doesn't use a bijective function, actions like CCActionSequence might have an unexpected result when used with this action.
+ */
+@interface CCActionEaseSineInOut : CCActionEase <NSCopying>
+@end
 
 #pragma mark - Ease Rate Actions
 /** 

--- a/cocos2d/CCActionEase.m
+++ b/cocos2d/CCActionEase.m
@@ -93,6 +93,48 @@
 @end
 
 
+#pragma mark - Ease Sine Actions
+
+//
+// EaseSineIn
+//
+@implementation CCActionEaseSineIn
+-(void) update: (CCTime) t
+{
+	[_inner update:-1*cosf(t * (float)M_PI_2) +1];
+}
+
+- (CCActionInterval*) reverse
+{
+	return [CCActionEaseSineOut actionWithAction: [_inner reverse]];
+}
+@end
+
+//
+// EaseSineOut
+//
+@implementation CCActionEaseSineOut
+-(void) update: (CCTime) t
+{
+	[_inner update:sinf(t * (float)M_PI_2)];
+}
+
+- (CCActionInterval*) reverse
+{
+	return [CCActionEaseSineIn actionWithAction: [_inner reverse]];
+}
+@end
+
+//
+// EaseSineInOut
+//
+@implementation CCActionEaseSineInOut
+-(void) update: (CCTime) t
+{
+	[_inner update:-0.5f*(cosf( (float)M_PI*t) - 1)];
+}
+@end
+
 #pragma mark -
 #pragma mark EaseRate
 

--- a/cocos2d/CCLayoutBox.m
+++ b/cocos2d/CCLayoutBox.m
@@ -84,7 +84,7 @@ static float roundUpToEven(float f)
         
         // Position the nodes
         float height = 0;
-        for (CCNode* child in self.children)
+        for (CCNode* child in [[self.children reverseObjectEnumerator] allObjects])
         {
             CGSize childSize = child.contentSizeInPoints;
             


### PR DESCRIPTION
Children are shown in reverse order when added to vertical layout box. With horizontal it works as expected. This pull request fixes the problem
