### PR TITLE
Redraw render texture before drawing the child sprite.

### DIFF
--- a/cocos2d/CCRenderTexture.m
+++ b/cocos2d/CCRenderTexture.m
@@ -315,8 +315,8 @@
 	kmGLPushMatrix();
 
 	[self transform];
-	[_sprite visit];
 	[self draw];
+	[_sprite visit];
 	
 	kmGLPopMatrix();
 	


### PR DESCRIPTION
A CCRenderTexture can be added to a scene, and if the autoDraw property is enabled, it will automatically render any child nodes into the texture that's displayed by it's CCSprite instance. However, there's a problem with the CCRenderTexture's visit implementation. It currently calls visit on the CCSprite before the texture has been updated. This means that the CCSprite will display the texture as it was rendered in the previous frame. This is especially annoying in the first frame update after adding the CCRenderTexture to your scene, as in this case the CCSprite will display an empty (black) texture. 

The fix is easy: redraw the render texture before visiting the CCSprite instance.
