### PR TITLE
Bugfix: Shadows overlapping/glow in stroke.

### DIFF
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -655,17 +655,16 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
         [outlineString addAttribute:NSForegroundColorAttributeName value:color range:NSMakeRange(0, outlineString.length)];
         
         [outlineString drawInRect:drawArea];
-        
-        CGContextSetTextDrawingMode(context, kCGTextFill);
-        
+
         // Don't draw shadow for main font
         CGContextSetShadowWithColor(context, CGSizeZero, 0, NULL);
-        
+
         if (hasShadow)
         {
             // Draw outline again because shadow overlap
             [outlineString drawInRect:drawArea];
         }
+        CGContextSetTextDrawingMode(context, kCGTextFill);
     }
     
     [attributedString drawInRect:drawArea];


### PR DESCRIPTION
The second draw of the stroke/outline was done with the wrong text fill mode, so it never had any impact to draw over the shadow glitches.
