### PR TITLE
CCBAnimationManager, CCBReader Fixes

### DIFF
--- a/cocos2d-ui/CCBReader/CCBAnimationManager.m
+++ b/cocos2d-ui/CCBReader/CCBAnimationManager.m
@@ -573,8 +573,13 @@ static NSInteger ccbAnimationManagerID = 0;
     block = [b copy];
 }
 
+- (void)cleanup {
+	[_scheduler unscheduleTarget:self];
+    [self clearAllActions];
+}
+
 - (void)dealloc {
-    self.rootNode = NULL;
+    _rootNode = NULL;
 }
 
 - (void)debug {

--- a/cocos2d-ui/CCBReader/CCBAnimationManager.m
+++ b/cocos2d-ui/CCBReader/CCBAnimationManager.m
@@ -574,6 +574,7 @@ static NSInteger ccbAnimationManagerID = 0;
 }
 
 - (void)cleanup {
+    [_scheduler setPaused:YES target:self];
 	[_scheduler unscheduleTarget:self];
     [self clearAllActions];
 }

--- a/cocos2d-ui/CCBReader/CCBReader.m
+++ b/cocos2d-ui/CCBReader/CCBReader.m
@@ -1582,7 +1582,7 @@ static inline float readFloat(CCBReader *self)
 + (CCScene*) sceneWithNodeGraphFromFile:(NSString *)file owner:(id)owner parentSize:(CGSize)parentSize
 {
     CCNode* node = [CCBReader load:file owner:owner parentSize:parentSize];
-    CCScene* scene = [[CCBReader reader] createScene];
+    CCScene* scene = [CCScene node];
     [scene addChild:node];
     return scene;
 }

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -205,6 +205,12 @@ static NSUInteger globalOrderOfArrival = 1;
 
 	// timers
 	[_children makeObjectsPerformSelector:@selector(cleanup)];
+    
+    // Custom cleanup for userOjbect (Typically CCBAnimationManager when using SpriteBuilder)
+    if([_userObject respondsToSelector:@selector(cleanup)]) {
+        [_userObject performSelector:@selector(cleanup)];
+    }
+    _userObject = nil;
 }
 
 - (NSString*) description

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -29,6 +29,7 @@
 #import "CCNode_Private.h"
 #import "CCDirector.h"
 #import "CCActionManager.h"
+#import "CCBAnimationManager.h"
 #import "CCScheduler.h"
 #import "ccConfig.h"
 #import "ccMacros.h"
@@ -41,6 +42,7 @@
 #import "CCTexture_Private.h"
 #import "CCActionManager_Private.h"
 
+
 #ifdef __CC_PLATFORM_IOS
 #import "Platforms/iOS/CCDirectorIOS.h"
 #endif
@@ -51,7 +53,6 @@
 #else
 #define RENDER_IN_SUBPIXEL(__ARGS__) (ceil(__ARGS__))
 #endif
-
 
 #pragma mark - Node
 
@@ -207,7 +208,7 @@ static NSUInteger globalOrderOfArrival = 1;
 	[_children makeObjectsPerformSelector:@selector(cleanup)];
     
     // Custom cleanup for userOjbect (Typically CCBAnimationManager when using SpriteBuilder)
-    if([_userObject respondsToSelector:@selector(cleanup)]) {
+    if([_userObject isKindOfClass:[CCBAnimationManager class]]) {
         [_userObject performSelector:@selector(cleanup)];
     }
     _userObject = nil;

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -207,7 +207,7 @@ static NSUInteger globalOrderOfArrival = 1;
 	// timers
 	[_children makeObjectsPerformSelector:@selector(cleanup)];
     
-    // Custom cleanup for userOjbect (Typically CCBAnimationManager when using SpriteBuilder)
+    // CCBAnimationManager Cleanup (Set by SpriteBuilder)
     if([_userObject isKindOfClass:[CCBAnimationManager class]]) {
         [_userObject performSelector:@selector(cleanup)];
     }


### PR DESCRIPTION
Cleanup method for CCBAnimationManager, will be called when it is detached from CCNode.
CCBReader was also double allocating and not deallocating.
Issue SpriteBuilder 402, 399 , 372
