### PR TITLE
Re-add CCAnimation.h and CCAnimationCache.h to cocos2d.h

### DIFF
--- a/cocos2d/cocos2d.h
+++ b/cocos2d/cocos2d.h
@@ -57,6 +57,8 @@
 #import "CCActionInterval.h"
 #import "CCActionProgressTimer.h"
 #import "CCActionTween.h"
+#import "CCAnimation.h"
+#import "CCAnimationCache.h"
 #import "CCClippingNode.h"
 #import "CCColor.h"
 #import "CCConfiguration.h"
@@ -107,8 +109,6 @@
 #import "OALSimpleAudio.h"
 
 // Retiring
-//#import "CCAnimation.h"
-//#import "CCAnimationCache.h"
 //#import "CCActionManager.h"
 //#import "ccFPSImages.h"
 //#import "CCAtlasNode.h"


### PR DESCRIPTION
As the replacement CCAnimationNode hasn't made it into 3.0, these ought to be back in the main header.
