### PR TITLE
Remove faulty assertion tests in CCES2Renderer + support for rotations between landscape & portrait iOS device orientations.

### DIFF
--- a/cocos2d/CCDirector.h
+++ b/cocos2d/CCDirector.h
@@ -230,9 +230,9 @@ and when to execute the Scenes.
 /**
  *  Changes the projection size.
  *
- *  @param newWindowSize New projection size.
+ *  @param newViewSize New projection size.
  */
--(void) reshapeProjection:(CGSize)newWindowSize;
+-(void) reshapeProjection:(CGSize)newViewSize;
 
 /**
  *  Converts a UIKit coordinate to an OpenGL coordinate.

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -448,12 +448,14 @@ static CCDirector *_sharedDirector = nil;
 	return (CGSizeEqualToSize(_designSize, CGSizeZero) ? self.viewSize : _designSize);
 }
 
--(void) reshapeProjection:(CGSize)newWindowSize
+-(void) reshapeProjection:(CGSize)newViewSize
 {
-	_winSizeInPixels = newWindowSize;
+	_winSizeInPixels = newViewSize;
 	_winSizeInPoints = CGSizeMake( _winSizeInPixels.width / __ccContentScaleFactor, _winSizeInPixels.height / __ccContentScaleFactor );
 	
 	[self setProjection:_projection];
+	
+	[_runningScene viewDidResizeTo: newViewSize];
 }
 
 #pragma mark Director Scene Management

--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -263,6 +263,14 @@ A common user pattern in building a Cocos2d game is to subclass CCNode, add it t
 /** The anchorPoint in absolute pixels.  Since v0.8 you can only read it. If you wish to modify it, use anchorPoint instead. */
 @property(nonatomic,readonly) CGPoint anchorPointInPoints;
 
+/**
+ * Invoked automatically when the OS view has been resized.
+ *
+ * This implementation simply propagates the same method to the children.
+ * Subclasses may override to actually do something when the view resizes.
+ */
+-(void) viewDidResizeTo: (CGSize) newViewSize;
+
 
 /** Returns a "local" axis aligned bounding box of the node in points.
  The returned box is relative only to its parent.

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -551,6 +551,11 @@ TransformPointAsVector(CGPoint p, CGAffineTransform t)
     return [self convertContentSizeToPoints:self.contentSize type:_contentSizeType];
 }
 
+-(void) viewDidResizeTo: (CGSize) newViewSize
+{
+	for (CCNode* child in _children) [child viewDidResizeTo: newViewSize];
+}
+
 - (float) scaleInPoints
 {
     if (_scaleType == CCScaleTypeScaled)

--- a/cocos2d/Platforms/iOS/CCAppDelegate.h
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.h
@@ -49,6 +49,9 @@ extern NSString* const CCScreenOrientationLandscape;
 // Portrait screen orientation.  Used with CCSetupScreenOrientation.
 extern NSString* const CCScreenOrientationPortrait;
 
+// Support all screen orientations.  Used with CCSetupScreenOrientation.
+extern NSString* const CCScreenOrientationAll;
+
 
 // The flexible screen mode is Cocos2d's default. It will give you an area that can vary slightly in size. In landscape mode the height will be 320 points for mobiles and 384 points for tablets. The width of the area can vary from 480 to 568 points.
 extern NSString* const CCScreenModeFlexible;
@@ -111,7 +114,7 @@ extern NSString* const CCScreenModeFixed;
  *
  *  - CCSetupPixelFormat NSString with the pixel format, normally kEAGLColorFormatRGBA8 or kEAGLColorFormatRGB565. The RGB565 option is faster, but will allow less colors.
  *  - CCSetupScreenMode NSString value that accepts either CCScreenModeFlexible or CCScreenModeFixed.
- *  - CCSetupScreenOrientation NSString value that accepts either CCScreenOrientationLandscape or CCScreenOrientationPortrait.
+ *  - CCSetupScreenOrientation NSString value that accepts CCScreenOrientationLandscape, CCScreenOrientationPortrait, or CCScreenOrientationAll.
  *  - CCSetupAnimationInterval NSNumber with double. Specifies the desired interval between animation frames. Supported values are 1.0/60.0 (default) and 1.0/30.0.
  *  - CCSetupFixedUpdateInterval NSNumber with double. Specifies the desired interval between fixed updates.Should be smaller than CCSetupAnimationInterval. Defaults to 1/60.0.
  *  - CCSetupShowDebugStats NSNumber with bool. Specifies if the stats (FPS, frame time and draw call count) should be shown. Defaults to NO.

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -49,6 +49,7 @@ NSString* const CCSetupNumberOfSamples = @"CCSetupNumberOfSamples";
 
 NSString* const CCScreenOrientationLandscape = @"CCScreenOrientationLandscape";
 NSString* const CCScreenOrientationPortrait = @"CCScreenOrientationPortrait";
+NSString* const CCScreenOrientationAll = @"CCScreenOrientationAll";
 
 NSString* const CCScreenModeFlexible = @"CCScreenModeFlexible";
 NSString* const CCScreenModeFixed = @"CCScreenModeFixed";
@@ -75,13 +76,17 @@ const CGSize FIXED_SIZE = {568, 384};
 // Only valid for iOS 6+. NOT VALID for iOS 4 / 5.
 -(NSUInteger)supportedInterfaceOrientations
 {
-    if ([_screenOrientation isEqual:CCScreenOrientationLandscape])
+    if ([_screenOrientation isEqual:CCScreenOrientationAll])
     {
-        return UIInterfaceOrientationMaskLandscape;
+        return UIInterfaceOrientationMaskAll;
+    }
+    else if ([_screenOrientation isEqual:CCScreenOrientationPortrait])
+    {
+        return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
     }
     else
     {
-        return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
+        return UIInterfaceOrientationMaskLandscape;
     }
 }
 
@@ -89,13 +94,17 @@ const CGSize FIXED_SIZE = {568, 384};
 // Only valid on iOS 4 / 5. NOT VALID for iOS 6.
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
-    if ([_screenOrientation isEqual:CCScreenOrientationLandscape])
+    if ([_screenOrientation isEqual:CCScreenOrientationAll])
     {
-        return UIInterfaceOrientationIsLandscape(interfaceOrientation);
+        return YES;
+    }
+    else if ([_screenOrientation isEqual:CCScreenOrientationPortrait])
+    {
+        return UIInterfaceOrientationIsPortrait(interfaceOrientation);
     }
     else
     {
-        return UIInterfaceOrientationIsPortrait(interfaceOrientation);
+        return UIInterfaceOrientationIsLandscape(interfaceOrientation);
     }
 }
 

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -193,13 +193,9 @@
 	[self performSelector:@selector(drawScene) onThread:thread withObject:nil waitUntilDone:YES];
 }
 
-// overriden, don't call super
--(void) reshapeProjection:(CGSize)size
+-(void) reshapeProjection:(CGSize)newViewSize
 {
-	_winSizeInPixels = size;
-	_winSizeInPoints = CGSizeMake(size.width/__ccContentScaleFactor, size.height/__ccContentScaleFactor);
-	
-	[self setProjection:_projection];
+	[super reshapeProjection:newViewSize];
   
 	if( [_delegate respondsToSelector:@selector(directorDidReshapeProjection:)] )
 		[_delegate directorDidReshapeProjection:self];

--- a/cocos2d/Platforms/iOS/CCES2Renderer.m
+++ b/cocos2d/Platforms/iOS/CCES2Renderer.m
@@ -67,10 +67,8 @@
 
         // Create default framebuffer object. The backing will be allocated for the current layer in -resizeFromLayer
         glGenFramebuffers(1, &_defaultFramebuffer);
-		NSAssert( _defaultFramebuffer, @"Can't create default frame buffer");
 
         glGenRenderbuffers(1, &_colorRenderbuffer);
-		NSAssert( _colorRenderbuffer, @"Can't create default render buffer");
 
         glBindFramebuffer(GL_FRAMEBUFFER, _defaultFramebuffer);
         glBindRenderbuffer(GL_RENDERBUFFER, _colorRenderbuffer);
@@ -84,7 +82,6 @@
 			
 			/* Create the MSAA framebuffer (offscreen) */
 			glGenFramebuffers(1, &_msaaFramebuffer);
-			NSAssert( _msaaFramebuffer, @"Can't create default MSAA frame buffer");
 			glBindFramebuffer(GL_FRAMEBUFFER, _msaaFramebuffer);
 			
 		}
@@ -121,7 +118,6 @@
 		//msaaFrameBuffer needs to be binded
 		glBindFramebuffer(GL_FRAMEBUFFER, _msaaFramebuffer);
 		glGenRenderbuffers(1, &_msaaColorbuffer);
-		NSAssert(_msaaFramebuffer, @"Can't create MSAA color buffer");
 		
 		glBindRenderbuffer(GL_RENDERBUFFER, _msaaColorbuffer);
 		
@@ -143,7 +139,6 @@
 	{
 		if( ! _depthBuffer ) {
 			glGenRenderbuffers(1, &_depthBuffer);
-			NSAssert(_depthBuffer, @"Can't create depth buffer");
 		}
 
 		glBindRenderbuffer(GL_RENDERBUFFER, _depthBuffer);


### PR DESCRIPTION
Remove faulty assertion tests in CCES2Renderer, to permit zero as a valid framebuffer and renderbuffer ID under Android. Plus add support for iOS device rotation between landscape and portrait.
