### PR TITLE
Add CCRenderer support for Cocos3D rendering.

### DIFF
--- a/cocos2d/CCRenderer.h
+++ b/cocos2d/CCRenderer.h
@@ -25,7 +25,7 @@
 #import "ccTypes.h"
 
 
-@class CCTexture;
+@class CCTexture, CCRenderer;
 
 /// Standard interleaved vertex format for Cocos2D.
 typedef struct CCVertex {
@@ -177,6 +177,26 @@ extern const NSString *CCBlendEquationAlpha;
 
 @end
 
+/**
+ * Describes the behaviour for an command object that can be submitted to the queue of a 
+ * CCRenderer in order to perform some drawing operations.
+ *
+ * When submitted to a renderer, render commands can be queued and executed at a later time.
+ * Each implementation of CCRenderCommand encapsulates the content to be rendered.
+ */
+@protocol CCRenderCommand <NSObject>
+
+/**
+ * Invokes this command on the specified renderer.
+ *
+ * When submitted to a renderer, render commands may be queued and executed at a later time.
+ * Implementations should expect that this method will not be executed at the time that this
+ * command is submitted to the renderer.
+ */
+-(void)invokeOnRenderer:(CCRenderer *)renderer;
+
+@end
+
 
 /// A rendering queue.
 /// All drawing commands in Cocos2D must be sequenced using a CCRenderer.
@@ -203,5 +223,8 @@ extern const NSString *CCBlendEquationAlpha;
 
 /// Enqueue a method that performs GL commands.
 -(void)enqueueMethod:(SEL)selector target:(id)target;
+
+// Enqueue a general or custom render command.
+-(void)enqueueRenderCommand: (id<CCRenderCommand>) renderCommand;
 
 @end

--- a/cocos2d/CCRenderer.m
+++ b/cocos2d/CCRenderer.m
@@ -347,12 +347,6 @@ CCRenderState *CCRENDERSTATE_DEBUGCOLOR = nil;
 @end
 
 
-//MARK: Render Command Protocol
-@protocol CCRenderCommand <NSObject>
--(void)invoke:(CCRenderer *)renderer;
-@end
-
-
 @interface CCRenderer()
 -(void)bindVAO:(BOOL)bind;
 -(void)setRenderState:(CCRenderState *)renderState;
@@ -393,7 +387,7 @@ CCRenderState *CCRENDERSTATE_DEBUGCOLOR = nil;
 	_elements += elements;
 }
 
--(void)invoke:(CCRenderer *)renderer
+-(void)invokeOnRenderer:(CCRenderer *)renderer
 {
 	glPushGroupMarkerEXT(0, "CCRendererCommandDraw: Invoke");
 	
@@ -427,7 +421,7 @@ CCRenderState *CCRENDERSTATE_DEBUGCOLOR = nil;
 	return self;
 }
 
--(void)invoke:(CCRenderer *)renderer
+-(void)invokeOnRenderer:(CCRenderer *)renderer
 {
 	glPushGroupMarkerEXT(0, [NSString stringWithFormat:@"CCRenderCommandCustom(%@): Invoke", _debugLabel].UTF8String);
 	
@@ -728,6 +722,11 @@ static NSString *CURRENT_RENDERER_KEY = @"CCRendererCurrent";
 	} debugLabel:NSStringFromSelector(selector)];
 }
 
+-(void)enqueueRenderCommand: (id<CCRenderCommand>) renderCommand {
+	[_queue addObject: renderCommand];
+	_lastDrawCommand = nil;
+}
+
 -(void)flush
 {
 	glPushGroupMarkerEXT(0, "CCRenderer: Flush");
@@ -743,7 +742,7 @@ static NSString *CURRENT_RENDERER_KEY = @"CCRendererCurrent";
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 	CC_CHECK_GL_ERROR_DEBUG();
 	
-	for(CCRenderCommandDraw *command in _queue) [command invoke:self];
+	for(CCRenderCommandDraw *command in _queue) [command invokeOnRenderer:self];
 	[self bindVAO:NO];
 	
 //	NSLog(@"Draw commands: %d, Draw calls: %d", _statDrawCommands, _queue.count);

--- a/cocos2d/cocos2d.h
+++ b/cocos2d/cocos2d.h
@@ -41,7 +41,7 @@
 
 // 0x00 HI ME LO
 // 00   03 00 00
-#define COCOS2D_VERSION 0x00030000
+#define COCOS2D_VERSION 0x00030100
 
 //
 // all cocos2d include files


### PR DESCRIPTION
Make `CCRenderCommand` protocol public. Rename `CCRenderCommand` invoke: method to
`invokeOnRenderer:` for more clarity as public protocol applicable to any object.
Add `CCRenderer enqueueRenderCommand:` method.
Set `COCOS2D_VERSION` to `0x00030100` so Cocos3D can detect new rendering.

Within Cocos3D, I've created implementations of `CCRenderCommand` to render Cocos3D components.  Exposing the `CCRenderCommand` as public, and adding the basic `enqueueRenderCommand:` supports this, and will allow any Cocos2D developer to create customized commands for their own rendering needs.

Finally, in order to provide support for multiple versions of Cocos2D, Cocos3D uses the `COCOS2D_VERSION` setting to detect the version. To allow such support, we should get in the habit of making this the first thing we change as we open a branch for an upcoming version.
