### PR TITLE
CCSprite - Wrap some effect code in CC_ENABLE_EXPERIMENTAL_EFFECTS

### DIFF
--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -558,6 +558,7 @@
 
 #pragma mark CCSprite - Effects
 
+#if CC_ENABLE_EXPERIMENTAL_EFFECTS
 - (void)updateShaderUniformsFromEffect
 {
     // Initialize the shader uniforms dictionary with the sprite's main texture and
@@ -569,6 +570,6 @@
     // And then copy the new effect's uniforms into the node's uniforms dictionary.
     [_shaderUniforms addEntriesFromDictionary:_effect.shaderUniforms];
 }
-
+#endif
 
 @end


### PR DESCRIPTION
Fixes build breakage if CC_ENABLE_EXPERIMENTAL_EFFECTS is not defined in ccConfig.h.
