### PR TITLE
Fixed bug #802. Changed opacity value from unsigned char to float.

### DIFF
--- a/cocos2d/CCTMXXMLParser.h
+++ b/cocos2d/CCTMXXMLParser.h
@@ -77,7 +77,7 @@ typedef enum ccTMXTileFlags_ {
 @property (nonatomic,readwrite)			BOOL visible;
 
 /** Layer Opacity. */
-@property (nonatomic,readwrite)			unsigned char opacity;
+@property (nonatomic,readwrite)			float opacity;
 
 /** True to release ownership of layer tiles. */
 @property (nonatomic,readwrite)			BOOL ownTiles;


### PR DESCRIPTION
Fixed bug #802. Changed opacity value from unsigned char to float.

http://forum.cocos2d-iphone.org/t/3-1-rc1-tilemap-layer-opacity-problem/13782
