### PR TITLE
Update CCTiledMap.m

### DIFF
--- a/cocos2d/CCTiledMap.m
+++ b/cocos2d/CCTiledMap.m
@@ -132,6 +132,12 @@
 -(id) parseLayer:(CCTiledMapLayerInfo*)layerInfo map:(CCTiledMapInfo*)mapInfo
 {
 	CCTiledMapTilesetInfo *tileset = [self tilesetForLayer:layerInfo map:mapInfo];
+	
+	// if the tileset is empty, return a nil layer
+	if(tileset == nil){
+		return nil;
+	}
+	
 	CCTiledMapLayer *layer = [CCTiledMapLayer layerWithTilesetInfo:tileset layerInfo:layerInfo mapInfo:mapInfo];
 
 	// tell the layerinfo to release the ownership of the tiles map.


### PR DESCRIPTION
This will ignore empty tilemap layers, if the desired functionality is to allow empty layers to be added, CCTiledMapLayer will have to be changed to allow for 'nil' tilesets.

CCTiledMapLayer:setupTiles doesn't check for a 'nil' tileset before trying to change its properties.
