### PR TITLE
Fix effects in OSX project. Add CCEffectHue.

### DIFF
--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -112,6 +112,8 @@
 		9D85671E191B018200573093 /* CCEffectBrightness.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D85671C191B018200573093 /* CCEffectBrightness.m */; };
 		9D856721191B019900573093 /* CCEffectContrast.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D85671F191B019900573093 /* CCEffectContrast.h */; };
 		9D856722191B019900573093 /* CCEffectContrast.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D856720191B019900573093 /* CCEffectContrast.m */; };
+		9DB7599A196E09FF00AF3E4A /* CCEffectHue.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DB75998196E09FF00AF3E4A /* CCEffectHue.h */; };
+		9DB7599B196E09FF00AF3E4A /* CCEffectHue.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DB75999196E09FF00AF3E4A /* CCEffectHue.m */; };
 		9DE90429192D630000AEB37A /* CCEffectRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE90427192D630000AEB37A /* CCEffectRenderer.h */; };
 		9DE9042A192D630000AEB37A /* CCEffectRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DE90428192D630000AEB37A /* CCEffectRenderer.m */; };
 		9DF37621191C594A00C6D27A /* CCEffectPixellate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF3761F191C594A00C6D27A /* CCEffectPixellate.h */; };
@@ -438,6 +440,8 @@
 		9D85671F191B019900573093 /* CCEffectContrast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectContrast.h; sourceTree = "<group>"; };
 		9D856720191B019900573093 /* CCEffectContrast.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectContrast.m; sourceTree = "<group>"; };
 		9D85B7DC195396E90039A9DB /* CCEffectStackProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CCEffectStackProtocol.h; sourceTree = "<group>"; };
+		9DB75998196E09FF00AF3E4A /* CCEffectHue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectHue.h; sourceTree = "<group>"; };
+		9DB75999196E09FF00AF3E4A /* CCEffectHue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectHue.m; sourceTree = "<group>"; };
 		9DE90427192D630000AEB37A /* CCEffectRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectRenderer.h; sourceTree = "<group>"; };
 		9DE90428192D630000AEB37A /* CCEffectRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectRenderer.m; sourceTree = "<group>"; };
 		9DF3761F191C594A00C6D27A /* CCEffectPixellate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectPixellate.h; sourceTree = "<group>"; };
@@ -1218,6 +1222,8 @@
 				9D85671C191B018200573093 /* CCEffectBrightness.m */,
 				9D85671F191B019900573093 /* CCEffectContrast.h */,
 				9D856720191B019900573093 /* CCEffectContrast.m */,
+				9DB75998196E09FF00AF3E4A /* CCEffectHue.h */,
+				9DB75999196E09FF00AF3E4A /* CCEffectHue.m */,
 				9DF3761F191C594A00C6D27A /* CCEffectPixellate.h */,
 				9DF37620191C594A00C6D27A /* CCEffectPixellate.m */,
 				D2B49102192146FB00C3443A /* CCEffectGaussianBlur.h */,
@@ -1418,6 +1424,7 @@
 				A0C20AC8144FDAF700D84B47 /* CCParticleBatchNode.h in Headers */,
 				B7705FDF1831A07B0043CC67 /* ObjectALConfig.h in Headers */,
 				A046E29314C1DB7D0005BBF2 /* CCDirectorMac.h in Headers */,
+				9DB7599A196E09FF00AF3E4A /* CCEffectHue.h in Headers */,
 				A046E29714C1DB7D0005BBF2 /* CCGLView.h in Headers */,
 				A046E29914C1DB7E0005BBF2 /* CCWindow.h in Headers */,
 				B791E85E182074C500DAE1D7 /* CCProgressNode.h in Headers */,
@@ -1555,6 +1562,7 @@
 				B7705FE91831A07B0043CC67 /* ALDevice.m in Sources */,
 				5018F2740DFDEAFF00C013A5 /* CCLabelTTF.m in Sources */,
 				9D856722191B019900573093 /* CCEffectContrast.m in Sources */,
+				9DB7599B196E09FF00AF3E4A /* CCEffectHue.m in Sources */,
 				926B97F61938606D00E345FB /* CCAnimationManager.m in Sources */,
 				5018F2760DFDEAFF00C013A5 /* CCNodeColor.m in Sources */,
 				B77060001831A07B0043CC67 /* NSMutableArray+WeakReferences.m in Sources */,

--- a/cocos2d-osx.xcodeproj/project.pbxproj
+++ b/cocos2d-osx.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		929D1B6E1954C2A600B27340 /* CCEffectContrast.h in Headers */ = {isa = PBXBuildFile; fileRef = 929D1B5A1954C2A600B27340 /* CCEffectContrast.h */; };
 		929D1B6F1954C2A600B27340 /* CCEffectContrast.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B5B1954C2A600B27340 /* CCEffectContrast.m */; };
 		929D1B701954C2A600B27340 /* CCEffectGaussianBlur.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B5C1954C2A600B27340 /* CCEffectGaussianBlur.m */; };
-		929D1B711954C2A600B27340 /* CCEffectGlow.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B5D1954C2A600B27340 /* CCEffectGlow.m */; };
 		929D1B721954C2A600B27340 /* CCEffectNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 929D1B5E1954C2A600B27340 /* CCEffectNode.h */; };
 		929D1B731954C2A600B27340 /* CCEffectNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B5F1954C2A600B27340 /* CCEffectNode.m */; };
 		929D1B741954C2A600B27340 /* CCEffectPixellate.h in Headers */ = {isa = PBXBuildFile; fileRef = 929D1B601954C2A600B27340 /* CCEffectPixellate.h */; };
@@ -36,9 +35,10 @@
 		929D1B7C1954C2A600B27340 /* CCEffectStack.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B681954C2A600B27340 /* CCEffectStack.m */; };
 		92D1343B1954FC7A003833C4 /* CCEffectStackProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D134361954FC7A003833C4 /* CCEffectStackProtocol.h */; };
 		92D1343C1954FC7A003833C4 /* CCRenderTexture_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D134371954FC7A003833C4 /* CCRenderTexture_Private.h */; };
-		92D1343D1954FC7A003833C4 /* CCEffectGlow.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D134381954FC7A003833C4 /* CCEffectGlow.h */; };
 		92D1343E1954FC7A003833C4 /* CCActionManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D134391954FC7A003833C4 /* CCActionManager_Private.h */; };
 		92D1343F1954FC7A003833C4 /* CCEffectGaussianBlur.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D1343A1954FC7A003833C4 /* CCEffectGaussianBlur.h */; };
+		9DB75994196E073200AF3E4A /* CCEffectBloom.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DB75992196E073200AF3E4A /* CCEffectBloom.h */; };
+		9DB75995196E073200AF3E4A /* CCEffectBloom.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DB75993196E073200AF3E4A /* CCEffectBloom.m */; };
 		9DDFEF6A19635F0600CCE3DF /* CCEffectRefraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DDFEF6819635F0600CCE3DF /* CCEffectRefraction.h */; };
 		9DDFEF6B19635F0600CCE3DF /* CCEffectRefraction.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DDFEF6919635F0600CCE3DF /* CCEffectRefraction.m */; };
 		A003ACA7165731D500C7B792 /* ccFPSImages.h in Headers */ = {isa = PBXBuildFile; fileRef = A003ACA5165731D500C7B792 /* ccFPSImages.h */; };
@@ -374,7 +374,6 @@
 		929D1B5A1954C2A600B27340 /* CCEffectContrast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectContrast.h; sourceTree = "<group>"; };
 		929D1B5B1954C2A600B27340 /* CCEffectContrast.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectContrast.m; sourceTree = "<group>"; };
 		929D1B5C1954C2A600B27340 /* CCEffectGaussianBlur.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectGaussianBlur.m; sourceTree = "<group>"; };
-		929D1B5D1954C2A600B27340 /* CCEffectGlow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectGlow.m; sourceTree = "<group>"; };
 		929D1B5E1954C2A600B27340 /* CCEffectNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectNode.h; sourceTree = "<group>"; };
 		929D1B5F1954C2A600B27340 /* CCEffectNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectNode.m; sourceTree = "<group>"; };
 		929D1B601954C2A600B27340 /* CCEffectPixellate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectPixellate.h; sourceTree = "<group>"; };
@@ -388,9 +387,10 @@
 		929D1B681954C2A600B27340 /* CCEffectStack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectStack.m; sourceTree = "<group>"; };
 		92D134361954FC7A003833C4 /* CCEffectStackProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectStackProtocol.h; sourceTree = "<group>"; };
 		92D134371954FC7A003833C4 /* CCRenderTexture_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCRenderTexture_Private.h; sourceTree = "<group>"; };
-		92D134381954FC7A003833C4 /* CCEffectGlow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectGlow.h; sourceTree = "<group>"; };
 		92D134391954FC7A003833C4 /* CCActionManager_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionManager_Private.h; sourceTree = "<group>"; };
 		92D1343A1954FC7A003833C4 /* CCEffectGaussianBlur.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectGaussianBlur.h; sourceTree = "<group>"; };
+		9DB75992196E073200AF3E4A /* CCEffectBloom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectBloom.h; sourceTree = "<group>"; };
+		9DB75993196E073200AF3E4A /* CCEffectBloom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectBloom.m; sourceTree = "<group>"; };
 		9DDFEF6819635F0600CCE3DF /* CCEffectRefraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectRefraction.h; sourceTree = "<group>"; };
 		9DDFEF6919635F0600CCE3DF /* CCEffectRefraction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectRefraction.m; sourceTree = "<group>"; };
 		A003ACA5165731D500C7B792 /* ccFPSImages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ccFPSImages.h; sourceTree = "<group>"; };
@@ -843,17 +843,17 @@
 		929D1B541954C28100B27340 /* Effects */ = {
 			isa = PBXGroup;
 			children = (
-				92D134381954FC7A003833C4 /* CCEffectGlow.h */,
 				929D1B551954C2A600B27340 /* CCEffect_Private.h */,
 				929D1B561954C2A600B27340 /* CCEffect.h */,
 				929D1B571954C2A600B27340 /* CCEffect.m */,
+				9DB75992196E073200AF3E4A /* CCEffectBloom.h */,
+				9DB75993196E073200AF3E4A /* CCEffectBloom.m */,
 				929D1B581954C2A600B27340 /* CCEffectBrightness.h */,
 				929D1B591954C2A600B27340 /* CCEffectBrightness.m */,
 				929D1B5A1954C2A600B27340 /* CCEffectContrast.h */,
 				929D1B5B1954C2A600B27340 /* CCEffectContrast.m */,
 				92D1343A1954FC7A003833C4 /* CCEffectGaussianBlur.h */,
 				929D1B5C1954C2A600B27340 /* CCEffectGaussianBlur.m */,
-				929D1B5D1954C2A600B27340 /* CCEffectGlow.m */,
 				929D1B5E1954C2A600B27340 /* CCEffectNode.h */,
 				929D1B5F1954C2A600B27340 /* CCEffectNode.m */,
 				929D1B601954C2A600B27340 /* CCEffectPixellate.h */,
@@ -1562,6 +1562,7 @@
 				D389412818639DD400725CFC /* CCPhysicsJoint.h in Headers */,
 				B770607B1831B0C40043CC67 /* ALDevice.h in Headers */,
 				B77060651831B0C40043CC67 /* OALAudioActions.h in Headers */,
+				9DB75994196E073200AF3E4A /* CCEffectBloom.h in Headers */,
 				D3AD531B18C84FA1005B6CF3 /* CCCache.h in Headers */,
 				B7D273291822F5460054849B /* CCBAnimationManager.h in Headers */,
 				929D1B781954C2A600B27340 /* CCEffectSaturation.h in Headers */,
@@ -1570,7 +1571,6 @@
 				E076E7361225EC7400DE0DA2 /* CCTiledMapObjectGroup.h in Headers */,
 				D3AD532218C84FC9005B6CF3 /* CCRenderer_private.h in Headers */,
 				E076E7381225EC7400DE0DA2 /* CCTiledMap.h in Headers */,
-				92D1343D1954FC7A003833C4 /* CCEffectGlow.h in Headers */,
 				E076E73A1225EC7400DE0DA2 /* CCTMXXMLParser.h in Headers */,
 				E076E73C1225EC7400DE0DA2 /* CCTransition.h in Headers */,
 				B77060921831B0C40043CC67 /* NSMutableArray+WeakReferences.h in Headers */,
@@ -1826,6 +1826,7 @@
 				E076E7251225EC7400DE0DA2 /* CCSpriteFrame.m in Sources */,
 				B770607A1831B0C40043CC67 /* ALContext.m in Sources */,
 				E076E7271225EC7400DE0DA2 /* CCSpriteFrameCache.m in Sources */,
+				9DB75995196E073200AF3E4A /* CCEffectBloom.m in Sources */,
 				E076E72B1225EC7400DE0DA2 /* CCTexture.m in Sources */,
 				E076E72F1225EC7400DE0DA2 /* CCTextureCache.m in Sources */,
 				B7D2732A1822F5460054849B /* CCBAnimationManager.m in Sources */,
@@ -1886,7 +1887,6 @@
 				B77060741831B0C40043CC67 /* ALBuffer.m in Sources */,
 				929D1B701954C2A600B27340 /* CCEffectGaussianBlur.m in Sources */,
 				A003ACA8165731D500C7B792 /* ccFPSImages.m in Sources */,
-				929D1B711954C2A600B27340 /* CCEffectGlow.m in Sources */,
 				B74C2B9617BDA54600A829C0 /* CCSprite9Slice.m in Sources */,
 				B770609A1831B0C40043CC67 /* OALTools.m in Sources */,
 				D3AD532418C84FC9005B6CF3 /* CCRenderer.m in Sources */,

--- a/cocos2d-osx.xcodeproj/project.pbxproj
+++ b/cocos2d-osx.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		92D1343C1954FC7A003833C4 /* CCRenderTexture_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D134371954FC7A003833C4 /* CCRenderTexture_Private.h */; };
 		92D1343E1954FC7A003833C4 /* CCActionManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D134391954FC7A003833C4 /* CCActionManager_Private.h */; };
 		92D1343F1954FC7A003833C4 /* CCEffectGaussianBlur.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D1343A1954FC7A003833C4 /* CCEffectGaussianBlur.h */; };
+		9D23869C196F0BC4001B792B /* CCEffectHue.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D23869A196F0BC4001B792B /* CCEffectHue.h */; };
+		9D23869D196F0BC4001B792B /* CCEffectHue.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D23869B196F0BC4001B792B /* CCEffectHue.m */; };
 		9DB75994196E073200AF3E4A /* CCEffectBloom.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DB75992196E073200AF3E4A /* CCEffectBloom.h */; };
 		9DB75995196E073200AF3E4A /* CCEffectBloom.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DB75993196E073200AF3E4A /* CCEffectBloom.m */; };
 		9DDFEF6A19635F0600CCE3DF /* CCEffectRefraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DDFEF6819635F0600CCE3DF /* CCEffectRefraction.h */; };
@@ -389,6 +391,8 @@
 		92D134371954FC7A003833C4 /* CCRenderTexture_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCRenderTexture_Private.h; sourceTree = "<group>"; };
 		92D134391954FC7A003833C4 /* CCActionManager_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionManager_Private.h; sourceTree = "<group>"; };
 		92D1343A1954FC7A003833C4 /* CCEffectGaussianBlur.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectGaussianBlur.h; sourceTree = "<group>"; };
+		9D23869A196F0BC4001B792B /* CCEffectHue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectHue.h; sourceTree = "<group>"; };
+		9D23869B196F0BC4001B792B /* CCEffectHue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectHue.m; sourceTree = "<group>"; };
 		9DB75992196E073200AF3E4A /* CCEffectBloom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectBloom.h; sourceTree = "<group>"; };
 		9DB75993196E073200AF3E4A /* CCEffectBloom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectBloom.m; sourceTree = "<group>"; };
 		9DDFEF6819635F0600CCE3DF /* CCEffectRefraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectRefraction.h; sourceTree = "<group>"; };
@@ -854,6 +858,8 @@
 				929D1B5B1954C2A600B27340 /* CCEffectContrast.m */,
 				92D1343A1954FC7A003833C4 /* CCEffectGaussianBlur.h */,
 				929D1B5C1954C2A600B27340 /* CCEffectGaussianBlur.m */,
+				9D23869A196F0BC4001B792B /* CCEffectHue.h */,
+				9D23869B196F0BC4001B792B /* CCEffectHue.m */,
 				929D1B5E1954C2A600B27340 /* CCEffectNode.h */,
 				929D1B5F1954C2A600B27340 /* CCEffectNode.m */,
 				929D1B601954C2A600B27340 /* CCEffectPixellate.h */,
@@ -1667,6 +1673,7 @@
 				B7E2603517E7C774007067F0 /* NSEvent+CC.h in Headers */,
 				B77060961831B0C40043CC67 /* OALAudioFile.h in Headers */,
 				B7E2603917E7C786007067F0 /* UITouch+CC.h in Headers */,
+				9D23869C196F0BC4001B792B /* CCEffectHue.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1846,6 +1853,7 @@
 				D389412B18639DD400725CFC /* CCPhysicsNode.m in Sources */,
 				E076E7641225EC7400DE0DA2 /* ccUtils.c in Sources */,
 				B770608C1831B0C40043CC67 /* OALSuspendHandler.m in Sources */,
+				9D23869D196F0BC4001B792B /* CCEffectHue.m in Sources */,
 				E076E7671225EC7400DE0DA2 /* CGPointExtension.m in Sources */,
 				E076E76A1225EC7400DE0DA2 /* TGAlib.m in Sources */,
 				B7EE69ED1819EAAC00B983FE /* CCLayoutBox.m in Sources */,

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -375,6 +375,35 @@
     [self.contentNode addChild:[self effectNodeWithEffects:@[effects[8]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.9, 0.5)]];
 }
 
+-(void)setupHueEffectTest
+{
+    self.subTitle = @"Hue Effect Test";
+    
+    // Different configurations of the saturation effect
+    NSArray *effects = @[
+                         [[CCEffectHue alloc] initWithHue:1.0f],
+                         [[CCEffectHue alloc] initWithHue:0.8f],
+                         [[CCEffectHue alloc] initWithHue:0.4f],
+                         [[CCEffectHue alloc] initWithHue:0.2f],
+                         [[CCEffectHue alloc] initWithHue:0.0f],
+                         [[CCEffectHue alloc] initWithHue:-0.2f],
+                         [[CCEffectHue alloc] initWithHue:-0.4f],
+                         [[CCEffectHue alloc] initWithHue:-0.8f],
+                         [[CCEffectHue alloc] initWithHue:-1.0f],
+                         ];
+    
+    // Effect nodes that use the effects in different combinations.
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[0]] image:@"Images/grossini.png" atPosition:ccp(0.1, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[1]] image:@"Images/grossini.png" atPosition:ccp(0.2, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[2]] image:@"Images/grossini.png" atPosition:ccp(0.3, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[3]] image:@"Images/grossini.png" atPosition:ccp(0.4, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[4]] image:@"Images/grossini.png" atPosition:ccp(0.5, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[5]] image:@"Images/grossini.png" atPosition:ccp(0.6, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[6]] image:@"Images/grossini.png" atPosition:ccp(0.7, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[7]] image:@"Images/grossini.png" atPosition:ccp(0.8, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[8]] image:@"Images/grossini.png" atPosition:ccp(0.9, 0.5)]];
+}
+
 -(void)setupPerformanceTest
 {
     self.subTitle = @"Effect Performance Test";

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -379,29 +379,26 @@
 {
     self.subTitle = @"Hue Effect Test";
     
-    // Different configurations of the saturation effect
-    NSArray *effects = @[
-                         [[CCEffectHue alloc] initWithHue:1.0f],
-                         [[CCEffectHue alloc] initWithHue:0.8f],
-                         [[CCEffectHue alloc] initWithHue:0.4f],
-                         [[CCEffectHue alloc] initWithHue:0.2f],
-                         [[CCEffectHue alloc] initWithHue:0.0f],
-                         [[CCEffectHue alloc] initWithHue:-0.2f],
-                         [[CCEffectHue alloc] initWithHue:-0.4f],
-                         [[CCEffectHue alloc] initWithHue:-0.8f],
-                         [[CCEffectHue alloc] initWithHue:-1.0f],
-                         ];
-    
     // Effect nodes that use the effects in different combinations.
-    [self.contentNode addChild:[self spriteWithEffects:@[effects[0]] image:@"Images/grossini.png" atPosition:ccp(0.1, 0.5)]];
-    [self.contentNode addChild:[self spriteWithEffects:@[effects[1]] image:@"Images/grossini.png" atPosition:ccp(0.2, 0.5)]];
-    [self.contentNode addChild:[self spriteWithEffects:@[effects[2]] image:@"Images/grossini.png" atPosition:ccp(0.3, 0.5)]];
-    [self.contentNode addChild:[self spriteWithEffects:@[effects[3]] image:@"Images/grossini.png" atPosition:ccp(0.4, 0.5)]];
-    [self.contentNode addChild:[self spriteWithEffects:@[effects[4]] image:@"Images/grossini.png" atPosition:ccp(0.5, 0.5)]];
-    [self.contentNode addChild:[self spriteWithEffects:@[effects[5]] image:@"Images/grossini.png" atPosition:ccp(0.6, 0.5)]];
-    [self.contentNode addChild:[self spriteWithEffects:@[effects[6]] image:@"Images/grossini.png" atPosition:ccp(0.7, 0.5)]];
-    [self.contentNode addChild:[self spriteWithEffects:@[effects[7]] image:@"Images/grossini.png" atPosition:ccp(0.8, 0.5)]];
-    [self.contentNode addChild:[self spriteWithEffects:@[effects[8]] image:@"Images/grossini.png" atPosition:ccp(0.9, 0.5)]];
+    int stepCount = 12;
+    
+    float startX = 0.05f;
+    float endX = 0.95f;
+    float stepX = (endX - startX) / stepCount;
+    float x = startX;
+    float y = 0.5f;
+
+    float startHue = 180.0f;
+    float endHue = -180.0f;
+    float stepHue = (endHue - startHue) / stepCount;
+    float hue = startHue;
+    
+    for (int i = 0; i <= stepCount; i++)
+    {
+        [self.contentNode addChild:[self spriteWithEffects:@[[[CCEffectHue alloc] initWithHue:hue]] image:@"Images/grossini.png" atPosition:ccp(x, y)]];
+        x += stepX;
+        hue += stepHue;
+    }
 }
 
 -(void)setupPerformanceTest

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -247,7 +247,7 @@
 {
     self.subTitle = @"Glow Effect Node Test";
     
-    CCSprite *sampleSprite_base = [CCSprite spriteWithImageNamed:@"sample_hollow_circle.png"];
+    CCSprite *sampleSprite_base = [CCSprite spriteWithImageNamed:@"Images/sample_hollow_circle.png"];
     sampleSprite_base.anchorPoint = ccp(0.0, 0.0);
     sampleSprite_base.position = ccp(0.27, 0.52);
     sampleSprite_base.positionType = CCPositionTypeNormalized;
@@ -274,7 +274,7 @@
     [self.contentNode addChild:glowEffectNode];
     
     
-    CCSprite *sampleSprite_base2 = [CCSprite spriteWithImageNamed:@"grossini_dance_08.png"];
+    CCSprite *sampleSprite_base2 = [CCSprite spriteWithImageNamed:@"Images/grossini_dance_08.png"];
     sampleSprite_base2.anchorPoint = ccp(0.0, 0.0);
     sampleSprite_base2.position = ccp(0.53, 0.515);
     sampleSprite_base2.positionType = CCPositionTypeNormalized;
@@ -282,7 +282,7 @@
     [self.contentNode addChild:sampleSprite_base2];
     
     // Create a hollow circle
-    CCSprite *sampleSprite2 = [CCSprite spriteWithImageNamed:@"grossini_dance_08.png"];
+    CCSprite *sampleSprite2 = [CCSprite spriteWithImageNamed:@"Images/grossini_dance_08.png"];
     sampleSprite2.anchorPoint = ccp(0.5, 0.5);
     sampleSprite2.position = ccp(0.5, 0.5);
     sampleSprite2.positionType = CCPositionTypeNormalized;

--- a/cocos2d/CCEffectHue.h
+++ b/cocos2d/CCEffectHue.h
@@ -1,0 +1,13 @@
+//
+//  CCEffectHue.h
+//  cocos2d-ios
+//
+//  Created by Thayer J Andrews on 7/9/14.
+//
+//
+
+#import "CCEffect.h"
+
+@interface CCEffectHue : CCEffect
+
+@end

--- a/cocos2d/CCEffectHue.h
+++ b/cocos2d/CCEffectHue.h
@@ -8,6 +8,14 @@
 
 #import "CCEffect.h"
 
+#if CC_ENABLE_EXPERIMENTAL_EFFECTS
 @interface CCEffectHue : CCEffect
 
+@property (nonatomic) float hue;
+
+-(id)init;
+-(id)initWithHue:(float)hue;
++(id)effectWithHue:(float)hue;
+
 @end
+#endif

--- a/cocos2d/CCEffectHue.m
+++ b/cocos2d/CCEffectHue.m
@@ -7,7 +7,87 @@
 //
 
 #import "CCEffectHue.h"
+#import "CCEffect_Private.h"
+#import "CCRenderer.h"
+#import "CCTexture.h"
+
+#if CC_ENABLE_EXPERIMENTAL_EFFECTS
+static float conditionHue(float hue);
+
+@interface CCEffectHue ()
+
+@property (nonatomic) float conditionedHue;
+
+@end
+
 
 @implementation CCEffectHue
 
+-(id)init
+{
+    return [self initWithHue:0.0f];
+}
+
+-(id)initWithHue:(float)hue
+{
+    CCEffectUniform* uniformHue = [CCEffectUniform uniform:@"float" name:@"u_hue" value:[NSNumber numberWithFloat:hue]];
+    
+    if((self = [super initWithFragmentUniforms:@[uniformHue] vertexUniforms:nil varying:nil]))
+    {
+        _hue = hue;
+        _conditionedHue = conditionHue(hue);
+        
+        self.debugName = @"CCEffectHue";
+    }
+    return self;
+}
+
++(id)effectWithHue:(float)hue
+{
+    return [[self alloc] initWithHue:hue];
+}
+
+-(void)buildFragmentFunctions
+{
+    self.fragmentFunctions = [[NSMutableArray alloc] init];
+
+    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
+
+    NSString* effectBody = CC_GLSL(
+                                   return inputValue;
+                                   );
+    
+    CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"hueEffect" body:effectBody inputs:@[input] returnType:@"vec4"];
+    [self.fragmentFunctions addObject:fragmentFunction];
+}
+
+-(void)buildRenderPasses
+{
+    __weak CCEffectHue *weakSelf = self;
+    
+    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    pass0.shader = self.shader;
+    pass0.beginBlocks = @[[^(CCEffectRenderPass *pass, CCTexture *previousPassTexture){
+        pass.shaderUniforms[CCShaderUniformMainTexture] = previousPassTexture;
+        pass.shaderUniforms[CCShaderUniformPreviousPassTexture] = previousPassTexture;
+        pass.shaderUniforms[self.uniformTranslationTable[@"u_hue"]] = [NSNumber numberWithFloat:weakSelf.conditionedHue];
+    } copy]];
+    
+    self.renderPasses = @[pass0];
+}
+
+-(void)setHue:(float)hue
+{
+    _hue = hue;
+    _conditionedHue = conditionHue(hue);
+}
+
 @end
+
+float conditionHue(float hue)
+{
+    NSCAssert((hue >= -1.0) && (hue <= 1.0), @"Supplied hue out of range [-1..1].");
+    return clampf(hue, -1.0f, 1.0f);
+}
+
+#endif

--- a/cocos2d/CCEffectHue.m
+++ b/cocos2d/CCEffectHue.m
@@ -5,6 +5,40 @@
 //  Created by Thayer J Andrews on 7/9/14.
 //
 //
+//  This effect makes use of algorithms and GLSL shaders from GPUImage whose
+//  license is included here.
+//
+//  <Begin GPUImage license>
+//
+//  Copyright (c) 2012, Brad Larson, Ben Cochran, Hugues Lismonde, Keitaroh
+//  Kobayashi, Alaric Cole, Matthew Clark, Jacob Gundersen, Chris Williams.
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  Redistributions of source code must retain the above copyright notice, this
+//  list of conditions and the following disclaimer.
+//  Redistributions in binary form must reproduce the above copyright notice,
+//  this list of conditions and the following disclaimer in the documentation
+//  and/or other materials provided with the distribution.
+//  Neither the name of the GPUImage framework nor the names of its contributors
+//  may be used to endorse or promote products derived from this software
+//  without specific prior written permission.
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  <End GPUImage license>
+
 
 #import "CCEffectHue.h"
 #import "CCEffect_Private.h"
@@ -53,8 +87,41 @@ static float conditionHue(float hue);
 
     CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
 
+    // Image hue shader based on hue filter in GPUImage - https://github.com/BradLarson/GPUImage
     NSString* effectBody = CC_GLSL(
-                                   return inputValue;
+                                   const highp vec4  kRGBToYPrime = vec4 (0.299, 0.587, 0.114, 0.0);
+                                   const highp vec4  kRGBToI      = vec4 (0.595716, -0.274453, -0.321263, 0.0);
+                                   const highp vec4  kRGBToQ      = vec4 (0.211456, -0.522591, 0.31135, 0.0);
+                                   
+                                   const highp vec4  kYIQToR      = vec4 (1.0, 0.9563, 0.6210, 0.0);
+                                   const highp vec4  kYIQToG      = vec4 (1.0, -0.2721, -0.6474, 0.0);
+                                   const highp vec4  kYIQToB      = vec4 (1.0, -1.1070, 1.7046, 0.0);
+                                   
+                                   // Convert to YIQ
+                                   highp float YPrime = dot (inputValue, kRGBToYPrime);
+                                   highp float I      = dot (inputValue, kRGBToI);
+                                   highp float Q      = dot (inputValue, kRGBToQ);
+                                   
+                                   // Calculate the hue and chroma
+                                   highp float hue    = atan (Q, I);
+                                   highp float chroma = sqrt (I * I + Q * Q);
+                                   
+                                   // Make the user's adjustments.
+                                   hue += -u_hue; // Why is this negative?
+                                   
+                                   // Convert back to YIQ
+                                   Q = chroma * sin (hue);
+                                   I = chroma * cos (hue);
+                                   
+                                   // Convert back to RGB
+                                   vec4 outputColor;
+                                   highp vec4    yIQ   = vec4 (YPrime, I, Q, 0.0);
+                                   outputColor.r = dot (yIQ, kYIQToR);
+                                   outputColor.g = dot (yIQ, kYIQToG);
+                                   outputColor.b = dot (yIQ, kYIQToB);
+                                   outputColor.a = inputValue.a;
+                                   
+                                   return outputColor;
                                    );
     
     CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"hueEffect" body:effectBody inputs:@[input] returnType:@"vec4"];
@@ -86,8 +153,8 @@ static float conditionHue(float hue);
 
 float conditionHue(float hue)
 {
-    NSCAssert((hue >= -1.0) && (hue <= 1.0), @"Supplied hue out of range [-1..1].");
-    return clampf(hue, -1.0f, 1.0f);
+    NSCAssert((hue >= -180.0f) && (hue <= 180.0), @"Supplied hue out of range [-180.0..180.0].");
+    return clampf(hue, -180.0f, 180.0f) * M_PI / 180.0f;
 }
 
 #endif

--- a/cocos2d/CCEffectHue.m
+++ b/cocos2d/CCEffectHue.m
@@ -1,0 +1,13 @@
+//
+//  CCEffectHue.m
+//  cocos2d-ios
+//
+//  Created by Thayer J Andrews on 7/9/14.
+//
+//
+
+#import "CCEffectHue.h"
+
+@implementation CCEffectHue
+
+@end

--- a/cocos2d/CCEffectNode.h
+++ b/cocos2d/CCEffectNode.h
@@ -18,6 +18,7 @@
 #import "CCEffectBloom.h"
 #import "CCEffectBrightness.h"
 #import "CCEffectContrast.h"
+#import "CCEffectHue.h"
 #import "CCEffectPixellate.h"
 #import "CCEffectSaturation.h"
 #import "CCEffectRefraction.h"


### PR DESCRIPTION
- Replaces CCEffectGlow with CCEffectBloom.
- Updates image paths in the bloom test to work on OSX.
- Adds CCEffectHue and a test for it. The hue adjustments are specified in degrees ranging from -180 to 180.
