### PR TITLE
CCSlider can be dragged on iOS when !enabled

### DIFF
--- a/cocos2d-ui/CCSlider.m
+++ b/cocos2d-ui/CCSlider.m
@@ -76,6 +76,8 @@
 
 - (void) touchEntered:(UITouch*)touch withEvent:(UIEvent*)event
 {
+    if (!self.enabled) return;
+    
     CGPoint worldLocation = [touch locationInWorld];
     
     [self inputEnteredWithWorlPos:worldLocation];


### PR DESCRIPTION
Fixing iOS version to not respond to dragging when self.enabled == NO.
Mac version was already ok.
