### PR TITLE
Update OALTools.m

### DIFF
--- a/external/ObjectAL/Support/OALTools.m
+++ b/external/ObjectAL/Support/OALTools.m
@@ -67,7 +67,7 @@ static NSBundle* g_defaultBundle;
 		return nil;
 	}
 	
-    NSString* fullPath = [[CCFileUtils sharedFileUtils] fullPathForFilename:path];
+    NSString* fullPath = [[CCFileUtils sharedFileUtils] fullPathForFilenameIgnoringResolutions:path];
     if(nil == fullPath)
     {
         OAL_LOG_ERROR(@"Could not find full path of file %@", path);


### PR DESCRIPTION
fullPathForFilename does not accept absolute paths, thus is not allowed to pass an absolute path to playBg:loop: (and others).
