### PR TITLE
CCLabelBMFont - _childForTag needs to be cleared when calling setFntFile...

### DIFF
--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -937,6 +937,8 @@ void FNTConfigRemoveCache( void )
 		_fntFile = fntFile;
 
 		_configuration = newConf;
+        
+        _childForTag = [NSMutableArray array];
 
 		self.texture = [CCTexture textureWithFile:_configuration.atlasName];
 		[self createFontChars];


### PR DESCRIPTION
....   This fixes an issue with bmfonts in spritebuilder displaying incorrectly.

Before Picture:

![image](https://cloud.githubusercontent.com/assets/1964778/3068559/eb9592e4-e28f-11e3-9584-7d9ef86d2c40.png)
