### PR TITLE
Fixing a leak in CCControl

### DIFF
--- a/cocos2d-ui/CCControl.m
+++ b/cocos2d-ui/CCControl.m
@@ -59,7 +59,7 @@
 
 - (void) setTarget:(id)target selector:(SEL)selector
 {
-    __unsafe_unretained id weakTarget = target; // avoid retain cycle
+    __weak id weakTarget = target; // avoid retain cycle
     [self setBlock:^(id sender) {
         objc_msgSend(weakTarget, selector, sender);
 	}];


### PR DESCRIPTION
This was the cause of a crash if the you repeatedly pressed a CCButton in short succession. The target wasn't deallocated and it crashed with EXC_BAD_ACCESS (code 1), which is an invalid pointer. This should fix it and since the deployment target is >= 5.0 there's no reason for it to be unsafe unretained. 
