### PR TITLE
CCTextField set textfield visibility and enabled

### DIFF
--- a/cocos2d-ui/CCTextField.m
+++ b/cocos2d-ui/CCTextField.m
@@ -165,7 +165,17 @@
 
 - (void) update:(CCTime)delta
 {
-    [self positionTextField];
+    BOOL isVisible = self.visible;
+    if (isVisible) {
+    	// run through ancestors and see if we are visible
+        for (CCNode *parent = self.parent; parent && isVisible; parent = parent.parent)
+            isVisible &= parent.visible;
+    }
+    
+    // hide the UITextField if node is invisible
+    _textField.hidden = !isVisible;
+    
+    if (isVisible) [self positionTextField];
 }
 
 - (void) layout
@@ -187,6 +197,11 @@
 #endif
     
     [super layout];
+}
+
+- (void) setEnabled:(BOOL)enabled {
+    _textField.enabled = enabled;
+    [super setEnabled:enabled];
 }
 
 #pragma mark Text Field Delegate Methods


### PR DESCRIPTION
show/hide the UITextField if it's responsible node or a related ancestor is visible/invisible

i'm not too happy about this implementation but not much that can be done, right now, about the polling method to control visibility.

also set the textfield's usability along with the enabled property of the control.

issue from the forums, http://forum.cocos2d-iphone.org/t/cctextfield-remains-visible-when-parent-is-not-visible/13139
