### PR TITLE
Ordering of nodes in a CCLayout depends on children's z-order which is n...

### DIFF
--- a/cocos2d/CCLayout.m
+++ b/cocos2d/CCLayout.m
@@ -24,6 +24,7 @@
  */
 
 #import "CCLayout.h"
+#import "CCNode_Private.h"
 
 @implementation CCLayout
 
@@ -62,6 +63,7 @@
 - (void) addChild:(CCNode *)node z:(NSInteger)z name:(NSString*)name
 {
     [super addChild:node z:z name:name];
+    [self sortAllChildren];
     [self layout];
 }
 


### PR DESCRIPTION
...ow correct after adding a node.

Fixes the SpriteBuilder bug https://github.com/spritebuilder/SpriteBuilder/issues/465

Please add this to the 3.1 branch.
