### PR TITLE
Bugfix: Setting CCNode's blendFunc won't show #705 

### DIFF
--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -1763,7 +1763,7 @@ CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
 
 -(void)setBlendFunc:(ccBlendFunc)blendFunc
 {
-	_blendMode = [CCBlendMode blendModeWithOptions:@{
+	self.blendMode = [CCBlendMode blendModeWithOptions:@{
 		CCBlendFuncSrcColor: @(blendFunc.src),
 		CCBlendFuncDstColor: @(blendFunc.dst),
 	}];


### PR DESCRIPTION
RenderState is not invalidated when blendFunc changes.
Solution: reuse blendMode setter, instead of setting the value directly. That will invalidate the renderState if the blendMode changes.
