### PR TITLE
Add popToRootSceneWithTransition: to CCDirector.

### DIFF
--- a/cocos2d/CCDirector.h
+++ b/cocos2d/CCDirector.h
@@ -316,6 +316,13 @@ and when to execute the Scenes.
  */
 - (void) popToRootScene;
 
+/**Pops out all scenes from the queue until the root scene in the queue, using a transition
+ *
+ * This scene will replace the running one.
+ * Internally it will call `popToRootScene`
+ */
+-(void) popToRootSceneWithTransition:(CCTransition *)transition;
+
 /** Replaces the running scene with a new one. The running scene is terminated.
  *
  * ONLY call it if there is a running scene.

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -586,6 +586,12 @@ static CCDirector *_sharedDirector = nil;
 	[self popToSceneStackLevel:1];
 }
 
+-(void) popToRootSceneWithTransition:(CCTransition *)transition {
+	[self popToRootScene];
+	_sendCleanupToScene = YES;
+	[transition performSelector:@selector(startTransition:) withObject:_nextScene];
+}
+
 -(void) popToSceneStackLevel:(NSUInteger)level
 {
 	NSAssert(_runningScene != nil, @"A running Scene is needed");


### PR DESCRIPTION
Adds a version of popToRootScene that takes a CCTransition object, to match the `WithTransition:` versions of `popScene`, `presentScene`, `pushScene` and `replaceScene`.
