### PR TITLE
Bugfix: CCbutton inside a CCScrollview steals touch and breaks all touch events #663 

### DIFF
--- a/cocos2d-ui/CCScrollView.m
+++ b/cocos2d-ui/CCScrollView.m
@@ -66,7 +66,7 @@
 
 @implementation CCTapDownGestureRecognizer
 
--(void)touchBegan:(UITouch *)touch withEvent:(UIEvent *)event
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {
     if (self.state == UIGestureRecognizerStatePossible)
     {
@@ -74,16 +74,8 @@
     }
 }
 
--(void)touchMoved:(UITouch *)touch withEvent:(UIEvent *)event
-{
-    self.state = UIGestureRecognizerStateFailed;
-}
-
--(void)touchEnded:(UITouch *)touch withEvent:(UIEvent *)event
-{
-    self.state = UIGestureRecognizerStateFailed;
-}
 @end
+
 #endif
 
 


### PR DESCRIPTION
Scrollview will stop panning if touched and won't steal touch anymore.
CCTapDownGestureRecognizer touch began phase implemented with very old iOS interface.
