### PR TITLE
CCScrollView scrollViewDidScroll: fires once at the end of a scroll instead of every update loop

### DIFF
--- a/cocos2d-ui/CCScrollView.m
+++ b/cocos2d-ui/CCScrollView.m
@@ -114,7 +114,9 @@
     float y = node.position.y;
     
 	node.position = ccp(x,y);
-	block();
+	if (node.position.x == _endPosition) {
+        block();
+    }
 }
 @end
 
@@ -154,7 +156,9 @@
     float x = node.position.x;
     
 	node.position = ccp(x,y);
-	block();
+	if (node.position.y == _endPosition) {
+        block();
+    }
 }
 @end
 


### PR DESCRIPTION
Fixed #916. CCScrollView scrollViewDidScroll: now fires once at the end of a scroll instead of once every update loop.
