### PR TITLE
issue #632 : 2x scale on not full screen mode in Mac-retina graphics

### DIFF
--- a/cocos2d/Platforms/Mac/CCDirectorMac.m
+++ b/cocos2d/Platforms/Mac/CCDirectorMac.m
@@ -150,7 +150,10 @@
 
         // Show the fullscreen window
         [_fullScreenWindow makeKeyAndOrderFront:self];
-		[_fullScreenWindow makeMainWindow];
+        [_fullScreenWindow makeMainWindow];
+        // issue #632
+        self.view.wantsBestResolutionOpenGLSurface = NO;
+
 
     } else {
 
@@ -168,7 +171,10 @@
 
         // Show the window
         [_windowGLView makeKeyAndOrderFront:self];
-		[_windowGLView makeMainWindow];
+        [_windowGLView makeMainWindow];
+        // issue #632
+        self.view.wantsBestResolutionOpenGLSurface = YES;
+
     }
 	
 	// issue #1189


### PR DESCRIPTION
there is some bug on v3 RC 3. if is was not full screen mode, sprite is 2x scale.
when each mode(full screen mode or not) is called, it will set view.wantsBestResolutionOpenGLSurface is NO or YES
