### PR TITLE
Fixes crash when action is getting applied to a deallocated target

### DIFF
--- a/cocos2d/CCAction.h
+++ b/cocos2d/CCAction.h
@@ -45,7 +45,7 @@ enum {
  */
 @interface CCAction : NSObject <NSCopying> {
 	id			__unsafe_unretained _originalTarget;
-	id			__unsafe_unretained _target;
+	id			__weak _target;
 	NSInteger	_tag;
 }
 
@@ -60,7 +60,7 @@ enum {
  *  When the 'stop' method is called, target will be set to nil.
  *  The target is 'assigned', it is not 'retained'.
  */
-@property (nonatomic,readonly,unsafe_unretained) id target;
+@property (nonatomic,readonly,weak) id target;
 
 /** The original target, since target can be nil. */
 @property (nonatomic,readonly,unsafe_unretained) id originalTarget;

--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -258,7 +258,9 @@
 
 	// New action. Start it.
 	if( found != _last )
-		[_actions[found] startWithTarget:_target];
+        if (_target) {
+            [_actions[found] startWithTarget:_target];
+        }
 	
 	[_actions[found] update: new_t];
 	_last = found;


### PR DESCRIPTION
Making _target property __weak makes sure the pointer is nilled out by ARC when the _target is deallocated
