### PR TITLE
Fixes for high priority issues and other smaller issues.

### DIFF
--- a/cocos2d-ui/CCBReader/CCAnimationManager.m
+++ b/cocos2d-ui/CCBReader/CCAnimationManager.m
@@ -201,7 +201,7 @@ static NSInteger ccbAnimationManagerID = 0;
     } else if ([name isEqualToString:@"rotationalSkewY"]) {
         return [CCActionRotateTo actionWithDuration:duration angleY:[kf1.value floatValue]];
     } else if ([name isEqualToString:@"opacity"]) {
-        return [CCActionFadeTo actionWithDuration:duration opacity:[kf1.value intValue]];
+        return [CCActionFadeTo actionWithDuration:duration opacity:[kf1.value floatValue]];
     } else if ([name isEqualToString:@"color"]) {
         CCColor* color = kf1.value;
         return [CCActionTintTo actionWithDuration:duration color:color];

--- a/cocos2d-ui/CCBReader/CCAnimationManager.m
+++ b/cocos2d-ui/CCBReader/CCAnimationManager.m
@@ -52,11 +52,6 @@ static NSInteger ccbAnimationManagerID = 0;
     _nodeSequences = [[NSMutableDictionary alloc] init];
     _baseValues = [[NSMutableDictionary alloc] init];
     
-    // Scheduler
-    _scheduler = [[CCDirector sharedDirector] scheduler];
-    [_scheduler scheduleTarget:self];
-    [_scheduler setPaused:NO target:self];
-    
     // Current Sequence Actions
     _currentActions = [[NSMutableArray alloc] init];
     _playbackSpeed  = 1.0f;
@@ -79,6 +74,13 @@ static NSInteger ccbAnimationManagerID = 0;
     } else {
         return _rootContainerSize;
     }
+}
+
+-(void) onEnter {
+    // Setup Scheduler
+    _scheduler = [[CCDirector sharedDirector] scheduler];
+    [_scheduler scheduleTarget:self];
+    [_scheduler setPaused:NO target:self];
 }
 
 - (void)addNode:(CCNode*)node andSequences:(NSDictionary*)seq

--- a/cocos2d-ui/CCBReader/CCBReader.m
+++ b/cocos2d-ui/CCBReader/CCBReader.m
@@ -1339,7 +1339,7 @@ static inline float readFloat(CCBReader *self)
         embeddedNode.scaleX = ccbFileNode.scaleX;
         embeddedNode.scaleY = ccbFileNode.scaleY;
         embeddedNode.name = ccbFileNode.name;
-        embeddedNode.visible = YES;
+        embeddedNode.visible = ccbFileNode.visible;
         //embeddedNode.ignoreAnchorPointForPosition = ccbFileNode.ignoreAnchorPointForPosition;
         
         [animationManager moveAnimationsFromNode:ccbFileNode toNode:embeddedNode];

--- a/cocos2d/CCActionInstant.h
+++ b/cocos2d/CCActionInstant.h
@@ -184,12 +184,12 @@
  *  This action allows a custom function to be called.
  */
 @interface CCActionCallFunc : CCActionInstant <NSCopying> {
-	id _targetCallback;
+	__weak id _targetCallback;
 	SEL _selector;
 }
 
 /** Target function that will be called. */
-@property (nonatomic, readwrite, strong) id targetCallback;
+@property (nonatomic, readwrite, weak) id targetCallback;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -1108,6 +1108,10 @@ CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
 		[[CCDirector sharedDirector].actionManager migrateActions:self from:[CCDirector sharedDirector].actionManagerFixed];
 		[self setActionManager:[CCDirector sharedDirector].actionManager];
 	}
+
+    if(_animationManager) {
+        [_animationManager performSelector:@selector(onEnter)];
+    }
 	
 	[self wasRunning:wasRunning];
 }


### PR DESCRIPTION
Investigating SB issues, turns out that an empty timeline will still always play the default timeline and then perform the sequenceComplete selector. (Not sure if it needs to but always has so leaving it alone).
CCActionCallFun retains this.

CCActionCallFunc set target node to weak,
Setup scheduler in CCAnimationManager only if added to a node (onEnter)

spritebuilder/SpriteBuilder#638
spritebuilder/SpriteBuilder#653
spritebuilder/SpriteBuilder#654
spritebuilder/SpriteBuilder#658
spritebuilder/SpriteBuilder#659
