### PR TITLE
Fix CCProxy memory leak

### DIFF
--- a/cocos2d/CCSpriteFrame.h
+++ b/cocos2d/CCSpriteFrame.h
@@ -47,7 +47,7 @@
 	CGSize			_originalSizeInPixels;
 	CCTexture		*_texture;
 	NSString		*_textureFilename;
-	CCProxy *_proxy;
+	CCProxy __weak *_proxy;
 }
 
 


### PR DESCRIPTION
CCProxy was being retained by CCSpriteFrame resulting in a retain cycle
