### PR TITLE
 Fixing memory leak

### DIFF
--- a/cocos2d/Support/CCColor.m
+++ b/cocos2d/Support/CCColor.m
@@ -170,10 +170,14 @@
 }
 #endif
 
+/// After using you must call CGColorRelease(color)
 - (CGColorRef) CGColor
 {
     CGFloat components[4] = {(CGFloat)_r, (CGFloat)_g, (CGFloat)_b, (CGFloat)_a};
-    return CGColorCreate(CGColorSpaceCreateDeviceRGB(), components);
+    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
+    CGColorRef color = CGColorCreate(colorspace, components);
+    CGColorSpaceRelease(colorspace);
+    return color;
 }
 
 #ifdef __CC_PLATFORM_IOS


### PR DESCRIPTION
(CGColorRef) CGColor { CGFloat components[4] = {(CGFloat)_r, (CGFloat)_g, (CGFloat)_b, (CGFloat)_a}; return CGColorCreate(CGColorSpaceCreateDeviceRGB(), components); }
CGColorSpaceCreateDeviceRGB() returns a Core Foundation object with +1 retain count and this object is not referenced later and has a retain count of +1.
