### PR TITLE
fixed buildResponderList: in CCResponderManager

### DIFF
--- a/cocos2d/CCResponderManager.m
+++ b/cocos2d/CCResponderManager.m
@@ -103,31 +103,29 @@
     _dirty = NO;
 }
 
--( void )buildResponderList:(CCNode *)node
+- (void)buildResponderList:(CCNode *)node
 {
-    BOOL nodeAdded = NO;
-    
     // dont add invisible nodes
     if (!node.visible) return;
     
-    if ((node.children) && (node.children.count > 0))
+    BOOL shouldAddNode = node.isUserInteractionEnabled;
+    
+    if (node.children.count)
     {
-        // scan through children, and build responderlist
+        // scan through children, and build responder list
         for (CCNode *child in node.children)
         {
-            if ((child.zOrder >= 0) && (!nodeAdded) && (node.isUserInteractionEnabled))
+            if (shouldAddNode && child.zOrder >= 0)
             {
                 [self addResponder:node];
-                nodeAdded = YES;
+                shouldAddNode = NO;
             }
             [self buildResponderList:child];
         }
     }
-    else
-    {
-        // only add self
-        if (node.isUserInteractionEnabled) [self addResponder:node];
-    }
+    
+    // if eligible, add the current node to the responder list
+    if (shouldAddNode) [self addResponder:node];
 }
 
 // -----------------------------------------------------------------


### PR DESCRIPTION
previously _buildResponderList:_ overlooked adding the current node to the responder list if the node _only_ contained children with a negative z-index while having interactions enabled.

flagging the node for possible addition, then eventually adding it should patch this.

and some minimisations.
