### PR TITLE
updated setZOrder: in CCNode.m

### DIFF
--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -593,10 +593,10 @@ GetPositionFromBody(CCNode *node, CCPhysicsBody *body)
 
 - (void) setZOrder:(NSInteger)zOrder
 {
-	[self _setZOrder:zOrder];
-
     if (_parent)
         [_parent reorderChild:self z:zOrder];
+    else
+    	[self _setZOrder:zOrder]; // issue #598
 }
 
 #pragma mark CCNode Composition


### PR DESCRIPTION
setting the zOrder of the current node is redundant if parent is present and will directly interfere with if( z == child.zOrder ) check in reorderChild:z: from CCSprite, CCSpriteBatchNode and CCParticleBatchNode causing them to defer from reordering their children. 

this is related to issue #598.
