### PR TITLE
CCLayoutBox incorrectly positions children in vertical direction

### DIFF
--- a/cocos2d/CCLayoutBox.m
+++ b/cocos2d/CCLayoutBox.m
@@ -84,7 +84,7 @@ static float roundUpToEven(float f)
         
         // Position the nodes
         float height = 0;
-        for (CCNode* child in self.children)
+        for (CCNode* child in [[self.children reverseObjectEnumerator] allObjects])
         {
             CGSize childSize = child.contentSizeInPoints;
             


### PR DESCRIPTION
Children are shown in reverse order when added to vertical layout box. With horizontal it works as expected.
