### PR TITLE
CCEffects - Various bug fixes, cleanup, and tweaks based on feedback

### DIFF
--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -274,8 +274,8 @@
 		D272032E18FC89A000B100FF /* CCEffectStack.m in Sources */ = {isa = PBXBuildFile; fileRef = D272032118FC89A000B100FF /* CCEffectStack.m */; };
 		D272033318FC9A4700B100FF /* CCEffectBloom.h in Headers */ = {isa = PBXBuildFile; fileRef = D272033118FC9A4700B100FF /* CCEffectBloom.h */; };
 		D272033418FC9A4700B100FF /* CCEffectBloom.m in Sources */ = {isa = PBXBuildFile; fileRef = D272033218FC9A4700B100FF /* CCEffectBloom.m */; };
-		D2B49104192146FB00C3443A /* CCEffectGaussianBlur.h in Headers */ = {isa = PBXBuildFile; fileRef = D2B49102192146FB00C3443A /* CCEffectGaussianBlur.h */; };
-		D2B49105192146FB00C3443A /* CCEffectGaussianBlur.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B49103192146FB00C3443A /* CCEffectGaussianBlur.m */; };
+		D2B49104192146FB00C3443A /* CCEffectBlur.h in Headers */ = {isa = PBXBuildFile; fileRef = D2B49102192146FB00C3443A /* CCEffectBlur.h */; };
+		D2B49105192146FB00C3443A /* CCEffectBlur.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B49103192146FB00C3443A /* CCEffectBlur.m */; };
 		D309055018AC23110081BF11 /* CCRenderer_private.h in Headers */ = {isa = PBXBuildFile; fileRef = D309054F18AC23110081BF11 /* CCRenderer_private.h */; };
 		D33803E318032ECE0072D8FE /* CCPhysicsBody.m in Sources */ = {isa = PBXBuildFile; fileRef = D33803E218032ECE0072D8FE /* CCPhysicsBody.m */; };
 		D33803E618032F390072D8FE /* CCPhysicsNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D33803E518032F390072D8FE /* CCPhysicsNode.m */; };
@@ -616,8 +616,8 @@
 		D272032118FC89A000B100FF /* CCEffectStack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectStack.m; sourceTree = "<group>"; };
 		D272033118FC9A4700B100FF /* CCEffectBloom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectBloom.h; sourceTree = "<group>"; };
 		D272033218FC9A4700B100FF /* CCEffectBloom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectBloom.m; sourceTree = "<group>"; };
-		D2B49102192146FB00C3443A /* CCEffectGaussianBlur.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectGaussianBlur.h; sourceTree = "<group>"; };
-		D2B49103192146FB00C3443A /* CCEffectGaussianBlur.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectGaussianBlur.m; sourceTree = "<group>"; };
+		D2B49102192146FB00C3443A /* CCEffectBlur.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectBlur.h; sourceTree = "<group>"; };
+		D2B49103192146FB00C3443A /* CCEffectBlur.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectBlur.m; sourceTree = "<group>"; };
 		D2B840C31909F447008063EA /* CCRenderTexture_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CCRenderTexture_Private.h; sourceTree = "<group>"; };
 		D309054F18AC23110081BF11 /* CCRenderer_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCRenderer_private.h; sourceTree = "<group>"; };
 		D33803DC18032E4F0072D8FE /* CCPhysics+ObjectiveChipmunk.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CCPhysics+ObjectiveChipmunk.h"; sourceTree = "<group>"; };
@@ -1242,8 +1242,8 @@
 				9DB75999196E09FF00AF3E4A /* CCEffectHue.m */,
 				9DF3761F191C594A00C6D27A /* CCEffectPixellate.h */,
 				9DF37620191C594A00C6D27A /* CCEffectPixellate.m */,
-				D2B49102192146FB00C3443A /* CCEffectGaussianBlur.h */,
-				D2B49103192146FB00C3443A /* CCEffectGaussianBlur.m */,
+				D2B49102192146FB00C3443A /* CCEffectBlur.h */,
+				D2B49103192146FB00C3443A /* CCEffectBlur.m */,
 				9DFB1E4E19241AEF008371EF /* CCEffectSaturation.h */,
 				9DFB1E4F19241AEF008371EF /* CCEffectSaturation.m */,
 				9D1C03B61954F636007B6735 /* CCEffectRefraction.h */,
@@ -1356,7 +1356,7 @@
 				B7705FE81831A07B0043CC67 /* ALDevice.h in Headers */,
 				B7705FCD1831A07B0043CC67 /* OALAction+Private.h in Headers */,
 				501CCFB50E99657C00B86F68 /* TGAlib.h in Headers */,
-				D2B49104192146FB00C3443A /* CCEffectGaussianBlur.h in Headers */,
+				D2B49104192146FB00C3443A /* CCEffectBlur.h in Headers */,
 				B7D2730D1822F4AA0054849B /* CCBAnimationManager.h in Headers */,
 				50F7B2780F28DE7C00057537 /* CCActionEase.h in Headers */,
 				B798D1451820305400E7BFCD /* CCSprite_Private.h in Headers */,
@@ -1594,7 +1594,7 @@
 				504055B10E3230BD00213FEF /* CCParticleExamples.m in Sources */,
 				506602120E38A70D000B500E /* CCScheduler.m in Sources */,
 				50A07B7B0E4CBCD300AAF0BB /* cocos2d.m in Sources */,
-				D2B49105192146FB00C3443A /* CCEffectGaussianBlur.m in Sources */,
+				D2B49105192146FB00C3443A /* CCEffectBlur.m in Sources */,
 				B7D273181822F4AA0054849B /* CCBSequenceProperty.m in Sources */,
 				501CCFB40E99657C00B86F68 /* TGAlib.m in Sources */,
 				B7E260D918171D2000A0E872 /* CCTextField.m in Sources */,

--- a/cocos2d-osx.xcodeproj/project.pbxproj
+++ b/cocos2d-osx.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		929D1B6D1954C2A600B27340 /* CCEffectBrightness.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B591954C2A600B27340 /* CCEffectBrightness.m */; };
 		929D1B6E1954C2A600B27340 /* CCEffectContrast.h in Headers */ = {isa = PBXBuildFile; fileRef = 929D1B5A1954C2A600B27340 /* CCEffectContrast.h */; };
 		929D1B6F1954C2A600B27340 /* CCEffectContrast.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B5B1954C2A600B27340 /* CCEffectContrast.m */; };
-		929D1B701954C2A600B27340 /* CCEffectGaussianBlur.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B5C1954C2A600B27340 /* CCEffectGaussianBlur.m */; };
+		929D1B701954C2A600B27340 /* CCEffectBlur.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B5C1954C2A600B27340 /* CCEffectBlur.m */; };
 		929D1B721954C2A600B27340 /* CCEffectNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 929D1B5E1954C2A600B27340 /* CCEffectNode.h */; };
 		929D1B731954C2A600B27340 /* CCEffectNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D1B5F1954C2A600B27340 /* CCEffectNode.m */; };
 		929D1B741954C2A600B27340 /* CCEffectPixellate.h in Headers */ = {isa = PBXBuildFile; fileRef = 929D1B601954C2A600B27340 /* CCEffectPixellate.h */; };
@@ -36,7 +36,7 @@
 		92D1343B1954FC7A003833C4 /* CCEffectStackProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D134361954FC7A003833C4 /* CCEffectStackProtocol.h */; };
 		92D1343C1954FC7A003833C4 /* CCRenderTexture_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D134371954FC7A003833C4 /* CCRenderTexture_Private.h */; };
 		92D1343E1954FC7A003833C4 /* CCActionManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D134391954FC7A003833C4 /* CCActionManager_Private.h */; };
-		92D1343F1954FC7A003833C4 /* CCEffectGaussianBlur.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D1343A1954FC7A003833C4 /* CCEffectGaussianBlur.h */; };
+		92D1343F1954FC7A003833C4 /* CCEffectBlur.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D1343A1954FC7A003833C4 /* CCEffectBlur.h */; };
 		9D23869C196F0BC4001B792B /* CCEffectHue.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D23869A196F0BC4001B792B /* CCEffectHue.h */; };
 		9D23869D196F0BC4001B792B /* CCEffectHue.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D23869B196F0BC4001B792B /* CCEffectHue.m */; };
 		9DB75994196E073200AF3E4A /* CCEffectBloom.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DB75992196E073200AF3E4A /* CCEffectBloom.h */; };
@@ -381,7 +381,7 @@
 		929D1B591954C2A600B27340 /* CCEffectBrightness.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectBrightness.m; sourceTree = "<group>"; };
 		929D1B5A1954C2A600B27340 /* CCEffectContrast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectContrast.h; sourceTree = "<group>"; };
 		929D1B5B1954C2A600B27340 /* CCEffectContrast.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectContrast.m; sourceTree = "<group>"; };
-		929D1B5C1954C2A600B27340 /* CCEffectGaussianBlur.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectGaussianBlur.m; sourceTree = "<group>"; };
+		929D1B5C1954C2A600B27340 /* CCEffectBlur.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectBlur.m; sourceTree = "<group>"; };
 		929D1B5E1954C2A600B27340 /* CCEffectNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectNode.h; sourceTree = "<group>"; };
 		929D1B5F1954C2A600B27340 /* CCEffectNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectNode.m; sourceTree = "<group>"; };
 		929D1B601954C2A600B27340 /* CCEffectPixellate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectPixellate.h; sourceTree = "<group>"; };
@@ -396,7 +396,7 @@
 		92D134361954FC7A003833C4 /* CCEffectStackProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectStackProtocol.h; sourceTree = "<group>"; };
 		92D134371954FC7A003833C4 /* CCRenderTexture_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCRenderTexture_Private.h; sourceTree = "<group>"; };
 		92D134391954FC7A003833C4 /* CCActionManager_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionManager_Private.h; sourceTree = "<group>"; };
-		92D1343A1954FC7A003833C4 /* CCEffectGaussianBlur.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectGaussianBlur.h; sourceTree = "<group>"; };
+		92D1343A1954FC7A003833C4 /* CCEffectBlur.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectBlur.h; sourceTree = "<group>"; };
 		9D23869A196F0BC4001B792B /* CCEffectHue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectHue.h; sourceTree = "<group>"; };
 		9D23869B196F0BC4001B792B /* CCEffectHue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectHue.m; sourceTree = "<group>"; };
 		9DB75992196E073200AF3E4A /* CCEffectBloom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectBloom.h; sourceTree = "<group>"; };
@@ -874,8 +874,8 @@
 				929D1B591954C2A600B27340 /* CCEffectBrightness.m */,
 				929D1B5A1954C2A600B27340 /* CCEffectContrast.h */,
 				929D1B5B1954C2A600B27340 /* CCEffectContrast.m */,
-				92D1343A1954FC7A003833C4 /* CCEffectGaussianBlur.h */,
-				929D1B5C1954C2A600B27340 /* CCEffectGaussianBlur.m */,
+				92D1343A1954FC7A003833C4 /* CCEffectBlur.h */,
+				929D1B5C1954C2A600B27340 /* CCEffectBlur.m */,
 				9D23869A196F0BC4001B792B /* CCEffectHue.h */,
 				9D23869B196F0BC4001B792B /* CCEffectHue.m */,
 				929D1B5E1954C2A600B27340 /* CCEffectNode.h */,
@@ -1685,7 +1685,7 @@
 				B74C2B9717BDA54600A829C0 /* CCSprite9Slice.h in Headers */,
 				B75C2E7717C5857F002B0E0D /* NSAttributedString+CCAdditions.h in Headers */,
 				B77060631831B0C40043CC67 /* OALActionManager.h in Headers */,
-				92D1343F1954FC7A003833C4 /* CCEffectGaussianBlur.h in Headers */,
+				92D1343F1954FC7A003833C4 /* CCEffectBlur.h in Headers */,
 				B77060711831B0C40043CC67 /* ObjectAL.h in Headers */,
 				A66680C317D4D73000ECDE6F /* CCResponder.h in Headers */,
 				A66680C517D4D73000ECDE6F /* CCResponderManager.h in Headers */,
@@ -1914,7 +1914,7 @@
 				B77060971831B0C40043CC67 /* OALAudioFile.m in Sources */,
 				2B192860163379400049A044 /* CCClippingNode.m in Sources */,
 				B77060741831B0C40043CC67 /* ALBuffer.m in Sources */,
-				929D1B701954C2A600B27340 /* CCEffectGaussianBlur.m in Sources */,
+				929D1B701954C2A600B27340 /* CCEffectBlur.m in Sources */,
 				B751D2611988896D00722D93 /* CCEffectReflection.m in Sources */,
 				A003ACA8165731D500C7B792 /* ccFPSImages.m in Sources */,
 				B74C2B9617BDA54600A829C0 /* CCSprite9Slice.m in Sources */,

--- a/cocos2d-ui-tests/tests/CCEffectPongTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectPongTest.m
@@ -10,7 +10,7 @@
 #import "CCTextureCache.h"
 #import "CCNodeColor.h"
 #import "CCEffectNode.h"
-#import "CCEffectGaussianBlur.h"
+#import "CCEffectBlur.h"
 
 
 #define PADDLE_SCALE 0.5f
@@ -37,7 +37,7 @@ typedef enum { TEST_PONG_PLAYING, TESTS_PONG_GAMEOVER } TEST_PONG_STATE;
     CGSize _designSize;
     
     CCEffectNode* _ballEffectNode;
-    CCEffectGaussianBlur* _ballEffect;
+    CCEffectBlur* _ballEffect;
     
     CCNodeColor* _ceiling;
     CCNodeColor* _floor;
@@ -155,7 +155,7 @@ typedef enum { TEST_PONG_PLAYING, TESTS_PONG_GAMEOVER } TEST_PONG_STATE;
         _ballEffectNode.scale = 0.1f;
         [_ballEffectNode addChild:_ball];
         
-        _ballEffect = [CCEffectGaussianBlur effectWithPixelBlurRadius:2.0];
+        _ballEffect = [CCEffectBlur effectWithPixelBlurRadius:2.0];
         _ballEffectNode.effect = _ballEffect;
     }
     

--- a/cocos2d-ui-tests/tests/CCEffectPongTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectPongTest.m
@@ -155,7 +155,7 @@ typedef enum { TEST_PONG_PLAYING, TESTS_PONG_GAMEOVER } TEST_PONG_STATE;
         _ballEffectNode.scale = 0.1f;
         [_ballEffectNode addChild:_ball];
         
-        _ballEffect = [CCEffectBlur effectWithPixelBlurRadius:2.0];
+        _ballEffect = [CCEffectBlur effectWithBlurRadius:2.0];
         _ballEffectNode.effect = _ballEffect;
     }
     

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -2,7 +2,7 @@
 #import "CCTextureCache.h"
 #import "CCNodeColor.h"
 #import "CCEffectNode.h"
-#import "CCEffectGaussianBlur.h"
+#import "CCEffectBlur.h"
 
 
 @interface CCEffectsTest : TestBase @end
@@ -283,7 +283,7 @@
     effectNode.positionType = CCPositionTypeNormalized;
     effectNode.position = ccp(0.1, 0.5);
     [effectNode addChild:sampleSprite];
-    CCEffectGaussianBlur* effect = [CCEffectGaussianBlur effectWithPixelBlurRadius:1.0];
+    CCEffectBlur* effect = [CCEffectBlur effectWithPixelBlurRadius:1.0];
     effectNode.effect = effect;
     
     [self.contentNode addChild:effectNode];
@@ -297,7 +297,7 @@
     effectNode2.positionType = CCPositionTypeNormalized;
     effectNode2.position = ccp(0.21, 0.5);
     [effectNode2 addChild:sampleSprite2];
-    CCEffectGaussianBlur* effect2 = [CCEffectGaussianBlur effectWithPixelBlurRadius:7.0];
+    CCEffectBlur* effect2 = [CCEffectBlur effectWithPixelBlurRadius:7.0];
     effectNode2.effect = effect2;
     
     [self.contentNode addChild:effectNode2];
@@ -313,7 +313,7 @@
     effectNode3.position = ccp(0.5, 0.5);
     effectNode3.anchorPoint = ccp(0.5, 0.5);
     [effectNode3 addChild:sampleSprite3];
-    CCEffectGaussianBlur* effect3 = [CCEffectGaussianBlur effectWithPixelBlurRadius:1.0];
+    CCEffectBlur* effect3 = [CCEffectBlur effectWithPixelBlurRadius:1.0];
     effectNode3.effect = effect3;
     
     [self.contentNode addChild:effectNode3];
@@ -327,7 +327,7 @@
     effectNode4.positionType = CCPositionTypeNormalized;
     effectNode4.position = ccp(0.6, 0.5);
     [effectNode4 addChild:sampleSprite4];
-    CCEffectGaussianBlur* effect4 = [CCEffectGaussianBlur effectWithPixelBlurRadius:7.0];
+    CCEffectBlur* effect4 = [CCEffectBlur effectWithPixelBlurRadius:7.0];
     effectNode4.effect = effect4;
         
     [self.contentNode addChild:effectNode4];
@@ -508,7 +508,7 @@
     [self.contentNode addChild:refractEnvironment];
     
     NSArray *effects = @[
-                         [CCEffectGaussianBlur effectWithPixelBlurRadius:7.0],
+                         [CCEffectBlur effectWithPixelBlurRadius:7.0],
                          [CCEffectBloom effectWithPixelBlurRadius:8 intensity:1.0f luminanceThreshold:0.0f],
                          [CCEffectBrightness effectWithBrightness:0.25f],
                          [CCEffectContrast effectWithContrast:1.0f],
@@ -563,7 +563,7 @@
     refractEnvironment.scale = 0.5;
     
     NSArray *allEffects = @[
-                            [CCEffectGaussianBlur effectWithPixelBlurRadius:7.0],
+                            [CCEffectBlur effectWithPixelBlurRadius:7.0],
                             [CCEffectBloom effectWithPixelBlurRadius:8 intensity:1.0f luminanceThreshold:0.0f],
                             [CCEffectBrightness effectWithBrightness:0.25f],
                             [CCEffectContrast effectWithContrast:1.0f],

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -81,7 +81,7 @@
     [self.contentNode addChild:environment];
     
     CCSpriteFrame *normalMap = [CCSpriteFrame frameWithImageNamed:@"Images/ShinyBallNormals.png"];
-    CCEffectReflection *reflection = [[CCEffectReflection alloc] initWithEnvironment:environment];
+    CCEffectReflection *reflection = [[CCEffectReflection alloc] initWithShininess:0.4f environment:environment];
     reflection.fresnelBias = 0.0f;
     reflection.fresnelPower = 0.0f;
     
@@ -517,7 +517,7 @@
                          [CCEffectHue effectWithHue:90.0f],
                          [CCEffectGlass effectWithRefraction:0.75f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment],
                          [CCEffectRefraction effectWithRefraction:0.75f environment:refractEnvironment],
-                         [CCEffectReflection effectWithFresnelBias:0.1f fresnelPower:2.0f environment:reflectEnvironment],
+                         [CCEffectReflection effectWithShininess:1.0f fresnelBias:0.1f fresnelPower:2.0f environment:reflectEnvironment],
                          ];
     
     
@@ -572,7 +572,7 @@
                             [CCEffectHue effectWithHue:90.0f],
                             [CCEffectGlass effectWithRefraction:0.5f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment],
                             [CCEffectRefraction effectWithRefraction:0.5f environment:refractEnvironment],
-                            [CCEffectReflection effectWithFresnelBias:0.1f fresnelPower:4.0f environment:reflectEnvironment],
+                            [CCEffectReflection effectWithShininess:1.0f fresnelBias:0.1f fresnelPower:4.0f environment:reflectEnvironment],
                             ];
     CCEffect *selectedEffect = allEffects[8];
 

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -283,7 +283,7 @@
     effectNode.positionType = CCPositionTypeNormalized;
     effectNode.position = ccp(0.1, 0.5);
     [effectNode addChild:sampleSprite];
-    CCEffectBlur* effect = [CCEffectBlur effectWithPixelBlurRadius:1.0];
+    CCEffectBlur* effect = [CCEffectBlur effectWithBlurRadius:1.0];
     effectNode.effect = effect;
     
     [self.contentNode addChild:effectNode];
@@ -297,7 +297,7 @@
     effectNode2.positionType = CCPositionTypeNormalized;
     effectNode2.position = ccp(0.21, 0.5);
     [effectNode2 addChild:sampleSprite2];
-    CCEffectBlur* effect2 = [CCEffectBlur effectWithPixelBlurRadius:7.0];
+    CCEffectBlur* effect2 = [CCEffectBlur effectWithBlurRadius:7.0];
     effectNode2.effect = effect2;
     
     [self.contentNode addChild:effectNode2];
@@ -313,7 +313,7 @@
     effectNode3.position = ccp(0.5, 0.5);
     effectNode3.anchorPoint = ccp(0.5, 0.5);
     [effectNode3 addChild:sampleSprite3];
-    CCEffectBlur* effect3 = [CCEffectBlur effectWithPixelBlurRadius:1.0];
+    CCEffectBlur* effect3 = [CCEffectBlur effectWithBlurRadius:1.0];
     effectNode3.effect = effect3;
     
     [self.contentNode addChild:effectNode3];
@@ -327,7 +327,7 @@
     effectNode4.positionType = CCPositionTypeNormalized;
     effectNode4.position = ccp(0.6, 0.5);
     [effectNode4 addChild:sampleSprite4];
-    CCEffectBlur* effect4 = [CCEffectBlur effectWithPixelBlurRadius:7.0];
+    CCEffectBlur* effect4 = [CCEffectBlur effectWithBlurRadius:7.0];
     effectNode4.effect = effect4;
         
     [self.contentNode addChild:effectNode4];
@@ -358,7 +358,7 @@
     glowEffectNode.positionType = CCPositionTypeNormalized;
     glowEffectNode.position = ccp(0.1, 0.5);
     [glowEffectNode addChild:sampleSprite];
-    CCEffectBloom* glowEffect = [CCEffectBloom effectWithPixelBlurRadius:8 intensity:1.0f luminanceThreshold:0.0f];
+    CCEffectBloom* glowEffect = [CCEffectBloom effectWithBlurRadius:8 intensity:1.0f luminanceThreshold:0.0f];
     glowEffectNode.effect = glowEffect;
     
     [self.contentNode addChild:glowEffectNode];
@@ -385,7 +385,7 @@
     glowEffectNode2.positionType = CCPositionTypeNormalized;
     glowEffectNode2.position = ccp(0.4, 0.5);
     [glowEffectNode2 addChild:sampleSprite2];
-    CCEffectBloom* glowEffect2 = [CCEffectBloom effectWithPixelBlurRadius:2 intensity:0.0f luminanceThreshold:0.0f];
+    CCEffectBloom* glowEffect2 = [CCEffectBloom effectWithBlurRadius:2 intensity:0.0f luminanceThreshold:0.0f];
     glowEffectNode2.effect = glowEffect2;
     
     [self.contentNode addChild:glowEffectNode2];
@@ -508,8 +508,8 @@
     [self.contentNode addChild:refractEnvironment];
     
     NSArray *effects = @[
-                         [CCEffectBlur effectWithPixelBlurRadius:7.0],
-                         [CCEffectBloom effectWithPixelBlurRadius:8 intensity:1.0f luminanceThreshold:0.0f],
+                         [CCEffectBlur effectWithBlurRadius:7.0],
+                         [CCEffectBloom effectWithBlurRadius:8 intensity:1.0f luminanceThreshold:0.0f],
                          [CCEffectBrightness effectWithBrightness:0.25f],
                          [CCEffectContrast effectWithContrast:1.0f],
                          [CCEffectPixellate effectWithBlockSize:8.0f],
@@ -563,8 +563,8 @@
     refractEnvironment.scale = 0.5;
     
     NSArray *allEffects = @[
-                            [CCEffectBlur effectWithPixelBlurRadius:7.0],
-                            [CCEffectBloom effectWithPixelBlurRadius:8 intensity:1.0f luminanceThreshold:0.0f],
+                            [CCEffectBlur effectWithBlurRadius:7.0],
+                            [CCEffectBloom effectWithBlurRadius:8 intensity:1.0f luminanceThreshold:0.0f],
                             [CCEffectBrightness effectWithBrightness:0.25f],
                             [CCEffectContrast effectWithContrast:1.0f],
                             [CCEffectPixellate effectWithBlockSize:4.0f],

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -526,7 +526,7 @@
     sprite.position = ccp(0.1f, 0.9f);
     sprite.scale = 0.5f;
 
-    sprite.effect = [[CCEffectStack alloc] initWithEffects:@[effects[4]]];
+    sprite.effect = [[CCEffectStack alloc] initWithEffects:@[effects[9], effects[6]]];
     sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:@"Images/ShinyBallNormals.png"];
     sprite.colorRGBA = [CCColor colorWithRed:0.75f green:0.75f blue:0.75f alpha:0.75f];
     

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -527,8 +527,8 @@
     sprite.position = ccp(0.5f, 0.5f);
     sprite.scale = 0.5f;
 
-    sprite.effect = [[CCEffectStack alloc] initWithEffects:@[effects[8], effects[9]]];
-//    sprite.effect = [[CCEffectStack alloc] initWithEffects:@[effects[7]]];
+    sprite.effect = [CCEffectStack effectStackWithEffects:@[effects[8], effects[9]]];
+//    sprite.effect = [CCEffectStack effectStackWithEffects:@[effects[7]]];
     
     sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:@"Images/ShinyBallNormals.png"];
     sprite.colorRGBA = [CCColor colorWithRed:0.75f green:0.75f blue:0.75f alpha:0.75f];
@@ -662,7 +662,7 @@
     }
     else if (effects.count > 1)
     {
-        CCEffectStack *stack = [[CCEffectStack alloc] initWithEffects:effects];
+        CCEffectStack *stack = [CCEffectStack effectStackWithEffects:effects];
         effectNode.effect = stack;
     }
     
@@ -683,7 +683,7 @@
     }
     else if (effects.count > 1)
     {
-        CCEffectStack *stack = [[CCEffectStack alloc] initWithEffects:effects];
+        CCEffectStack *stack = [CCEffectStack effectStackWithEffects:effects];
         sprite.effect = stack;
     }
     

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -515,9 +515,9 @@
                          [CCEffectPixellate effectWithBlockSize:8.0f],
                          [CCEffectSaturation effectWithSaturation:-1.0f],
                          [CCEffectHue effectWithHue:90.0f],
-                         [CCEffectGlass effectWithRefraction:0.5f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment],
-                         [CCEffectRefraction effectWithRefraction:0.5f environment:refractEnvironment],
-                         [CCEffectReflection effectWithFresnelBias:0.2f fresnelPower:2.0f environment:reflectEnvironment],
+                         [CCEffectGlass effectWithRefraction:0.75f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment],
+                         [CCEffectRefraction effectWithRefraction:0.75f environment:refractEnvironment],
+                         [CCEffectReflection effectWithFresnelBias:0.1f fresnelPower:2.0f environment:reflectEnvironment],
                          ];
     
     

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -521,22 +521,29 @@
                          ];
     
     
-    CCSprite *sprite = [CCSprite spriteWithImageNamed:@"Images/ShinyBallColor.png"];
+//    CCSprite *sprite = [CCSprite spriteWithImageNamed:@"Images/ShinyBallColor.png"];
+    CCSprite *sprite = [[CCSprite alloc] init];
     sprite.positionType = CCPositionTypeNormalized;
-    sprite.position = ccp(0.1f, 0.9f);
+    sprite.position = ccp(0.5f, 0.5f);
     sprite.scale = 0.5f;
 
-    sprite.effect = [[CCEffectStack alloc] initWithEffects:@[effects[9], effects[6]]];
+    sprite.effect = [[CCEffectStack alloc] initWithEffects:@[effects[8], effects[9]]];
+//    sprite.effect = [[CCEffectStack alloc] initWithEffects:@[effects[7]]];
+    
     sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:@"Images/ShinyBallNormals.png"];
     sprite.colorRGBA = [CCColor colorWithRed:0.75f green:0.75f blue:0.75f alpha:0.75f];
+    sprite.colorRGBA = [CCColor colorWithRed:0.0f green:0.0f blue:0.0f alpha:0.0f];
     
     [self.contentNode addChild:sprite];
     
+    CGPoint p1 = CGPointMake(0.1f, 0.1f);
+    CGPoint p2 = CGPointMake(0.9f, 0.9f);
+    
     [sprite runAction:[CCActionRepeatForever actionWithAction:[CCActionSequence actions:
-                                                               [CCActionMoveTo actionWithDuration:8.0 position:ccp(0.9f, 0.9f)],
-                                                               [CCActionMoveTo actionWithDuration:8.0 position:ccp(0.9f, 0.1f)],
-                                                               [CCActionMoveTo actionWithDuration:8.0 position:ccp(0.1f, 0.1f)],
-                                                               [CCActionMoveTo actionWithDuration:8.0 position:ccp(0.1f, 0.9f)],
+                                                               [CCActionMoveTo actionWithDuration:2.0 position:ccp(p1.x, p2.y)],
+                                                               [CCActionMoveTo actionWithDuration:4.0 position:ccp(p2.x, p2.y)],
+                                                               [CCActionMoveTo actionWithDuration:2.0 position:ccp(p2.x, p1.y)],
+                                                               [CCActionMoveTo actionWithDuration:4.0 position:ccp(p1.x, p1.y)],
                                                                nil
                                                                ]]];
 }

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -41,7 +41,7 @@
     
     
     CCSpriteFrame *normalMap = [CCSpriteFrame frameWithImageNamed:@"Images/ShinyBallNormals.png"];
-    CCEffectGlass *glass = [[CCEffectGlass alloc] initWithRefraction:1.0f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment];
+    CCEffectGlass *glass = [[CCEffectGlass alloc] initWithShininess:1.0f refraction:1.0f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment];
     glass.fresnelBias = 0.1f;
     glass.fresnelPower = 2.0f;
     glass.refraction = 0.75f;
@@ -515,7 +515,7 @@
                          [CCEffectPixellate effectWithBlockSize:8.0f],
                          [CCEffectSaturation effectWithSaturation:-1.0f],
                          [CCEffectHue effectWithHue:90.0f],
-                         [CCEffectGlass effectWithRefraction:0.75f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment],
+                         [CCEffectGlass effectWithShininess:1.0f refraction:0.75f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment],
                          [CCEffectRefraction effectWithRefraction:0.75f environment:refractEnvironment],
                          [CCEffectReflection effectWithShininess:1.0f fresnelBias:0.1f fresnelPower:2.0f environment:reflectEnvironment],
                          ];
@@ -570,7 +570,7 @@
                             [CCEffectPixellate effectWithBlockSize:4.0f],
                             [CCEffectSaturation effectWithSaturation:-1.0f],
                             [CCEffectHue effectWithHue:90.0f],
-                            [CCEffectGlass effectWithRefraction:0.5f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment],
+                            [CCEffectGlass effectWithShininess:1.0f refraction:0.5f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment],
                             [CCEffectRefraction effectWithRefraction:0.5f environment:refractEnvironment],
                             [CCEffectReflection effectWithShininess:1.0f fresnelBias:0.1f fresnelPower:4.0f environment:reflectEnvironment],
                             ];

--- a/cocos2d/CCEffect.m
+++ b/cocos2d/CCEffect.m
@@ -492,7 +492,7 @@ static NSString* vertBase =
     self.renderPasses = @[];
 }
 
--(NSInteger)renderPassesRequired
+-(NSUInteger)renderPassesRequired
 {
     return _renderPasses.count;
 }
@@ -512,9 +512,9 @@ static NSString* vertBase =
     return CCEffectPrepareNothingToDo;
 }
 
--(CCEffectRenderPass *)renderPassAtIndex:(NSInteger)passIndex
+-(CCEffectRenderPass *)renderPassAtIndex:(NSUInteger)passIndex
 {
-    NSAssert((passIndex >= 0) && (passIndex < _renderPasses.count), @"Pass index out of range.");
+    NSAssert((passIndex < _renderPasses.count), @"Pass index out of range.");
     return _renderPasses[passIndex];
 }
 

--- a/cocos2d/CCEffect.m
+++ b/cocos2d/CCEffect.m
@@ -299,29 +299,29 @@ static NSString* vertBase =
 
 -(id)init
 {
-    return [self initWithFragmentFunction:nil vertexFunctions:nil fragmentUniforms:nil vertexUniforms:nil varying:nil];
+    return [self initWithFragmentFunction:nil vertexFunctions:nil fragmentUniforms:nil vertexUniforms:nil varyings:nil];
 }
 
--(id)initWithFragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varying:(NSArray*)varying
+-(id)initWithFragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings
 {
-    return [self initWithFragmentFunction:nil vertexFunctions:nil fragmentUniforms:fragmentUniforms vertexUniforms:vertexUniforms varying:varying];
+    return [self initWithFragmentFunction:nil vertexFunctions:nil fragmentUniforms:fragmentUniforms vertexUniforms:vertexUniforms varyings:varyings];
 }
 
--(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varying:(NSArray*)varying
+-(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings
 {
-    return [self initWithFragmentFunction:fragmentFunctions vertexFunctions:nil fragmentUniforms:fragmentUniforms vertexUniforms:vertexUniforms varying:varying];
+    return [self initWithFragmentFunction:fragmentFunctions vertexFunctions:nil fragmentUniforms:fragmentUniforms vertexUniforms:vertexUniforms varyings:varyings];
 }
 
--(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varying:(NSArray*)varying
+-(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings
 {
     if((self = [super init]))
     {
-        [self buildEffectWithFragmentFunction:fragmentFunctions vertexFunctions:vertexFunctions fragmentUniforms:fragmentUniforms vertexUniforms:vertexUniforms varying:varying];
+        [self buildEffectWithFragmentFunction:fragmentFunctions vertexFunctions:vertexFunctions fragmentUniforms:fragmentUniforms vertexUniforms:vertexUniforms varyings:varyings];
     }
     return self;
 }
 
-- (void)buildEffectWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varying:(NSArray*)varying
+- (void)buildEffectWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings
 {
     if (fragmentFunctions)
     {
@@ -360,7 +360,7 @@ static NSString* vertBase =
         _vertexUniforms = [[CCEffect defaultEffectVertexUniforms] copy];
     }
     
-    [self setVarying:varying];
+    [self setVaryings:varyings];
     
     _stitchFlags = CCEffectFunctionStitchBoth;
     
@@ -400,11 +400,11 @@ static NSString* vertBase =
     }
 }
 
--(void)setVarying:(NSArray*)varying
+-(void)setVaryings:(NSArray*)varyings
 {
-    if (varying)
+    if (varyings)
     {
-        _varyingVars = [varying copy];
+        _varyingVars = [varyings copy];
     }
     else
     {

--- a/cocos2d/CCEffectBloom.h
+++ b/cocos2d/CCEffectBloom.h
@@ -85,6 +85,6 @@
  *  @return The CCEffectBloom object.
  *
  */
-+(id)effectWithPixelBlurRadius:(NSUInteger)blurRadius intensity:(float)intensity luminanceThreshold:(float)luminanceThreshold;
++(id)effectWithBlurRadius:(NSUInteger)blurRadius intensity:(float)intensity luminanceThreshold:(float)luminanceThreshold;
 
 @end

--- a/cocos2d/CCEffectBloom.m
+++ b/cocos2d/CCEffectBloom.m
@@ -92,7 +92,7 @@
     return self;
 }
 
-+(id)effectWithPixelBlurRadius:(NSUInteger)blurRadius intensity:(float)intensity luminanceThreshold:(float)luminanceThreshold
++(id)effectWithBlurRadius:(NSUInteger)blurRadius intensity:(float)intensity luminanceThreshold:(float)luminanceThreshold
 {
     return [[self alloc] initWithPixelBlurRadius:blurRadius intensity:intensity luminanceThreshold:luminanceThreshold];
 }

--- a/cocos2d/CCEffectBloom.m
+++ b/cocos2d/CCEffectBloom.m
@@ -81,7 +81,7 @@
     
     if(self = [super initWithFragmentUniforms:@[u_enableGlowMap, u_luminanceThreshold, u_intensity]
                                vertexUniforms:@[u_blurDirection]
-                                      varying:@[v_blurCoords]])
+                                     varyings:@[v_blurCoords]])
     {
         
         self.debugName = @"CCEffectBloom";
@@ -364,7 +364,7 @@
     {
         unsigned long count = (unsigned long)(1 + (_numberOfOptimizedOffsets * 2));
         CCEffectVarying* v_blurCoords = [CCEffectVarying varying:@"vec2" name:@"v_blurCoordinates" count:count];
-        [self setVarying:@[v_blurCoords]];
+        [self setVaryings:@[v_blurCoords]];
 
         [self buildFragmentFunctions];
         [self buildVertexFunctions];

--- a/cocos2d/CCEffectBloom.m
+++ b/cocos2d/CCEffectBloom.m
@@ -121,13 +121,13 @@
 
 - (void)setBlurRadiusAndDependents:(NSUInteger)blurRadius
 {
-    blurRadius = MIN(blurRadius, GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX);
+    blurRadius = MIN(blurRadius, BLUR_OPTIMIZED_RADIUS_MAX);
     _blurRadius = blurRadius;
     _sigma = blurRadius / 2;
     if(_sigma == 0.0)
         _sigma = 1.0f;
     
-    _numberOfOptimizedOffsets = MIN(blurRadius / 2 + (blurRadius % 2), GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX);
+    _numberOfOptimizedOffsets = MIN(blurRadius / 2 + (blurRadius % 2), BLUR_OPTIMIZED_RADIUS_MAX);
 }
 
 -(void)buildFragmentFunctions
@@ -157,7 +157,7 @@
     }
     
     // From these weights we calculate the offsets to read interpolated values from
-    NSUInteger numberOfOptimizedOffsets = MIN(_blurRadius / 2 + (_blurRadius % 2), GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX);
+    NSUInteger numberOfOptimizedOffsets = MIN(_blurRadius / 2 + (_blurRadius % 2), BLUR_OPTIMIZED_RADIUS_MAX);
     NSUInteger trueNumberOfOptimizedOffsets = _blurRadius / 2 + (_blurRadius % 2);
     
     NSMutableString *shaderString = [[NSMutableString alloc] init];

--- a/cocos2d/CCEffectBlur.h
+++ b/cocos2d/CCEffectBlur.h
@@ -60,7 +60,7 @@
  *
  *  @return The CCEffectBlur object.
  */
-+(id)effectWithPixelBlurRadius:(NSUInteger)blurRadius;
++(id)effectWithBlurRadius:(NSUInteger)blurRadius;
 
 @end
 

--- a/cocos2d/CCEffectBlur.h
+++ b/cocos2d/CCEffectBlur.h
@@ -1,5 +1,5 @@
 //
-//  CCEffectGaussianBlur.h
+//  CCEffectBlur.h
 //  cocos2d-ios
 //
 //  Created by Oleg Osin on 5/12/14.
@@ -10,10 +10,10 @@
 
 
 /**
- * CCEffectGaussianBlur performs blur operation on the pixels of the attached node.
+ * CCEffectBlur performs blur operation on the pixels of the attached node.
  */
 
-@interface CCEffectGaussianBlur : CCEffect
+@interface CCEffectBlur : CCEffect
 
 
 /// -----------------------------------------------------------------------
@@ -26,39 +26,39 @@
 
 
 /// -----------------------------------------------------------------------
-/// @name Initializing a CCEffectGaussianBlur object
+/// @name Initializing a CCEffectBlur object
 /// -----------------------------------------------------------------------
 
 /**
- *  Initializes a CCEffectGaussianBlur object with the following default parameters:
+ *  Initializes a CCEffectBlur object with the following default parameters:
  *  blurRadius = 2
  *
- *  @return The CCEffectGaussianBlur object.
+ *  @return The CCEffectBlur object.
  */
 -(id)init;
 
 /**
- *  Initializes a CCEffectGaussianBlur object with the specified parameters.
+ *  Initializes a CCEffectBlur object with the specified parameters.
  *
  *  @param blurRadius number of pixels blur will extend to (6 is the maximum, because we are limited by the number
  *  of varying variables that can be passed to a glsl program).
  *
- *  @return The CCEffectGaussianBlur object.
+ *  @return The CCEffectBlur object.
  */
 -(id)initWithPixelBlurRadius:(NSUInteger)blurRadius;
 
 
 /// -----------------------------------------------------------------------
-/// @name Creating a CCEffectGaussianBlur object
+/// @name Creating a CCEffectBlur object
 /// -----------------------------------------------------------------------
 
 /**
- *  Creates a CCEffectGaussianBlur object with the specified parameters.
+ *  Creates a CCEffectBlur object with the specified parameters.
  *
  *  @param blurRadius number of pixels blur will extend to (6 is the maximum, because we are limited by the number
  *  of varying variables that can be passed to a glsl program).
  *
- *  @return The CCEffectGaussianBlur object.
+ *  @return The CCEffectBlur object.
  */
 +(id)effectWithPixelBlurRadius:(NSUInteger)blurRadius;
 

--- a/cocos2d/CCEffectBlur.m
+++ b/cocos2d/CCEffectBlur.m
@@ -1,5 +1,5 @@
 //
-//  CCEffectGaussianBlur.m
+//  CCEffectBlur.m
 //  cocos2d-ios
 //
 //  Created by Oleg Osin on 5/12/14.
@@ -40,11 +40,11 @@
 //  <End GPUImage license>
 
 #import "CCEffect_Private.h"
-#import "CCEffectGaussianBlur.h"
+#import "CCEffectBlur.h"
 #import "CCTexture.h"
 
 
-@implementation CCEffectGaussianBlur {
+@implementation CCEffectBlur {
     NSUInteger _numberOfOptimizedOffsets;
     NSUInteger _blurRadius;
     GLfloat _sigma;
@@ -77,7 +77,7 @@
                                      varyings:[NSArray arrayWithObjects:v_blurCoords, nil]])
     {
         
-        self.debugName = @"CCEffectGaussianBlur";
+        self.debugName = @"CCEffectBlur";
         self.stitchFlags = 0;
         return self;
     }
@@ -103,13 +103,13 @@
 
 - (void)setBlurRadiusAndDependents:(NSUInteger)blurRadius
 {
-    blurRadius = MIN(blurRadius, GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX);
+    blurRadius = MIN(blurRadius, BLUR_OPTIMIZED_RADIUS_MAX);
     _blurRadius = blurRadius;
     _sigma = blurRadius / 2;
     if(_sigma == 0.0)
         _sigma = 1.0f;
     
-    _numberOfOptimizedOffsets = MIN(blurRadius / 2 + (blurRadius % 2), GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX);
+    _numberOfOptimizedOffsets = MIN(blurRadius / 2 + (blurRadius % 2), BLUR_OPTIMIZED_RADIUS_MAX);
 }
 
 -(void)buildFragmentFunctions
@@ -139,7 +139,7 @@
     }
     
     // From these weights we calculate the offsets to read interpolated values from
-    NSUInteger numberOfOptimizedOffsets = MIN(_blurRadius / 2 + (_blurRadius % 2), GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX);
+    NSUInteger numberOfOptimizedOffsets = MIN(_blurRadius / 2 + (_blurRadius % 2), BLUR_OPTIMIZED_RADIUS_MAX);
     NSUInteger trueNumberOfOptimizedOffsets = _blurRadius / 2 + (_blurRadius % 2);
     
     NSMutableString *shaderString = [[NSMutableString alloc] init];
@@ -261,10 +261,10 @@
     // pass 0: blurs (horizontal) texture[0] and outputs blurmap to texture[1]
     // pass 1: blurs (vertical) texture[1] and outputs to texture[2]
 
-    __weak CCEffectGaussianBlur *weakSelf = self;
+    __weak CCEffectBlur *weakSelf = self;
     
     CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
-    pass0.debugLabel = @"CCEffectGaussianBlur pass 0";
+    pass0.debugLabel = @"CCEffectBlur pass 0";
     pass0.shader = self.shader;
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[^(CCEffectRenderPass *pass, CCTexture *previousPassTexture){
@@ -279,7 +279,7 @@
 
     
     CCEffectRenderPass *pass1 = [[CCEffectRenderPass alloc] init];
-    pass1.debugLabel = @"CCEffectGaussianBlur pass 1";
+    pass1.debugLabel = @"CCEffectBlur pass 1";
     pass1.shader = self.shader;
     pass1.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass1.beginBlocks = @[[^(CCEffectRenderPass *pass, CCTexture *previousPassTexture){

--- a/cocos2d/CCEffectBlur.m
+++ b/cocos2d/CCEffectBlur.m
@@ -85,7 +85,7 @@
     return self;
 }
 
-+(id)effectWithPixelBlurRadius:(NSUInteger)blurRadius
++(id)effectWithBlurRadius:(NSUInteger)blurRadius
 {
     return [[self alloc] initWithPixelBlurRadius:blurRadius];
 }

--- a/cocos2d/CCEffectBrightness.m
+++ b/cocos2d/CCEffectBrightness.m
@@ -31,7 +31,7 @@ static float conditionBrightness(float brightness);
 {
     CCEffectUniform* uniformBrightness = [CCEffectUniform uniform:@"float" name:@"u_brightness" value:[NSNumber numberWithFloat:0.0f]];
     
-    if((self = [super initWithFragmentUniforms:@[uniformBrightness] vertexUniforms:nil varying:nil]))
+    if((self = [super initWithFragmentUniforms:@[uniformBrightness] vertexUniforms:nil varyings:nil]))
     {
         _brightness = brightness;
         _conditionedBrightness = [NSNumber numberWithFloat:conditionBrightness(brightness)];

--- a/cocos2d/CCEffectContrast.m
+++ b/cocos2d/CCEffectContrast.m
@@ -32,7 +32,7 @@ static float conditionContrast(float contrast);
 {
     CCEffectUniform* uniformContrast = [CCEffectUniform uniform:@"float" name:@"u_contrast" value:[NSNumber numberWithFloat:1.0f]];
     
-    if((self = [super initWithFragmentUniforms:@[uniformContrast] vertexUniforms:nil varying:nil]))
+    if((self = [super initWithFragmentUniforms:@[uniformContrast] vertexUniforms:nil varyings:nil]))
     {
         _contrast = contrast;
         _conditionedContrast = [NSNumber numberWithFloat:conditionContrast(contrast)];

--- a/cocos2d/CCEffectGaussianBlur.m
+++ b/cocos2d/CCEffectGaussianBlur.m
@@ -74,7 +74,7 @@
     
     if(self = [super initWithFragmentUniforms:nil
                                vertexUniforms:[NSArray arrayWithObjects:u_blurDirection, nil]
-                                      varying:[NSArray arrayWithObjects:v_blurCoords, nil]])
+                                     varyings:[NSArray arrayWithObjects:v_blurCoords, nil]])
     {
         
         self.debugName = @"CCEffectGaussianBlur";
@@ -300,7 +300,7 @@
     {
         unsigned long count = (unsigned long)(1 + (_numberOfOptimizedOffsets * 2));
         CCEffectVarying* v_blurCoords = [CCEffectVarying varying:@"vec2" name:@"v_blurCoordinates" count:count];
-        [self setVarying:@[v_blurCoords]];
+        [self setVaryings:@[v_blurCoords]];
 
         [self buildFragmentFunctions];
         [self buildVertexFunctions];

--- a/cocos2d/CCEffectGlass.h
+++ b/cocos2d/CCEffectGlass.h
@@ -28,6 +28,11 @@
  */
 @property (nonatomic) float refraction;
 
+/** The overall shininess of the attached sprite. This value is in the range [0..1] and it controls
+ *  how much of the reflected environment contributes to the final color of the affected pixels.
+ */
+@property (nonatomic) float shininess;
+
 /** The bias term in the fresnel reflectance equation:
  *    reflectance = max(0.0, fresnelBias + (1 - fresnelBias) * pow((1 - nDotV), fresnelPower))
  *  This value is in the range [0..1] and it controls the constant (view angle independent) contribution 
@@ -75,17 +80,19 @@
 /**
  *  Initializes a CCEffectGlass object with the supplied parameters and a nil normal map.
  *
+ *  @param shininess The overall shininess.
  *  @param refraction The refraction strength.
  *  @param refractionEnvironment The environment image that will be refracted by the affected node.
  *  @param reflectionEnvironment The environment image that will be reflected by the affected node.
  *
  *  @return The CCEffectGlass object.
  */
--(id)initWithRefraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment;
+-(id)initWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment;
 
 /**
  *  Initializes a CCEffectGlass object with the supplied parameters.
  *
+ *  @param shininess The overall shininess.
  *  @param refraction The refraction strength.
  *  @param refractionEnvironment The environment image that will be refracted by the affected node.
  *  @param reflectionEnvironment The environment image that will be reflected by the affected node.
@@ -93,7 +100,7 @@
  *
  *  @return The CCEffectGlass object.
  */
--(id)initWithRefraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap;
+-(id)initWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap;
 
 
 /// -----------------------------------------------------------------------
@@ -104,17 +111,19 @@
 /**
  *  Creates a CCEffectGlass object with the supplied parameters and a nil normal map.
  *
+ *  @param shininess The overall shininess.
  *  @param refraction The refraction strength.
  *  @param refractionEnvironment The environment image that will be refracted by the affected node.
  *  @param reflectionEnvironment The environment image that will be reflected by the affected node.
  *
  *  @return The CCEffectGlass object.
  */
-+(id)effectWithRefraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment;
++(id)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment;
 
 /**
  *  Creates a CCEffectGlass object with the supplied parameters.
  *
+ *  @param shininess The overall shininess.
  *  @param refraction The refraction strength.
  *  @param refractionEnvironment The environment image that will be refracted by the affected node.
  *  @param reflectionEnvironment The environment image that will be reflected by the affected node.
@@ -122,6 +131,6 @@
  *
  *  @return The CCEffectGlass object.
  */
-+(id)effectWithRefraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap;
++(id)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap;
 
 @end

--- a/cocos2d/CCEffectGlass.m
+++ b/cocos2d/CCEffectGlass.m
@@ -65,7 +65,7 @@ static const float CCEffectGlassDefaultFresnelPower = 2.0f;
                           
                           ];
     
-    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varying:nil]))
+    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varyings:nil]))
     {
         _refraction = refraction;
         _conditionedRefraction = CCEffectUtilsConditionRefraction(refraction);

--- a/cocos2d/CCEffectGlass.m
+++ b/cocos2d/CCEffectGlass.m
@@ -18,9 +18,16 @@
 #import "CCSprite_Private.h"
 
 
+static const float CCEffectGlassDefaultFresnelBias = 0.1f;
+static const float CCEffectGlassDefaultFresnelPower = 2.0f;
+
+
 @interface CCEffectGlass ()
 
 @property (nonatomic) float conditionedRefraction;
+@property (nonatomic) float conditionedShininess;
+@property (nonatomic) float conditionedFresnelBias;
+@property (nonatomic) float conditionedFresnelPower;
 
 @end
 
@@ -61,10 +68,17 @@
     if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varying:nil]))
     {
         _refraction = refraction;
-        _shininess = shininess;
-        _fresnelBias = 0.1f;
-        _fresnelPower = 2.0f;
         _conditionedRefraction = CCEffectUtilsConditionRefraction(refraction);
+        
+        _shininess = shininess;
+        _conditionedShininess = CCEffectUtilsConditionShininess(shininess);
+        
+        _fresnelBias = CCEffectGlassDefaultFresnelBias;
+        _conditionedFresnelBias = CCEffectUtilsConditionFresnelBias(CCEffectGlassDefaultFresnelBias);
+
+        _fresnelPower = CCEffectGlassDefaultFresnelPower;
+        _conditionedFresnelPower = CCEffectUtilsConditionFresnelPower(CCEffectGlassDefaultFresnelPower);
+        
         _refractionEnvironment = refractionEnvironment;
         _reflectionEnvironment = reflectionEnvironment;
         _normalMap = normalMap;
@@ -185,9 +199,9 @@
         
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_refraction"]] = [NSNumber numberWithFloat:weakSelf.conditionedRefraction];
         
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_shininess"]] = [NSNumber numberWithFloat:weakSelf.shininess];
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelBias"]] = [NSNumber numberWithFloat:weakSelf.fresnelBias];
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelPower"]] = [NSNumber numberWithFloat:weakSelf.fresnelPower];
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_shininess"]] = [NSNumber numberWithFloat:weakSelf.conditionedShininess];
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelBias"]] = [NSNumber numberWithFloat:weakSelf.conditionedFresnelBias];
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelPower"]] = [NSNumber numberWithFloat:weakSelf.conditionedFresnelPower];
         
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_refractEnvMap"]] = weakSelf.refractionEnvironment.texture ?: [CCTexture none];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_reflectEnvMap"]] = weakSelf.reflectionEnvironment.texture ?: [CCTexture none];
@@ -235,4 +249,23 @@
     _refraction = refraction;
     _conditionedRefraction = CCEffectUtilsConditionRefraction(refraction);
 }
+
+-(void)setShininess:(float)shininess
+{
+    _shininess = shininess;
+    _conditionedShininess = CCEffectUtilsConditionShininess(shininess);
+}
+
+-(void)setFresnelBias:(float)bias
+{
+    _fresnelBias = bias;
+    _conditionedFresnelBias = CCEffectUtilsConditionFresnelBias(bias);
+}
+
+-(void)setFresnelPower:(float)power
+{
+    _fresnelPower = power;
+    _conditionedFresnelPower = CCEffectUtilsConditionFresnelPower(power);
+}
+
 @end

--- a/cocos2d/CCEffectGlass.m
+++ b/cocos2d/CCEffectGlass.m
@@ -29,19 +29,20 @@
 
 -(id)init
 {
-    return [self initWithRefraction:1.0f refractionEnvironment:nil reflectionEnvironment:nil normalMap:nil];
+    return [self initWithShininess:1.0f refraction:1.0f refractionEnvironment:nil reflectionEnvironment:nil normalMap:nil];
 }
 
--(id)initWithRefraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment
+-(id)initWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment
 {
-    return [self initWithRefraction:refraction refractionEnvironment:refractionEnvironment reflectionEnvironment:reflectionEnvironment normalMap:nil];
+    return [self initWithShininess:shininess refraction:refraction refractionEnvironment:refractionEnvironment reflectionEnvironment:reflectionEnvironment normalMap:nil];
 }
 
--(id)initWithRefraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap
+-(id)initWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap
 {
     NSArray *uniforms = @[
                           [CCEffectUniform uniform:@"float" name:@"u_refraction" value:[NSNumber numberWithFloat:1.0f]],
                           
+                          [CCEffectUniform uniform:@"float" name:@"u_shininess" value:[NSNumber numberWithFloat:1.0f]],
                           [CCEffectUniform uniform:@"float" name:@"u_fresnelBias" value:[NSNumber numberWithFloat:0.0f]],
                           [CCEffectUniform uniform:@"float" name:@"u_fresnelPower" value:[NSNumber numberWithFloat:0.0f]],
                           
@@ -60,6 +61,7 @@
     if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varying:nil]))
     {
         _refraction = refraction;
+        _shininess = shininess;
         _fresnelBias = 0.1f;
         _fresnelPower = 2.0f;
         _conditionedRefraction = CCEffectUtilsConditionRefraction(refraction);
@@ -71,14 +73,15 @@
     }
     return self;
 }
-+(id)effectWithRefraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment
+
++(id)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment
 {
-    return [[self alloc] initWithRefraction:refraction refractionEnvironment:refractionEnvironment reflectionEnvironment:reflectionEnvironment];
+    return [[self alloc] initWithShininess:shininess refraction:refraction refractionEnvironment:refractionEnvironment reflectionEnvironment:reflectionEnvironment];
 }
 
-+(id)effectWithRefraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap
++(id)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap
 {
-    return [[self alloc] initWithRefraction:refraction refractionEnvironment:refractionEnvironment reflectionEnvironment:reflectionEnvironment normalMap:normalMap];
+    return [[self alloc] initWithShininess:shininess refraction:refraction refractionEnvironment:refractionEnvironment reflectionEnvironment:reflectionEnvironment normalMap:normalMap];
 }
 
 -(void)buildFragmentFunctions
@@ -147,7 +150,7 @@
                                    // Add the reflected color modulated by the fresnel term. Multiplying by the normal
                                    // map alpha also allows the effect to be disabled for specific pixels.
                                    float fresnel = max(u_fresnelBias + (1.0 - u_fresnelBias) * pow((1.0 - nDotV), u_fresnelPower), 0.0);
-                                   vec4 reflection = normalMap.a * fresnel * texture2D(u_reflectEnvMap, reflectTexCoords);
+                                   vec4 reflection = normalMap.a * fresnel * u_shininess * texture2D(u_reflectEnvMap, reflectTexCoords);
 
                                    return primaryColor + refraction + reflection;
                                    );
@@ -182,6 +185,7 @@
         
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_refraction"]] = [NSNumber numberWithFloat:weakSelf.conditionedRefraction];
         
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_shininess"]] = [NSNumber numberWithFloat:weakSelf.shininess];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelBias"]] = [NSNumber numberWithFloat:weakSelf.fresnelBias];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelPower"]] = [NSNumber numberWithFloat:weakSelf.fresnelPower];
         

--- a/cocos2d/CCEffectHue.m
+++ b/cocos2d/CCEffectHue.m
@@ -81,7 +81,7 @@ static GLKMatrix4 matrixWithHue(float hue);
 #endif
                           ];
     
-    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varying:nil]))
+    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varyings:nil]))
     {
         _hue = hue;
 #if CCEFFECTHUE_USES_COLOR_MATRIX

--- a/cocos2d/CCEffectNode.m
+++ b/cocos2d/CCEffectNode.m
@@ -168,7 +168,7 @@
     
     if (_effect)
     {
-        _effectRenderer.contentSize = self.texture.contentSize;
+        _effectRenderer.contentSize = self.contentSize;
         if ([_effect prepareForRendering] == CCEffectPrepareSuccess)
         {
             // Preparing an effect for rendering can modify its uniforms

--- a/cocos2d/CCEffectPixellate.m
+++ b/cocos2d/CCEffectPixellate.m
@@ -78,7 +78,7 @@ static float conditionBlockSize(float blockSize);
     return self;
 }
 
-+(id)effectWithBlockSize:(float)blockSize;
++(id)effectWithBlockSize:(float)blockSize
 {
     return [[self alloc] initWithBlockSize:blockSize];
 }

--- a/cocos2d/CCEffectPixellate.m
+++ b/cocos2d/CCEffectPixellate.m
@@ -66,7 +66,7 @@ static float conditionBlockSize(float blockSize);
     CCEffectUniform* uniformUStep = [CCEffectUniform uniform:@"float" name:@"u_uStep" value:[NSNumber numberWithFloat:1.0f]];
     CCEffectUniform* uniformVStep = [CCEffectUniform uniform:@"float" name:@"u_vStep" value:[NSNumber numberWithFloat:1.0f]];
     
-    if((self = [super initWithFragmentUniforms:@[uniformUStep, uniformVStep] vertexUniforms:nil varying:nil]))
+    if((self = [super initWithFragmentUniforms:@[uniformUStep, uniformVStep] vertexUniforms:nil varyings:nil]))
     {
         _blockSize = blockSize;
         _conditionedBlockSize = conditionBlockSize(blockSize);

--- a/cocos2d/CCEffectReflection.h
+++ b/cocos2d/CCEffectReflection.h
@@ -32,6 +32,11 @@
  */
 @property (nonatomic) CCSpriteFrame *normalMap;
 
+/** The overall shininess of the attached sprite. This value is in the range [0..1] and it controls
+ *  how much of the reflected environment contributes to the final color of the affected pixels.
+ */
+@property (nonatomic) float shininess;
+
 /** The bias term in the fresnel reflectance equation:
  *    reflectance = max(0.0, fresnelBias + (1 - fresnelBias) * pow((1 - nDotV), fresnelPower))
  *  This value is in the range [0..1] and it controls the constant (view angle independent) contribution
@@ -63,37 +68,41 @@
  *  Initializes a CCEffectReflection object with the specified environment and normal map and the following default parameters:
  *  fresnelBias = 1.0, fresnelPower = 0.0, normalMap = nil
  *
+ *  @param shininess The overall shininess of the effect.
  *  @param environment The environment image that will be reflected by the affected node.
  *
  *  @return The CCEffectReflection object.
  */
--(id)initWithEnvironment:(CCSprite *)environment;
+-(id)initWithShininess:(float)shininess environment:(CCSprite *)environment;
 
 /**
  *  Initializes a CCEffectReflection object with the specified environment and normal map and the following default parameters:
  *  fresnelBias = 1.0, fresnelPower = 0.0
  *
+ *  @param shininess The overall shininess of the effect.
  *  @param environment The environment image that will be reflected by the affected node.
  *  @param normalMap The normal map of the affected node. This can also be specified as a property of the affected sprite.
  *
  *  @return The CCEffectReflection object.
  */
--(id)initWithEnvironment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
+-(id)initWithShininess:(float)shininess environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
 
 /**
  *  Initializes a CCEffectReflection object with the specified parameters and a nil normal map.
  *
+ *  @param shininess The overall shininess of the effect.
  *  @param bias The bias term in the fresnel reflectance equation.
  *  @param power The power term in the fresnel reflectance equation.
  *  @param environment The environment image that will be reflected by the affected node.
  *
  *  @return The CCEffectReflection object.
  */
--(id)initWithFresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment;
+-(id)initWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment;
 
 /**
  *  Initializes a CCEffectReflection object with the specified parameters.
  *
+ *  @param shininess The overall shininess of the effect.
  *  @param bias The bias term in the fresnel reflectance equation.
  *  @param power The power term in the fresnel reflectance equation.
  *  @param environment The environment image that will be reflected by the affected node.
@@ -101,7 +110,7 @@
  *
  *  @return The CCEffectReflection object.
  */
--(id)initWithFresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
+-(id)initWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
 
 
 /// -----------------------------------------------------------------------
@@ -112,37 +121,41 @@
  *  Creates a CCEffectReflection object with the specified environment and the following default parameters:
  *  fresnelBias = 1.0, fresnelPower = 0.0, normalMap = nil
  *
+ *  @param shininess The overall shininess of the effect.
  *  @param environment The environment image that will be reflected by the affected node.
  *
  *  @return The CCEffectReflection object.
  */
-+(id)effectWithEnvironment:(CCSprite *)environment;
++(id)effectWithShininess:(float)shininess environment:(CCSprite *)environment;
 
 /**
  *  Creates a CCEffectReflection object with the specified environment and normal map and the following default parameters:
  *  fresnelBias = 1.0, fresnelPower = 0.0
  *
+ *  @param shininess The overall shininess of the effect.
  *  @param environment The environment image that will be reflected by the affected node.
  *  @param normalMap The normal map of the affected node. This can also be specified as a property of the affected sprite.
  *
  *  @return The CCEffectReflection object.
  */
-+(id)effectWithEnvironment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
++(id)effectWithShininess:(float)shininess environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
 
 /**
  *  Creates a CCEffectReflection object with the specified parameters and nil normal map.
  *
+ *  @param shininess The overall shininess of the effect.
  *  @param bias The bias term in the fresnel reflectance equation.
  *  @param power The power term in the fresnel reflectance equation.
  *  @param environment The environment image that will be reflected by the affected node.
  *
  *  @return The CCEffectReflection object.
  */
-+(id)effectWithFresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment;
++(id)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment;
 
 /**
  *  Creates a CCEffectReflection object with the specified parameters.
  *
+ *  @param shininess The overall shininess of the effect.
  *  @param bias The bias term in the fresnel reflectance equation.
  *  @param power The power term in the fresnel reflectance equation.
  *  @param environment The environment image that will be reflected by the affected node.
@@ -150,6 +163,6 @@
  *
  *  @return The CCEffectReflection object.
  */
-+(id)effectWithFresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
++(id)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
 
 @end

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -30,27 +30,28 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
 
 -(id)init
 {
-    return [self initWithEnvironment:nil];
+    return [self initWithShininess:1.0f environment:nil];
 }
 
--(id)initWithEnvironment:(CCSprite *)environment
+-(id)initWithShininess:(float)shininess environment:(CCSprite *)environment
 {
-    return [self initWithEnvironment:environment normalMap:nil];
+    return [self initWithShininess:shininess environment:environment normalMap:nil];
 }
 
--(id)initWithEnvironment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
+-(id)initWithShininess:(float)shininess environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
 {
-    return [self initWithFresnelBias:1.0f fresnelPower:0.0f environment:environment normalMap:normalMap];
+    return [self initWithShininess:shininess fresnelBias:1.0f fresnelPower:0.0f environment:environment normalMap:normalMap];
 }
 
--(id)initWithFresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment
+-(id)initWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment
 {
-    return [self initWithFresnelBias:bias fresnelPower:power environment:environment normalMap:nil];
+    return [self initWithShininess:shininess fresnelBias:bias fresnelPower:power environment:environment normalMap:nil];
 }
 
--(id)initWithFresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
+-(id)initWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
 {
     NSArray *uniforms = @[
+                          [CCEffectUniform uniform:@"float" name:@"u_shininess" value:[NSNumber numberWithFloat:1.0f]],
                           [CCEffectUniform uniform:@"float" name:@"u_fresnelBias" value:[NSNumber numberWithFloat:1.0f]],
                           [CCEffectUniform uniform:@"float" name:@"u_fresnelPower" value:[NSNumber numberWithFloat:0.0f]],
                           [CCEffectUniform uniform:@"sampler2D" name:@"u_envMap" value:(NSValue*)[CCTexture none]],
@@ -63,6 +64,7 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
     {
         _environment = environment;
         _normalMap = normalMap;
+        _shininess = shininess;
         _fresnelBias = bias;
         _fresnelPower = power;
         
@@ -71,24 +73,24 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
     return self;
 }
 
-+(id)effectWithEnvironment:(CCSprite *)environment
++(id)effectWithShininess:(float)shininess environment:(CCSprite *)environment
 {
-    return [[self alloc] initWithEnvironment:environment];
+    return [[self alloc] initWithShininess:shininess environment:environment];
 }
 
-+(id)effectWithEnvironment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
++(id)effectWithShininess:(float)shininess environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
 {
-    return [[self alloc] initWithEnvironment:environment normalMap:normalMap];
+    return [[self alloc] initWithShininess:shininess environment:environment normalMap:normalMap];
 }
 
-+(id)effectWithFresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment
++(id)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment
 {
-    return [[self alloc] initWithFresnelBias:bias fresnelPower:power environment:environment];
+    return [[self alloc] initWithShininess:shininess fresnelBias:bias fresnelPower:power environment:environment];
 }
 
-+(id)effectWithFresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
++(id)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
 {
-    return [[self alloc] initWithFresnelBias:bias fresnelPower:power environment:environment normalMap:normalMap];
+    return [[self alloc] initWithShininess:shininess fresnelBias:bias fresnelPower:power environment:environment normalMap:normalMap];
 }
 
 -(void)buildFragmentFunctions
@@ -130,7 +132,7 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
                                    // If the refracted texture coordinates are within the bounds of the environment map
                                    // blend the primary color with the refracted environment. Multiplying by the normal
                                    // map alpha also allows the effect to be disabled for specific pixels.
-                                   primaryColor += normalMap.a * fresnel * texture2D(u_envMap, reflectTexCoords);
+                                   primaryColor += normalMap.a * fresnel * u_shininess * texture2D(u_envMap, reflectTexCoords);
                                    return primaryColor;
                                    );
     
@@ -162,6 +164,7 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
             pass.verts = verts;
         }
         
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_shininess"]] = [NSNumber numberWithFloat:weakSelf.shininess];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelBias"]] = [NSNumber numberWithFloat:weakSelf.fresnelBias];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelPower"]] = [NSNumber numberWithFloat:weakSelf.fresnelPower];
         

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -22,6 +22,9 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
 
 @interface CCEffectReflection ()
 
+@property (nonatomic) float conditionedShininess;
+@property (nonatomic) float conditionedFresnelBias;
+@property (nonatomic) float conditionedFresnelPower;
 
 @end
 
@@ -62,11 +65,17 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
     
     if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varying:nil]))
     {
+        _shininess = shininess;
+        _conditionedShininess = CCEffectUtilsConditionShininess(shininess);
+        
+        _fresnelBias = bias;
+        _conditionedFresnelBias = CCEffectUtilsConditionFresnelBias(bias);
+        
+        _fresnelPower = power;
+        _conditionedFresnelPower = CCEffectUtilsConditionFresnelPower(power);
+        
         _environment = environment;
         _normalMap = normalMap;
-        _shininess = shininess;
-        _fresnelBias = bias;
-        _fresnelPower = power;
         
         self.debugName = @"CCEffectReflection";
     }
@@ -164,9 +173,9 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
             pass.verts = verts;
         }
         
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_shininess"]] = [NSNumber numberWithFloat:weakSelf.shininess];
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelBias"]] = [NSNumber numberWithFloat:weakSelf.fresnelBias];
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelPower"]] = [NSNumber numberWithFloat:weakSelf.fresnelPower];
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_shininess"]] = [NSNumber numberWithFloat:weakSelf.conditionedShininess];
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelBias"]] = [NSNumber numberWithFloat:weakSelf.conditionedFresnelBias];
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_fresnelPower"]] = [NSNumber numberWithFloat:weakSelf.conditionedFresnelPower];
         
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_envMap"]] = weakSelf.environment.texture ?: [CCTexture none];
         
@@ -189,6 +198,25 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
     
     self.renderPasses = @[pass0];
 }
+
+-(void)setShininess:(float)shininess
+{
+    _shininess = shininess;
+    _conditionedShininess = CCEffectUtilsConditionShininess(shininess);
+}
+
+-(void)setFresnelBias:(float)bias
+{
+    _fresnelBias = bias;
+    _conditionedFresnelBias = CCEffectUtilsConditionFresnelBias(bias);
+}
+
+-(void)setFresnelPower:(float)power
+{
+    _fresnelPower = power;
+    _conditionedFresnelPower = CCEffectUtilsConditionFresnelPower(power);
+}
+
 @end
 
 GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at)

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -17,8 +17,6 @@
 #import "CCEffect_Private.h"
 #import "CCSprite_Private.h"
 
-static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
-
 
 @interface CCEffectReflection ()
 
@@ -218,12 +216,4 @@ static GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at);
 }
 
 @end
-
-GLKMatrix4 GLKMatrix4FromAffineTransform(CGAffineTransform at)
-{
-    return GLKMatrix4Make(at.a,  at.b,  0.0f,  0.0f,
-                          at.c,  at.d,  0.0f,  0.0f,
-                          0.0f,  0.0f,  1.0f,  0.0f,
-                          at.tx, at.ty, 0.0f,  1.0f);
-}
 

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -61,7 +61,7 @@
                           [CCEffectUniform uniform:@"mat4" name:@"u_screenToEnv" value:[NSValue valueWithGLKMatrix4:GLKMatrix4Identity]],
                           ];
     
-    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varying:nil]))
+    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varyings:nil]))
     {
         _shininess = shininess;
         _conditionedShininess = CCEffectUtilsConditionShininess(shininess);

--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -46,7 +46,7 @@
                           [CCEffectUniform uniform:@"mat4" name:@"u_screenToEnv" value:[NSValue valueWithGLKMatrix4:GLKMatrix4Identity]],
                           ];
     
-    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varying:nil]))
+    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varyings:nil]))
     {
         _refraction = refraction;
         _conditionedRefraction = CCEffectUtilsConditionRefraction(refraction);

--- a/cocos2d/CCEffectRenderer.m
+++ b/cocos2d/CCEffectRenderer.m
@@ -151,7 +151,7 @@
     [self freeAllRenderTargets];
     
     CCEffectRenderTarget *previousPassRT = nil;
-    for(int i = 0; i < effect.renderPassesRequired; i++)
+    for(NSUInteger i = 0; i < effect.renderPassesRequired; i++)
     {
         BOOL lastPass = (i == (effect.renderPassesRequired - 1));
         BOOL directRendering = lastPass && effect.supportsDirectRendering;

--- a/cocos2d/CCEffectRenderer.m
+++ b/cocos2d/CCEffectRenderer.m
@@ -191,6 +191,9 @@
             renderPass.transform = GLKMatrix4MakeOrtho(0.0f, _contentSize.width, 0.0f, _contentSize.height, -1024.0f, 1024.0f);
 
             CGSize rtSize = CGSizeMake(_contentSize.width * _contentScale, _contentSize.height * _contentScale);
+            rtSize.width = (rtSize.width <= 1.0f) ? 1.0f : rtSize.width;
+            rtSize.height = (rtSize.height <= 1.0f) ? 1.0f : rtSize.height;
+            
             rt = [self renderTargetWithSize:rtSize];
             
             [renderPass begin:previousPassTexture];
@@ -249,6 +252,8 @@
 
 - (CCEffectRenderTarget *)renderTargetWithSize:(CGSize)size
 {
+    NSAssert((size.width > 0.0f) && (size.height > 0.0f), @"Render targets must have non-zero dimensions.");
+
     // If there is a free render target available for use, return that one. If
     // not, create a new one and return that.
     CCEffectRenderTarget *rt = nil;

--- a/cocos2d/CCEffectRenderer.m
+++ b/cocos2d/CCEffectRenderer.m
@@ -123,10 +123,23 @@
 @property (nonatomic, assign) GLKVector4 oldViewport;
 @property (nonatomic, assign) GLint oldFBO;
 
++(CCShader *)sharedCopyShader;
+
 @end
 
 
 @implementation CCEffectRenderer
+
++ (CCShader *)sharedCopyShader
+{
+	static dispatch_once_t once;
+	static CCShader *copyShader = nil;
+	dispatch_once(&once, ^{
+        copyShader = [[CCShader alloc] initWithFragmentShaderSource:@"void main(){gl_FragColor = texture2D(cc_MainTexture, cc_FragTexCoord1);}"];
+        copyShader.debugName = @"CCEffectRendererTextureCopyShader";
+	});
+	return copyShader;
+}
 
 -(id)init
 {
@@ -214,6 +227,7 @@
         [renderer pushGroup];
 
         CCTexture *backup = sprite.texture;
+        sprite.shader = [CCEffectRenderer sharedCopyShader];
         sprite.texture = previousPassRT.texture;
         [sprite enqueueTriangles:renderer transform:transform];
         sprite.texture = backup;

--- a/cocos2d/CCEffectSaturation.m
+++ b/cocos2d/CCEffectSaturation.m
@@ -67,7 +67,7 @@ static float conditionSaturation(float saturation);
 {
     CCEffectUniform* uniformSaturation = [CCEffectUniform uniform:@"float" name:@"u_saturation" value:[NSNumber numberWithFloat:1.0f]];
     
-    if((self = [super initWithFragmentUniforms:@[uniformSaturation] vertexUniforms:nil varying:nil]))
+    if((self = [super initWithFragmentUniforms:@[uniformSaturation] vertexUniforms:nil varyings:nil]))
     {
         _saturation = saturation;
         _conditionedSaturation = [NSNumber numberWithFloat:conditionSaturation(saturation)];

--- a/cocos2d/CCEffectStack.h
+++ b/cocos2d/CCEffectStack.h
@@ -38,13 +38,27 @@
 - (id)init;
 
 /**
- *  Initializes an empty effect stack object.
+ *  Initializes an effect stack object with the specified array of effects.
  *
  *  @param effects The array of effects to add to the stack.
  *
  *  @return The CCEffectStack object.
  */
 - (id)initWithEffects:(NSArray *)effects;
+
+
+/// -----------------------------------------------------------------------
+/// @name Creating a CCEffectStack object
+/// -----------------------------------------------------------------------
+
+/**
+ *  Creates an effect stack object with the specified array of effects.
+ *
+ *  @param effects The array of effects to add to the stack.
+ *
+ *  @return The CCEffectStack object.
+ */
++ (id)effectStackWithEffects:(NSArray *)effects;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectStack.m
+++ b/cocos2d/CCEffectStack.m
@@ -46,6 +46,11 @@
     return self;
 }
 
++ (id)effectStackWithEffects:(NSArray *)effects
+{
+    return [[self alloc] initWithEffects:effects];
+}
+
 - (NSUInteger)effectCount
 {
     return _effects.count;

--- a/cocos2d/CCEffectStack.m
+++ b/cocos2d/CCEffectStack.m
@@ -216,7 +216,7 @@
         effectIndex++;
     }
     
-    CCEffect* stitchedEffect = [[CCEffect alloc] initWithFragmentFunction:allFragFunctions vertexFunctions:allVertexFunctions fragmentUniforms:allFragUniforms vertexUniforms:allVertexUniforms varying:allVaryings];
+    CCEffect* stitchedEffect = [[CCEffect alloc] initWithFragmentFunction:allFragFunctions vertexFunctions:allVertexFunctions fragmentUniforms:allFragUniforms vertexUniforms:allVertexUniforms varyings:allVaryings];
     stitchedEffect.debugName = @"CCEffectStack_Stitched";
     
     // Set the stitch flags of the resulting effect based on the flags of the first

--- a/cocos2d/CCEffectUtils.h
+++ b/cocos2d/CCEffectUtils.h
@@ -13,4 +13,7 @@ CGAffineTransform CCEffectUtilsWorldToEnvironmentTransform(CCSprite *environment
 GLKVector4 CCEffectUtilsTangentInEnvironmentSpace(GLKMatrix4 effectToWorldMat, GLKMatrix4 worldToEnvMat);
 GLKMatrix4 CCEffectUtilsMat4FromAffineTransform(CGAffineTransform at);
 float CCEffectUtilsConditionRefraction(float refraction);
+float CCEffectUtilsConditionShininess(float shininess);
+float CCEffectUtilsConditionFresnelBias(float bias);
+float CCEffectUtilsConditionFresnelPower(float power);
 

--- a/cocos2d/CCEffectUtils.m
+++ b/cocos2d/CCEffectUtils.m
@@ -41,7 +41,7 @@ GLKMatrix4 CCEffectUtilsMat4FromAffineTransform(CGAffineTransform at)
 
 float CCEffectUtilsConditionRefraction(float refraction)
 {
-    NSCAssert((refraction >= -1.0) && (refraction <= 1.0), @"Supplied refraction out of range [-1..1].");
+    NSCAssert((refraction >= -1.0f) && (refraction <= 1.0f), @"Supplied refraction out of range [-1..1].");
     
     // Lerp between min and max
     if (refraction >= 0.0f)
@@ -53,4 +53,23 @@ float CCEffectUtilsConditionRefraction(float refraction)
         return CCEffectUtilsMinRefract * -refraction;
     }
 }
+
+float CCEffectUtilsConditionShininess(float shininess)
+{
+    NSCAssert((shininess >= 0.0f) && (shininess <= 1.0f), @"Supplied shininess out of range [0..1].");
+    return clampf(shininess, 0.0f, 1.0f);
+}
+
+float CCEffectUtilsConditionFresnelBias(float bias)
+{
+    NSCAssert((bias >= 0.0f) && (bias <= 1.0f), @"Supplied bias out of range [0..1].");
+    return clampf(bias, 0.0f, 1.0f);
+}
+
+float CCEffectUtilsConditionFresnelPower(float power)
+{
+    NSCAssert(power >= 0.0f, @"Supplied power out of range [0..inf].");
+    return (power < 0.0f) ? 0.0f : power;
+}
+
 

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -116,7 +116,7 @@ typedef void (^CCEffectRenderPassEndBlock)(CCEffectRenderPass *pass);
 
 @property (nonatomic, readonly) CCShader* shader; // Note: consider adding multiple shaders (one for reach renderpass, this will help break up logic and avoid branching in a potential uber shader).
 @property (nonatomic, readonly) NSMutableDictionary* shaderUniforms;
-@property (nonatomic, readonly) NSInteger renderPassesRequired;
+@property (nonatomic, readonly) NSUInteger renderPassesRequired;
 @property (nonatomic, readonly) BOOL supportsDirectRendering;
 @property (nonatomic, readonly) BOOL readyForRendering;
 
@@ -136,7 +136,7 @@ typedef void (^CCEffectRenderPassEndBlock)(CCEffectRenderPass *pass);
 -(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varying:(NSArray*)varying;
 
 -(CCEffectPrepareStatus)prepareForRendering;
--(CCEffectRenderPass *)renderPassAtIndex:(NSInteger)passIndex;
+-(CCEffectRenderPass *)renderPassAtIndex:(NSUInteger)passIndex;
 
 -(BOOL)stitchSupported:(CCEffectFunctionStitchFlags)stitch;
 

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -131,16 +131,16 @@ typedef void (^CCEffectRenderPassEndBlock)(CCEffectRenderPass *pass);
 @property (nonatomic) NSMutableDictionary* uniformTranslationTable;
 
 
--(id)initWithFragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varying:(NSArray*)varying;
--(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varying:(NSArray*)varying;
--(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varying:(NSArray*)varying;
+-(id)initWithFragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings;
+-(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings;
+-(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings;
 
 -(CCEffectPrepareStatus)prepareForRendering;
 -(CCEffectRenderPass *)renderPassAtIndex:(NSUInteger)passIndex;
 
 -(BOOL)stitchSupported:(CCEffectFunctionStitchFlags)stitch;
 
--(void)setVarying:(NSArray*)varying;
+-(void)setVaryings:(NSArray*)varyings;
 
 
 -(void)buildEffectShader;

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -10,8 +10,8 @@
 #import "CCEffectStackProtocol.h"
 
 
-#ifndef GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX
-#define GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX 6UL
+#ifndef BLUR_OPTIMIZED_RADIUS_MAX
+#define BLUR_OPTIMIZED_RADIUS_MAX 6UL
 #endif
 
 extern NSString * const CCShaderUniformPreviousPassTexture;

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -11,7 +11,7 @@
 
 
 #ifndef GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX
-#define GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX 6
+#define GAUSSIANBLUR_OPTMIZIED_RADIUS_MAX 6UL
 #endif
 
 extern NSString * const CCShaderUniformPreviousPassTexture;

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -369,7 +369,7 @@ EnqueueTriangles(CCSprite *self, CCRenderer *renderer, const GLKMatrix4 *transfo
 	
 	if (_effect)
 	{
-		_effectRenderer.contentSize = self.texture.contentSize;
+		_effectRenderer.contentSize = self.contentSize;
 		if ([self.effect prepareForRendering] == CCEffectPrepareSuccess)
 		{
 			// Preparing an effect for rendering can modify its uniforms

--- a/cocos2d/cocos2d.h
+++ b/cocos2d/cocos2d.h
@@ -66,7 +66,7 @@
 #import "CCEffectBloom.h"
 #import "CCEffectBrightness.h"
 #import "CCEffectContrast.h"
-#import "CCEffectGaussianBlur.h"
+#import "CCEffectBlur.h"
 #import "CCEffectGlass.h"
 #import "CCEffectHue.h"
 #import "CCEffectNode.h"


### PR DESCRIPTION
- Rename CCEffectGaussianBlur to CCEffectBlur
- Rename effectWithPixelBlurRadius to effectWithBlurRadius
- Add shininess property to CCEffectReflection and CCEffectGlass
- Add a constructor to CCEffectStack
- Avoid a GL error and subsequent assertion failure when applying effects to sprites with no texture and no normal map.
- Fix an issue with vertex shader stitching that resulted in incorrect results when stacking effects after reflection, refraction, and glass.
- Various compiler warning fixes
