### PR TITLE
CCNode setPaused different behavior proposal...

### DIFF
--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -524,9 +524,6 @@
 		A06BF84C168109170018A802 /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
 		A06D9C131728D5F600704732 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
 		A0707F6215F946E9001C1263 /* LICENSE_CCBReader.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_CCBReader.txt; sourceTree = "<group>"; };
-		A0707F6315F946E9001C1263 /* LICENSE_JRSwizzle.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_JRSwizzle.txt; sourceTree = "<group>"; };
-		A0707F6415F946E9001C1263 /* LICENSE_jsbindings.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_jsbindings.txt; sourceTree = "<group>"; };
-		A0707F6515F946E9001C1263 /* LICENSE_SpiderMonkey.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_SpiderMonkey.txt; sourceTree = "<group>"; };
 		A07EC9B2141A8D32008C1F12 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		A08C378E14144FBB004538FD /* neon_matrix_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neon_matrix_impl.h; sourceTree = "<group>"; };
 		A08C379014144FDE004538FD /* neon_matrix_impl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = neon_matrix_impl.c; sourceTree = "<group>"; };
@@ -701,11 +698,8 @@
 		E02BB702126CADEA006E46A2 /* CCAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCAnimation.h; sourceTree = "<group>"; };
 		E02BB703126CADEA006E46A2 /* CCAnimation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCAnimation.m; sourceTree = "<group>"; };
 		E0BC7D6E1342CC58001B4DCC /* LICENSE_artwork.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_artwork.txt; sourceTree = "<group>"; };
-		E0BC7D6F1342CC58001B4DCC /* LICENSE_Box2D.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_Box2D.txt; sourceTree = "<group>"; };
-		E0BC7D701342CC58001B4DCC /* LICENSE_Chipmunk.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_Chipmunk.txt; sourceTree = "<group>"; };
 		E0BC7D711342CC58001B4DCC /* LICENSE_cocos2d.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_cocos2d.txt; sourceTree = "<group>"; };
 		E0BC7D721342CC58001B4DCC /* LICENSE_CocosDenshion.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_CocosDenshion.txt; sourceTree = "<group>"; };
-		E0BC7D741342CC58001B4DCC /* LICENSE_libpng.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE_libpng.txt; sourceTree = "<group>"; };
 		E0BC7D991342CE7B001B4DCC /* CCShaderCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCShaderCache.h; sourceTree = "<group>"; };
 		E0BC7D9A1342CE7B001B4DCC /* CCShaderCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCShaderCache.m; sourceTree = "<group>"; };
 		E0BC7D9B1342CE7B001B4DCC /* CCGLProgram.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCGLProgram.h; sourceTree = "<group>"; };
@@ -768,15 +762,9 @@
 				50AC0A500EC34DD400EB5EDC /* DONORS */,
 				E0BC7D711342CC58001B4DCC /* LICENSE_cocos2d.txt */,
 				E0BC7D6E1342CC58001B4DCC /* LICENSE_artwork.txt */,
-				E0BC7D6F1342CC58001B4DCC /* LICENSE_Box2D.txt */,
-				E0BC7D701342CC58001B4DCC /* LICENSE_Chipmunk.txt */,
 				E0BC7D721342CC58001B4DCC /* LICENSE_CocosDenshion.txt */,
-				E0BC7D741342CC58001B4DCC /* LICENSE_libpng.txt */,
 				A060106813C2992800BB6F49 /* LICENSE_Kazmath.txt */,
 				A0707F6215F946E9001C1263 /* LICENSE_CCBReader.txt */,
-				A0707F6315F946E9001C1263 /* LICENSE_JRSwizzle.txt */,
-				A0707F6415F946E9001C1263 /* LICENSE_jsbindings.txt */,
-				A0707F6515F946E9001C1263 /* LICENSE_SpiderMonkey.txt */,
 				5018F2510DFDEAFF00C013A5 /* cocos2d */,
 				B78AE45917E7AF010028BE0B /* cocos2d-ui */,
 				501756090F335CE900624901 /* external */,

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -1253,13 +1253,11 @@ CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
 
 -(void)setPaused:(BOOL)paused
 {
-	if(_paused != paused){
-		BOOL wasRunning = self.runningInActiveScene;
-		_paused = paused;
-		[self wasRunning:wasRunning];
-		
-		RecursivelyIncrementPausedAncestors(self, (paused ? 1 : -1));
-	}
+	BOOL wasRunning = self.runningInActiveScene;
+	_paused = paused;
+	[self wasRunning:wasRunning];
+	
+	RecursivelyIncrementPausedAncestors(self, (paused ? 1 : -1));
 }
 
 #pragma mark CCNode Transform


### PR DESCRIPTION
I have setup with **gameScene** (self) and animated **pauseLayer** as a child. With current cocos2d version if I do:

``` Obj-C
self.paused = YES;
self.pauseLayer.paused = NO;
```

animated _pauseLayer_ will not show, because its parent is already paused and _pauseLayer_ will not change its paused status. But if I remove **if statement** from the code, everything works as expected. So I have more control over which children are paused and which are not. I don't know if removing those lines have other implications, so please somebody else test it.

I know somebody suggested other approaches, like adding all game content to _self.someNode_ and then pausing only _someNode_, which works great, except I also want to pause all other schedulers and actions that are run on self and it's impossible this way, as self in that case isn't paused...

Best
