### PR TITLE
Added ellipse recognition to the tmx-parser.

### DIFF
--- a/cocos2d/CCTMXXMLParser.m
+++ b/cocos2d/CCTMXXMLParser.m
@@ -444,6 +444,13 @@
 			[dict setObject:propertyValue forKey:propertyName];
 		}
 
+    } else if ([elementName isEqualToString:@"ellipse"]) {
+		
+		// find parent object's dict and add ellipse-boolean (true) to it
+		CCTiledMapObjectGroup *objectGroup = [_objectGroups lastObject];
+		NSMutableDictionary *dict = [[objectGroup objects] lastObject];
+		[dict setObject:[NSNumber numberWithBool:YES] forKey:@"ellipse"];
+    
 	} else if ([elementName isEqualToString:@"polygon"]) {
 		
 		// find parent object's dict and add polygon-points to it


### PR DESCRIPTION
The CCTMXXMLParser now recognizes the ellipse-element `<ellipse/>` inside an object-group and adds an boolean (NSNumber, true) to the dictionary if the object uses the ellipse-tag.
