### PR TITLE
CCActionFollow should use positionInPoints because it operates on the view size

### DIFF
--- a/cocos2d/CCAction.m
+++ b/cocos2d/CCAction.m
@@ -317,11 +317,11 @@
 		if(_boundaryFullyCovered)
 			return;
 
-		CGPoint tempPos = ccpSub( _halfScreenSize, _followedNode.position);
-		[(CCNode *)_target setPosition:ccp(clampf(tempPos.x, _leftBoundary, _rightBoundary), clampf(tempPos.y, _bottomBoundary, _topBoundary))];
+		CGPoint tempPos = ccpSub( _halfScreenSize, _followedNode.positionInPoints);
+		[(CCNode *)_target setPositionInPoints:ccp(clampf(tempPos.x, _leftBoundary, _rightBoundary), clampf(tempPos.y, _bottomBoundary, _topBoundary))];
 	}
 	else
-		[(CCNode *)_target setPosition:ccpSub( _halfScreenSize, _followedNode.position )];
+		[(CCNode *)_target setPositionInPoints:ccpSub( _halfScreenSize, _followedNode.positionInPoints )];
 }
 
 


### PR DESCRIPTION
Currently `CCActionFollow` breaks with normalized position types, because it is implemented assuming that the position types of the target Node and followed Node are points, which is necessary to compare positions to the `viewSize`. Since new position types have been introduced in Cocos2D 3.0 this action should use the `positionInPoints` property to always access the position in points.
