### PR TITLE
Update CCParallaxNode.m

### DIFF
--- a/cocos2d/CCParallaxNode.m
+++ b/cocos2d/CCParallaxNode.m
@@ -95,7 +95,27 @@
 
 -(void) removeChild:(CCNode*)node cleanup:(BOOL)cleanup
 {
-	[_parallaxArray removeObject:node];
+
+	CGPointObject *objectToRemove = nil;
+    
+	for (CGPointObject *point in _parallaxArray) {
+	    
+		if(point.child == node){
+
+			objectToRemove = point;
+            
+			break;
+            
+		}
+    
+	}
+    
+	if(objectToRemove != nil){
+        
+		[_parallaxArray removeObject:objectToRemove];
+
+	}
+    
 	[super removeChild:node cleanup:cleanup];
 }
 


### PR DESCRIPTION
_parallaxArray is an array of CGPointObjects, not an array of nodes. We should search for the CGPointObject that points to the CCNode to be removed, and remove it.
