### PR TITLE
CCTiledMapLayer.m issues #687 & #693

### DIFF
--- a/cocos2d/CCTiledMapLayer.m
+++ b/cocos2d/CCTiledMapLayer.m
@@ -117,7 +117,7 @@ int compareInts (const void * a, const void * b);
 		_mapTileSize = mapInfo.tileSize;
 		_layerOrientation = mapInfo.orientation;
 		
-		CGFloat pixelsToPoints = 1.0/tex.contentScale;
+		CGFloat pixelsToPoints = tex ? 1.0/tex.contentScale : 1.0;
 		
 		// offset (after layer orientation is set);
 		CGPoint offset = [self calculateLayerOffset:layerInfo.offset];


### PR DESCRIPTION
Fixes possible divide by zero. If the layer has no tileset, the tex is nil and causes pixelsToPoints to be INF. This causes the contentSize to be INF, INF and prevents any further layers from being parsed.
