### PR TITLE
updated swap:withNewIndex: in CCSpriteBatchNode.m

### DIFF
--- a/cocos2d/CCSpriteBatchNode.m
+++ b/cocos2d/CCSpriteBatchNode.m
@@ -337,6 +337,10 @@ const NSUInteger defaultCapacity = 0;
     //update the index of other swapped item
 	( ( CCSprite* )[ _descendants objectAtIndex:newIndex ] ).atlasIndex = oldIndex;
     [_descendants exchangeObjectAtIndex:oldIndex withObjectAtIndex:newIndex];
+    
+    // update the quads for the swapped sprites in the textureAtlas (issue #598)
+    _textureAtlas.quads[newIndex] = [(CCSprite *)[_descendants objectAtIndex:newIndex] quad];
+    _textureAtlas.quads[oldIndex] = [(CCSprite *)[_descendants objectAtIndex:oldIndex] quad];
 }
 
 - (void) reorderBatch:(BOOL) reorder


### PR DESCRIPTION
textureAtlas quads are not updated to reflect changes to the atlas index of a swapped object. in consequence the draw order does not change. 

related to issue #598.
