### PR TITLE
Update CCParallaxNode.m

### DIFF
--- a/cocos2d/CCParallaxNode.m
+++ b/cocos2d/CCParallaxNode.m
@@ -95,8 +95,21 @@
 
 -(void) removeChild:(CCNode*)node cleanup:(BOOL)cleanup
 {
-	[_parallaxArray removeObject:node];
-	[super removeChild:node cleanup:cleanup];
+
+    NSUInteger index = 0, removeIndex = NSNotFound;
+    
+    for(CGPointObject *point in _parallaxArray){
+        if (point.child == node) {
+            removeIndex = index;
+            break;
+        }
+        index++;
+    }
+    
+    if (removeIndex != NSNotFound) [_parallaxArray removeObjectAtIndex:removeIndex];
+    
+    [super removeChild:node cleanup:cleanup];
+    
 }
 
 -(void) removeAllChildrenWithCleanup:(BOOL)cleanup


### PR DESCRIPTION
_parallaxArray is an array of CGPointObjects, not an array of nodes. We should search for the CGPointObject that points to the CCNode to be removed, and remove it.
