### PR TITLE
Fix outline color on CCLabelTTF

### DIFF
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -650,10 +650,9 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
         CGContextSetTextDrawingMode(context, kCGTextFillStroke);
         CGContextSetLineWidth(context, outlineWidth * 2);
         CGContextSetLineJoin(context, kCGLineJoinRound);
-        CGContextSetStrokeColorWithColor(context, [color CGColor]);
-        
+
         NSMutableAttributedString* outlineString = [attributedString mutableCopy];
-        [outlineString removeAttribute:NSForegroundColorAttributeName range:NSMakeRange(0, outlineString.length)];
+        [outlineString addAttribute:NSForegroundColorAttributeName value:color range:NSMakeRange(0, outlineString.length)];
         
         [outlineString drawInRect:drawArea];
         


### PR DESCRIPTION
Without this, the outline would always be black.

Tested on devices running iOS 6.1.3 and 7.0.6. Shadows with different color/offset works, as does the outline width (it seems NSAttributedString doesn't explicitly set line width, like it does with the foreground color). shadowBlurRadius does work.

Note: This is a resubmission of pull request #636 which was closed during the apocalypse.
