### PR TITLE
Round calculated label sizes up to prevent strings from not rendering

### DIFF
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -528,6 +528,9 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
         dimensions = [attributedString boundingRectWithSize:NSSizeFromCGSize(dimensions) options:NSStringDrawingUsesLineFragmentOrigin].size;
 #endif
         
+        dimensions.width = ceil(dimensions.width);
+        dimensions.height = ceil(dimensions.height);
+        
         wDrawArea = dimensions.width;
         hDrawArea = dimensions.height;
         


### PR DESCRIPTION
I'm loading a custom TTF and have an issue where certain strings will not render

I've traced through and can see that the sizes are being calculated and rendered using `NSString drawInRect:` The calculated size is always a float, as expected. When we attempt to render them using  `string drawInRect` it renders blank.

When I apply a `ceil()` to the calculated size's width and height, all string render 100% normal

I can't provide the ttf unfortunately because it's a licensed file, I will search for an open source font

This seems like it might be an issue with `NSStringDrawing`, or possibly even the font. 

thoughts?
