### PR TITLE
Fixes nil string crash

### DIFF
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -1041,6 +1041,8 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
     {
         // This is a file, register font with font manager
         NSString* fontPath = [[CCFileUtils sharedFileUtils] fullPathForFilename:fontFile];
+        if (!fontPath)
+            return;
         NSURL* fontURL = [NSURL fileURLWithPath:fontPath];
         CTFontManagerRegisterFontsForURL((__bridge CFURLRef)fontURL, kCTFontManagerScopeProcess, NULL);
     }


### PR DESCRIPTION
I am not sure if this is a true fix but I was getting a crash in my app that was: [NSURL initFileURLWithPath:]: nil string parameter and I traced it back to the NSURL *fontURL line. Anyway after some logging, it seemed that registerCustomTTF was getting called twice. I am not sure why that is exactly as I am using the latest version of SpriteBuilder but the second time, fontPath was NULL and causing a crash. Anyway this simple check will simply avoid that crash as an immediate fix but hopefully this will bring awareness to this issue and perhaps you know of a better fix or a reason that this crash was happening in the first place.
