### PR TITLE
CCEffectRefraction - Fix various issues uncovered by Viktor during testing

### DIFF
--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -74,7 +74,12 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
                                    vec2 refractTexCoords = envSpaceTexCoords.xy + normal.xy * u_refraction;
 
                                    vec4 primaryColor = cc_FragColor * texture2D(cc_MainTexture, cc_FragTexCoord1);
-                                   return primaryColor * texture2D(u_envMap, refractTexCoords);
+                                   if ((refractTexCoords.x >= 0.0) && (refractTexCoords.x <= 1.0) &&
+                                       (refractTexCoords.y >= 0.0) && (refractTexCoords.y <= 1.0))
+                                   {
+                                       primaryColor = primaryColor + texture2D(u_envMap, refractTexCoords) * (1.0 - primaryColor.a);
+                                   }
+                                   return primaryColor;
                                    );
     
     CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"refractionEffect" body:effectBody inputs:@[input] returnType:@"vec4"];

--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -72,13 +72,16 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
                                    // Perturb the screen space texture coordinate by the scaled normal
                                    // vector.
                                    vec2 refractTexCoords = envSpaceTexCoords.xy + normal.xy * u_refraction;
+                                   
+                                   // This is positive if refractTexCoords is in [0..1] and negative otherwise.
+                                   vec2 compare = 0.5 - abs(refractTexCoords - 0.5);
+                                   
+                                   // This is 1.0 if both refracted texture coords are in bounds and 0.0 otherwise.
+                                   float inBounds = step(0.0, min(compare.x, compare.y));
 
                                    vec4 primaryColor = cc_FragColor * texture2D(cc_MainTexture, cc_FragTexCoord1);
-                                   if ((refractTexCoords.x >= 0.0) && (refractTexCoords.x <= 1.0) &&
-                                       (refractTexCoords.y >= 0.0) && (refractTexCoords.y <= 1.0))
-                                   {
-                                       primaryColor = primaryColor + texture2D(u_envMap, refractTexCoords) * (1.0 - primaryColor.a);
-                                   }
+                                   primaryColor += inBounds * texture2D(u_envMap, refractTexCoords) * (1.0 - primaryColor.a);
+                                   
                                    return primaryColor;
                                    );
     

--- a/cocos2d/CCEffectRenderer.m
+++ b/cocos2d/CCEffectRenderer.m
@@ -159,11 +159,12 @@
         CCTexture *previousPassTexture = nil;
         if (previousPassRT)
         {
+            NSAssert(previousPassRT.texture, @"Texture for render target unexpectedly nil.");
             previousPassTexture = previousPassRT.texture;
         }
         else
         {
-            previousPassTexture = sprite.texture;
+            previousPassTexture = sprite.texture ?: [CCTexture none];
         }
         
         CCEffectRenderPass* renderPass = [effect renderPassAtIndex:i];

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -529,13 +529,22 @@
 
 -(void) setNormalMapSpriteFrame:(CCSpriteFrame*)frame
 {
+    if (!self.texture)
+    {
+        // If there is no texture set on the sprite, set the sprite's texture rect from the
+        // normal map's sprite frame. Note that setting the main texture, then the normal map,
+        // and then removing the main texture will leave the texture rect from the main texture.
+        [self setTextureRect:frame.rect rotated:frame.rotated untrimmedSize:frame.originalSize];
+    }
+
+    // Set the second texture coordinate set from the normal map's sprite frame.
     CCSpriteTexCoordSet texCoords = [CCSprite textureCoordsForTexture:frame.texture withRect:frame.rect rotated:frame.rotated xFlipped:_flipX yFlipped:_flipY];
     _verts.bl.texCoord2 = texCoords.bl;
     _verts.br.texCoord2 = texCoords.br;
     _verts.tr.texCoord2 = texCoords.tr;
     _verts.tl.texCoord2 = texCoords.tl;
     
-    // Set the main texture in the uniforms dictionary (if the dictionary exists).
+    // Set the normal map texture in the uniforms dictionary (if the dictionary exists).
     self.shaderUniforms[CCShaderUniformNormalMapTexture] = (frame.texture ?: [CCTexture none]);
     _renderState = nil;
     


### PR DESCRIPTION
- Use premultiplied alpha blending to combine the sprite's main texture with the refracted environment.
- If the refracted texture coordinates would be out of bounds of the environment, do not combine the resulting environment pixel with the sprite's main texture.
- Fix a crash that occurred if an effect was applied to a sprite with a nil main texture.
- If a sprite has no main texture, set the texture rect from the normal map instead.
