### PR TITLE
Only forward touch events if CCResponder has user interaction enabled

### DIFF
--- a/cocos2d/CCResponderManager.m
+++ b/cocos2d/CCResponderManager.m
@@ -433,7 +433,13 @@
 {
     for (CCRunningResponder *touchEntry in _runningResponderList)
     {
-        if (touchEntry.touch == touch) return(touchEntry);
+        if (touchEntry.touch == touch) {
+            CCNode *target = (CCNode *)touchEntry.target;
+            
+            if (target.userInteractionEnabled) {
+                return(touchEntry);
+            }
+        }
     }
     return(nil);
 }


### PR DESCRIPTION
With the current implementation touch events caused by an active touch will be forwarded to a `CCResponder` even if the responder sets `userInteractionEnabled` to `NO`. 

Can be reproduced with the following sequence:
- Start touch
- Set `userInteractionEnabled`to `NO`
- Move touch

With the current implementation `touchMoved` would be called in the above example. 
With the suggested change a touch event will only be forwarded if a node has `userInteractionEnabled` set to `YES`.
