### PR TITLE
CCNodeGradientRadialColor class: draw radial gradient with GL_TRIANGLE_FAN 

### DIFF
--- a/cocos2d-ui-tests/tests/ColorTest.m
+++ b/cocos2d-ui-tests/tests/ColorTest.m
@@ -167,15 +167,14 @@
 -(void) setupCCNodeGradientRadialColorTest
 {
 	CGSize s = [[CCDirector sharedDirector] viewSize];
-    
+
 	CCNodeGradientRadial *colorNode = [CCNodeGradientRadial nodeWithColor:[CCColor blueColor]
-                                                     fadingTo:[CCColor redColor]
-                                                  alongVector:ccp(1, 1)];
+                                                     fadingTo:[CCColor greenColor]];
 	colorNode.contentSize = CGSizeMake(200, 200);
 	colorNode.position = ccp( s.width/2.0f - 100, s.height/2.0f - 100);
 	[self.contentNode addChild:colorNode];
 	
-	self.subTitle = @"Blue inner, red outer";
+	self.subTitle = @"Blue inner, green outer";
 }
 
 -(void) unfinishedsetupBMFontColorCascadeTest

--- a/cocos2d-ui-tests/tests/ColorTest.m
+++ b/cocos2d-ui-tests/tests/ColorTest.m
@@ -164,6 +164,19 @@
 	self.subTitle = @"Blue bottom left, red top right";
 }
 
+-(void) setupCCNodeGradientRadialColorTest
+{
+	CGSize s = [[CCDirector sharedDirector] viewSize];
+    
+	CCNodeGradientRadial *colorNode = [CCNodeGradientRadial nodeWithColor:[CCColor blueColor]
+                                                     fadingTo:[CCColor redColor]
+                                                  alongVector:ccp(1, 1)];
+	colorNode.contentSize = CGSizeMake(200, 200);
+	colorNode.position = ccp( s.width/2.0f - 100, s.height/2.0f - 100);
+	[self.contentNode addChild:colorNode];
+	
+	self.subTitle = @"Blue inner, red outer";
+}
 
 -(void) unfinishedsetupBMFontColorCascadeTest
 {

--- a/cocos2d/CCNodeColor.h
+++ b/cocos2d/CCNodeColor.h
@@ -247,7 +247,7 @@
 
 
 /// -----------------------------------------------------------------------
-/// @name Creating a CCNodeColor Object
+/// @name Creating a CCNodeGradientRadial Object
 /// -----------------------------------------------------------------------
 
 /**
@@ -257,7 +257,7 @@
  *  @param w     Width of the node.
  *  @param h     Height of the node.
  *
- *  @return The CCNodeColor Object.
+ *  @return The CCNodeGradientRadial Object.
  */
 +(id) nodeWithColor: (CCColor*)color width:(GLfloat)w height:(GLfloat)h;
 
@@ -266,12 +266,22 @@
  *
  *  @param color Color of the node.
  *
- *  @return The CCNodeColor Object.
+ *  @return The CCNodeGradientRadial Object.
  */
 +(id) nodeWithColor: (CCColor*)color;
 
+/**
+ *  Creates a full-screen CCNode with a gradient between start and end color values.
+ *
+ *  @param start Start color.
+ *  @param end   End color.
+ *
+ *  @return The CCNodeGradientRadial Object.
+ */
++(id)nodeWithColor:(CCColor*)start fadingTo:(CCColor*)end;
+
 /// -----------------------------------------------------------------------
-/// @name Initializing a CCNodeColor Object
+/// @name Initializing a CCNodeGradientRadial Object
 /// -----------------------------------------------------------------------
 
 
@@ -282,7 +292,7 @@
  *  @param w     Width of the node.
  *  @param h     Height of the node.
  *
- *  @return An initialized CCNodeColor Object.
+ *  @return An initialized CCNodeGradientRadial Object.
  */
 -(id) initWithColor:(CCColor*)color width:(GLfloat)w height:(GLfloat)h;
 
@@ -291,39 +301,9 @@
  *
  *  @param color Color of the node.
  *
- *  @return An initialized CCNodeColor Object.
+ *  @return An initialized CCNodeGradientRadial Object.
  */
 -(id) initWithColor:(CCColor*)color;
-
-/// -----------------------------------------------------------------------
-/// @name Creating a CCNodeGradient Object
-/// -----------------------------------------------------------------------
-
-/**
- *  Creates a full-screen CCNode with a gradient between start and end color values.
- *
- *  @param start Start color.
- *  @param end   End color.
- *
- *  @return The CCNodeGradient Object.
- */
-+(id)nodeWithColor:(CCColor*)start fadingTo:(CCColor*)end;
-
-/**
- *  Creates a full-screen CCNode with a gradient between start and end color values with gradient direction vector.
- *
- *  @param start Start color.
- *  @param end   End color.
- *  @param v Direction vector for gradient.
- *
- *  @return The CCNodeGradient Object.
- */
-+(id)nodeWithColor:(CCColor*)start fadingTo:(CCColor*)end alongVector:(CGPoint)v;
-
-
-/// -----------------------------------------------------------------------
-/// @name Initializing a CCNodeGradient Object
-/// -----------------------------------------------------------------------
 
 /**
  *  Initializes a full-screen CCNode with a gradient between start and end color values.
@@ -331,24 +311,13 @@
  *  @param start Start color.
  *  @param end   End color.
  *
- *  @return An initialized CCNodeGradient Object.
+ *  @return An initialized CCNodeGradientRadial Object.
  */
 - (id)initWithColor:(CCColor*)start fadingTo:(CCColor*)end;
 
-/**
- *  Creates a full-screen CCNode with a gradient between start and end color values with gradient direction vector.
- *
- *  @param start Start color.
- *  @param end   End color.
- *  @param v Direction vector for gradient.
- *
- *  @return An initialized CCNodeGradient Object.
- */
-- (id)initWithColor:(CCColor*)start fadingTo:(CCColor*)end alongVector:(CGPoint)v;
-
 
 /// -----------------------------------------------------------------------
-/// @name Accessing CCNodeGradient Attributes
+/// @name Accessing CCNodeGradientRadial Attributes
 /// -----------------------------------------------------------------------
 
 /** The starting color. */
@@ -363,9 +332,6 @@
 /** The ending color. */
 @property (nonatomic, readwrite) CGFloat endOpacity;
 
-/** The vector along which to fade color. */
-@property (nonatomic, readwrite) CGPoint vector;
-
 /** The gradientFactor controls the interpolation from startColor to endColor. 
  * If resolution = 6 (or vertexCount = 26) then along each edge we get 6 vertices
  * For gradientFactor = 1 the color fades along each edge as
@@ -374,7 +340,9 @@
  * for gradientFactor = 2; the color fade along each edge as:
  * [0.00, 0.17, 0.33, 0.50, 0.33, 0.17]
  *
- * The default value is 3
+ * The default value is 3.0
+ *
+ * @warning gradientFactor should be > 0
  */
 @property (nonatomic, readwrite) CGFloat gradientFactor;
 

--- a/cocos2d/CCNodeColor.h
+++ b/cocos2d/CCNodeColor.h
@@ -204,6 +204,187 @@
 
 @end
 
+#pragma mark - CCNodeGradientRadial
+
+/** CCNodeGradientRadial is a CCNode that can be used to display radial gradient
+ *
+ * It isn't a subclass of CCNodeColor because 
+ *
+ * 1. CCNodeColor only has 4 vertex available whereas for a gradient effect we 
+ *    need more vertices.
+ * 2. CCNodeColor uses GL_TRIANGLE_STRIP for rendering but for gradient we use 
+ *    GL_TRIANGLE_FAN
+ *
+ * Still the CCNodeGradientRadial's interface is kept as close to CCNodeGradient
+ * so that the gradient effect could be switched with minimum efforts.
+ *
+ */
+
+/** kCCNodeGradientRadialResolution tells the how detailed the mesh is.
+ *
+ * Total vertices for a circular fan are calculated as:
+ *
+ *  int vertexCount = 2 + resolution * 4;
+ *
+ * where:
+ * - resolution > 0
+ * - vertex[0] is the center vertex
+ * - vertex[1] == vertex[vertexCount-1]; to close the loop
+ *
+ * In my test cases for resolution > 3 didn't improve much quality
+ * so we shall use resolution = 3
+ * Remember these are just the number of vertices, for improving the gradient
+ * we always have the gradientFactor property.
+ */
+#define kCCNodeGradientRadialResolution 3
+#define kCCNodeGradientRadialVertexCount(r) (2 + r * 4)
+
+@interface CCNodeGradientRadial : CCNode<CCBlendProtocol> {
+	ccVertex2F	_fanVertices[kCCNodeGradientRadialVertexCount(kCCNodeGradientRadialResolution)];
+	ccColor4F	_fanColors[kCCNodeGradientRadialVertexCount(kCCNodeGradientRadialResolution)];
+	ccBlendFunc	_blendFunc;
+}
+
+
+/// -----------------------------------------------------------------------
+/// @name Creating a CCNodeColor Object
+/// -----------------------------------------------------------------------
+
+/**
+ *  Creates a node with color, width and height in Points.
+ *
+ *  @param color Color of the node.
+ *  @param w     Width of the node.
+ *  @param h     Height of the node.
+ *
+ *  @return The CCNodeColor Object.
+ */
++(id) nodeWithColor: (CCColor*)color width:(GLfloat)w height:(GLfloat)h;
+
+/**
+ *  Creates a node with color. Width and height are the window size.
+ *
+ *  @param color Color of the node.
+ *
+ *  @return The CCNodeColor Object.
+ */
++(id) nodeWithColor: (CCColor*)color;
+
+/// -----------------------------------------------------------------------
+/// @name Initializing a CCNodeColor Object
+/// -----------------------------------------------------------------------
+
+
+/**
+ *  Initializes a node with color, width and height in Points.
+ *
+ *  @param color Color of the node.
+ *  @param w     Width of the node.
+ *  @param h     Height of the node.
+ *
+ *  @return An initialized CCNodeColor Object.
+ */
+-(id) initWithColor:(CCColor*)color width:(GLfloat)w height:(GLfloat)h;
+
+/**
+ *  Initializes a node with color. Width and height are the window size.
+ *
+ *  @param color Color of the node.
+ *
+ *  @return An initialized CCNodeColor Object.
+ */
+-(id) initWithColor:(CCColor*)color;
+
+/// -----------------------------------------------------------------------
+/// @name Creating a CCNodeGradient Object
+/// -----------------------------------------------------------------------
+
+/**
+ *  Creates a full-screen CCNode with a gradient between start and end color values.
+ *
+ *  @param start Start color.
+ *  @param end   End color.
+ *
+ *  @return The CCNodeGradient Object.
+ */
++(id)nodeWithColor:(CCColor*)start fadingTo:(CCColor*)end;
+
+/**
+ *  Creates a full-screen CCNode with a gradient between start and end color values with gradient direction vector.
+ *
+ *  @param start Start color.
+ *  @param end   End color.
+ *  @param v Direction vector for gradient.
+ *
+ *  @return The CCNodeGradient Object.
+ */
++(id)nodeWithColor:(CCColor*)start fadingTo:(CCColor*)end alongVector:(CGPoint)v;
+
+
+/// -----------------------------------------------------------------------
+/// @name Initializing a CCNodeGradient Object
+/// -----------------------------------------------------------------------
+
+/**
+ *  Initializes a full-screen CCNode with a gradient between start and end color values.
+ *
+ *  @param start Start color.
+ *  @param end   End color.
+ *
+ *  @return An initialized CCNodeGradient Object.
+ */
+- (id)initWithColor:(CCColor*)start fadingTo:(CCColor*)end;
+
+/**
+ *  Creates a full-screen CCNode with a gradient between start and end color values with gradient direction vector.
+ *
+ *  @param start Start color.
+ *  @param end   End color.
+ *  @param v Direction vector for gradient.
+ *
+ *  @return An initialized CCNodeGradient Object.
+ */
+- (id)initWithColor:(CCColor*)start fadingTo:(CCColor*)end alongVector:(CGPoint)v;
+
+
+/// -----------------------------------------------------------------------
+/// @name Accessing CCNodeGradient Attributes
+/// -----------------------------------------------------------------------
+
+/** The starting color. */
+@property (nonatomic, strong) CCColor* startColor;
+
+/** The ending color. */
+@property (nonatomic, strong) CCColor* endColor;
+
+/** The starting opacity. */
+@property (nonatomic, readwrite) CGFloat startOpacity;
+
+/** The ending color. */
+@property (nonatomic, readwrite) CGFloat endOpacity;
+
+/** The vector along which to fade color. */
+@property (nonatomic, readwrite) CGPoint vector;
+
+/** The gradientFactor controls the interpolation from startColor to endColor. 
+ * If resolution = 6 (or vertexCount = 26) then along each edge we get 6 vertices
+ * For gradientFactor = 1 the color fades along each edge as
+ * [0.00, 0.33, 0.67, 1.00, 0.67, 0.33]
+ *
+ * for gradientFactor = 2; the color fade along each edge as:
+ * [0.00, 0.17, 0.33, 0.50, 0.33, 0.17]
+ *
+ * The default value is 3
+ */
+@property (nonatomic, readwrite) CGFloat gradientFactor;
+
+/** Blend method to use. */
+@property (nonatomic,readwrite) ccBlendFunc blendFunc;
+
+@end
+
+
+
 #pragma mark - CCNodeMultiplexer
 
 /** CCNodeMultiplexer is a CCNode with the ability to multiplex its children.

--- a/cocos2d/CCNodeColor.m
+++ b/cocos2d/CCNodeColor.m
@@ -283,6 +283,293 @@
 }
 @end
 
+
+#pragma mark -
+#pragma mark CCNodeGradientRadial
+
+/** Get a radial mix value between [0.0, 1.0)
+ * If num = 6; and gradientFactor = 1; for value of i returns
+ * 0: 0.00
+ * 1: 0.33
+ * 2: 0.67
+ * 3: 1.00
+ * 4: 0.67
+ * 5: 0.33
+ *
+ * If num = 6; and gradientFactor = 2; for value of i returns
+ * 0: 0.00
+ * 1: 0.17
+ * 2: 0.33
+ * 3: 0.50
+ * 4: 0.33
+ * 5: 0.17
+ 
+ */
+static inline float RadialMix(const int i, const int num, const float gradientFactor)
+{
+    float mid = num/2.0f;
+    return (mid - fabs(mid - i)) / (mid * gradientFactor);
+}
+
+static inline ccVertex2F ccVertex2FLerp(const ccVertex2F start, const ccVertex2F end, float t)
+{
+    ccVertex2F ret;
+    ret.x = start.x + (end.x - start.x) * t;
+    ret.y = start.y + (end.y - start.y) * t;
+    
+    return ret;
+}
+
+@interface CCNodeGradientRadial () {
+    ccColor4F _endColor;
+	CGPoint _vector;    
+}
+
+- (void)updatePosition;
+-(void) updateColor;
+
+@end
+
+@implementation CCNodeGradientRadial
+
+// Opacity and RGB color protocol
+@synthesize blendFunc = _blendFunc;
+
++ (id) nodeWithColor:(CCColor*)color width:(GLfloat)w  height:(GLfloat) h
+{
+	return [[self alloc] initWithColor:color width:w height:h];
+}
+
++ (id) nodeWithColor:(CCColor*)color
+{
+	return [(CCNodeGradientRadial*)[self alloc] initWithColor:color];
+}
+
++ (id) nodeWithColor: (CCColor*) start fadingTo: (CCColor*) end
+{
+    return [[self alloc] initWithColor:start fadingTo:end];
+}
+
++ (id) nodeWithColor: (CCColor*) start fadingTo: (CCColor*) end alongVector: (CGPoint) v
+{
+    return [[self alloc] initWithColor:start fadingTo:end alongVector:v];
+}
+
+- (id) init
+{
+	return [self initWithColor:[CCColor blackColor] fadingTo:[CCColor blackColor]];
+}
+
+- (id) initWithColor: (CCColor*) start fadingTo: (CCColor*) end
+{
+    return [self initWithColor:start fadingTo:end alongVector:ccp(0, -1)];
+}
+
+- (id) initWithColor: (CCColor*) start fadingTo: (CCColor*) end alongVector: (CGPoint) v
+{
+	_color = start.ccColor4f;
+	_endColor = end.ccColor4f;
+	_vector = v;
+    
+	return [self initWithColor:start];
+}
+
+- (id) initWithColor:(CCColor*)color
+{
+	CGSize s = [CCDirector sharedDirector].designSize;
+	return [self initWithColor:color width:s.width height:s.height];
+}
+
+// Designated initializer
+- (id) initWithColor:(CCColor*)color width:(GLfloat)w  height:(GLfloat) h
+{
+	if( (self=[super init]) ) {
+        
+		// default blend function
+		_blendFunc = (ccBlendFunc) { GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA };
+        
+		_displayColor = _color = color.ccColor4f;
+        
+        _gradientFactor = 3.0f;
+        
+		for (NSUInteger i = 0; i<sizeof(_fanVertices) / sizeof( _fanVertices[0]); i++ ) {
+			_fanVertices[i].x = 0.0f;
+			_fanVertices[i].y = 0.0f;
+		}
+        
+		[self updateColor];
+		[self setContentSize:CGSizeMake(w, h) ];
+        
+		self.shaderProgram = [[CCShaderCache sharedShaderCache] programForKey:kCCShader_PositionColor];
+	}
+	return self;
+}
+
+- (void) draw
+{
+    [self updatePosition];
+    
+	CC_NODE_DRAW_SETUP();
+    
+	ccGLEnableVertexAttribs( kCCVertexAttribFlag_Position | kCCVertexAttribFlag_Color );
+    
+	//
+	// Attributes
+	//
+	glVertexAttribPointer(kCCVertexAttrib_Position, 2, GL_FLOAT, GL_FALSE, 0, _fanVertices);
+	glVertexAttribPointer(kCCVertexAttrib_Color, 4, GL_FLOAT, GL_FALSE, 0, _fanColors);
+    
+	ccGLBlendFunc( _blendFunc.src, _blendFunc.dst );
+    
+	glDrawArrays(GL_TRIANGLE_FAN, 0, kCCNodeGradientRadialVertexCount(kCCNodeGradientRadialResolution));
+	
+	CC_INCREMENT_GL_DRAWS(1);
+}
+
+- (void)updatePosition
+{
+    CGSize size = self.contentSizeInPoints;
+    
+    /* calc position data */
+    ccVertex2F posEdges[5] = {
+        {size.width/2.0f, size.height/2.0f},    /* center */
+        {0.0f,               0.0f},             /* bottom-left */
+        {size.width,      0.0f},                /* bottom-right */
+        {size.width,      size.height},         /* top-right */
+        {0.0f,            size.height}          /* top-left */
+    };
+        
+    int v = 0;
+
+    /* center */
+    memcpy(&_fanVertices[v++], &posEdges[0], sizeof(posEdges[0]));
+
+    /** edges index
+     * e : [eBegin,  eEnd]
+     * 0 : [1,          2] : bottom
+     * 1 : [2,          3] : right
+     * 2 : [3,          4] : top
+     * 3 : [4,          1] : left
+     */
+    for (int e = 0; e < 4; ++e) {
+        
+        int eBegin = e + 1;
+        int eEnd = (e+1)%4 + 1;
+        
+        for (int r = 0; r < kCCNodeGradientRadialResolution; ++r) {
+            
+            ccVertex2F pos = ccVertex2FLerp(posEdges[eBegin], posEdges[eEnd],
+                                            r/(float)kCCNodeGradientRadialResolution);
+            memcpy(&_fanVertices[v++], &pos, sizeof(pos));
+        }
+    }
+    
+    /* close the loop */
+    memcpy(&_fanVertices[v++], &posEdges[1], sizeof(posEdges[0]));
+}
+
+- (void) updateColor
+{
+	for( NSUInteger i = 0; i < sizeof(_fanColors)/sizeof(_fanColors[0]); i++ )
+	{
+		_fanColors[i] = _displayColor;
+	}
+
+    /* calculate color data */
+    int v = 0;
+    
+    /* center */
+    memcpy(&_fanColors[v++], &_color, sizeof(_color));
+    
+    /** edges index
+     * e : [eBegin,  eEnd]
+     * 0 : [1,          2] : bottom
+     * 1 : [2,          3] : right
+     * 2 : [3,          4] : top
+     * 3 : [4,          1] : left
+     */
+    for (int e = 0; e < 4; ++e) {
+        
+        int eBegin = e + 1;
+        int eEnd = (e+1)%4 + 1;
+        
+        for (int r = 0; r < kCCNodeGradientRadialResolution; ++r) {
+
+            ccColor4F clr = ccc4FInterpolated(_endColor, _color, RadialMix(r, kCCNodeGradientRadialResolution, _gradientFactor));
+            memcpy(&_fanColors[v++], &clr, sizeof(clr));
+        }
+    }
+    
+    /* close the loop */
+    memcpy(&_fanColors[v++], &_endColor, sizeof(_endColor));
+}
+
+-(CCColor*) startColor
+{
+	return [CCColor colorWithCcColor4f: _color];
+}
+
+-(void) setStartColor:(CCColor*)color
+{
+	[self setColor:color];
+}
+
+- (CCColor*) endColor
+{
+	return [CCColor colorWithCcColor4f:_endColor];
+}
+
+-(void) setEndColor:(CCColor*)color
+{
+	_endColor = color.ccColor4f;
+	[self updateColor];
+}
+
+- (CGFloat) startOpacity
+{
+	return _color.a;
+}
+
+-(void) setStartOpacity: (CGFloat) o
+{
+	_color.a = o;
+	[self updateColor];
+}
+
+- (CGFloat) endOpacity
+{
+	return _endColor.a;
+}
+
+-(void) setEndOpacity: (CGFloat) o
+{
+	_endColor.a = o;
+	[self updateColor];
+}
+
+-(void) setVector: (CGPoint) v
+{
+	_vector = v;
+	[self updateColor];
+}
+
+#pragma mark Protocols
+// Color Protocol
+
+-(void) setColor:(CCColor*)color
+{
+	[super setColor:color];
+	[self updateColor];
+}
+
+-(void) setOpacity: (CGFloat) opacity
+{
+	[super setOpacity:opacity];
+	[self updateColor];
+}
+
+@end
+
 #pragma mark -
 #pragma mark MultiplexLayer
 

--- a/cocos2d/CCNodeColor.m
+++ b/cocos2d/CCNodeColor.m
@@ -311,6 +311,7 @@ static inline float RadialMix(const int i, const int num, const float gradientFa
     return (mid - fabs(mid - i)) / (mid * gradientFactor);
 }
 
+/** Linerly interpolate two vectors */
 static inline ccVertex2F ccVertex2FLerp(const ccVertex2F start, const ccVertex2F end, float t)
 {
     ccVertex2F ret;
@@ -322,7 +323,7 @@ static inline ccVertex2F ccVertex2FLerp(const ccVertex2F start, const ccVertex2F
 
 @interface CCNodeGradientRadial () {
     ccColor4F _endColor;
-	CGPoint _vector;    
+    CGFloat _gradient;
 }
 
 - (void)updatePosition;
@@ -350,11 +351,6 @@ static inline ccVertex2F ccVertex2FLerp(const ccVertex2F start, const ccVertex2F
     return [[self alloc] initWithColor:start fadingTo:end];
 }
 
-+ (id) nodeWithColor: (CCColor*) start fadingTo: (CCColor*) end alongVector: (CGPoint) v
-{
-    return [[self alloc] initWithColor:start fadingTo:end alongVector:v];
-}
-
 - (id) init
 {
 	return [self initWithColor:[CCColor blackColor] fadingTo:[CCColor blackColor]];
@@ -362,14 +358,8 @@ static inline ccVertex2F ccVertex2FLerp(const ccVertex2F start, const ccVertex2F
 
 - (id) initWithColor: (CCColor*) start fadingTo: (CCColor*) end
 {
-    return [self initWithColor:start fadingTo:end alongVector:ccp(0, -1)];
-}
-
-- (id) initWithColor: (CCColor*) start fadingTo: (CCColor*) end alongVector: (CGPoint) v
-{
 	_color = start.ccColor4f;
 	_endColor = end.ccColor4f;
-	_vector = v;
     
 	return [self initWithColor:start];
 }
@@ -390,7 +380,7 @@ static inline ccVertex2F ccVertex2FLerp(const ccVertex2F start, const ccVertex2F
         
 		_displayColor = _color = color.ccColor4f;
         
-        _gradientFactor = 3.0f;
+        _gradient = 3.0f;
         
 		for (NSUInteger i = 0; i<sizeof(_fanVertices) / sizeof( _fanVertices[0]); i++ ) {
 			_fanVertices[i].x = 0.0f;
@@ -495,7 +485,7 @@ static inline ccVertex2F ccVertex2FLerp(const ccVertex2F start, const ccVertex2F
         
         for (int r = 0; r < kCCNodeGradientRadialResolution; ++r) {
 
-            ccColor4F clr = ccc4FInterpolated(_endColor, _color, RadialMix(r, kCCNodeGradientRadialResolution, _gradientFactor));
+            ccColor4F clr = ccc4FInterpolated(_endColor, _color, RadialMix(r, kCCNodeGradientRadialResolution, _gradient));
             memcpy(&_fanColors[v++], &clr, sizeof(clr));
         }
     }
@@ -547,10 +537,20 @@ static inline ccVertex2F ccVertex2FLerp(const ccVertex2F start, const ccVertex2F
 	[self updateColor];
 }
 
--(void) setVector: (CGPoint) v
+- (CGFloat) gradientFactor
 {
-	_vector = v;
-	[self updateColor];
+    return _gradient;
+}
+
+- (void)setGradientFactor:(CGFloat)gradientFactor
+{
+    NSAssert(gradientFactor > 0.0,
+             @"gradientFactor should always have a value greater than 0.0.\n"
+             "gradientFactor controls the smoothness of the interpolation between the two colors\n"
+             "Ideally it should be >= 3.0.");
+
+    _gradient = gradientFactor;
+    [self updateColor];
 }
 
 #pragma mark Protocols


### PR DESCRIPTION
CCNodeGradientRadial is a CCNode that can be used to display radial gradient

 It isn't a subclass of CCNodeColor or CCNodeGradient because:
1. CCNodeColor only has 4 vertex available whereas for a gradient effect we need more vertices.
2. CCNodeColor uses GL_TRIANGLE_STRIP for rendering but for radial gradient we're using GL_TRIANGLE_FAN

Still the CCNodeGradientRadial's interface is kept as close to CCNodeGradient so that the gradient effect could be switched with minimum efforts.

Here's a screenshot from my game in development:
![img_0680](https://cloud.githubusercontent.com/assets/213683/3049181/4cbb016e-e158-11e3-8612-93e3d4fdaa04.PNG)

I searched the internet for a way to draw radial backgrounds, but most of the people were suggesting using a texture or implementing using a fragment shader. I think with GL_TRIANGLE_FAN we can get a descent enough result with less performance overhead compared to the other two suggestions.

I've also added a test case and here's the result:

![screenshot 2014-05-22 07 59 57](https://cloud.githubusercontent.com/assets/213683/3049210/07dd9ae2-e159-11e3-8b34-b36dc9174761.png)

I'm new to the cocos2d and I'm still at level 0 with git. The cocos2d repository is already so complicated for me, sorry for anything stupid that I might have already done. Please let me know how it works out. 

Thanks for all your great work, I would love to get more involved in the future with the development :)
- Sid.
