### PR TITLE
CCLayoutBox in vertical order was sorted in reverse order.

### DIFF
--- a/cocos2d/CCLayoutBox.m
+++ b/cocos2d/CCLayoutBox.m
@@ -84,7 +84,7 @@ static float roundUpToEven(float f)
         
         // Position the nodes
         float height = 0;
-        for (CCNode* child in self.children)
+        for (CCNode* child in [[self.children reverseObjectEnumerator] allObjects])
         {
             CGSize childSize = child.contentSizeInPoints;
             


### PR DESCRIPTION
Fixes: https://github.com/spritebuilder/SpriteBuilder/issues/280
