### PR TITLE
Avoid a heap alloc of NSUInteger in [CCNode visit]

### DIFF
--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -898,7 +898,7 @@ RecursivelyIncrementPausedAncestors(CCNode *node, int increment)
 
 		[self sortAllChildren];
 
-		NSUInteger i = 0;
+		int i = 0;
 
 		// draw children zOrder < 0
 		for( ; i < _children.count; i++ ) {


### PR DESCRIPTION
While profiling a Cocos2d project I noticed that [CCNode visit] was allocating and deallocating an object every call. Some testing showed that changing the NSUInteger to an int removed this alloc/dealloc and resulted in a minor speedup for that method.
