### PR TITLE
CCEffects - Stack constructors, bloom fixes, and stacking fixes

### DIFF
--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -470,15 +470,15 @@
                          ];
 
     // Effect nodes that use the effects in different combinations.
-    [self.contentNode addChild:[self effectNodeWithEffects:@[effects[0]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.1, 0.5)]];
-    [self.contentNode addChild:[self effectNodeWithEffects:@[effects[1]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.2, 0.5)]];
-    [self.contentNode addChild:[self effectNodeWithEffects:@[effects[2]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.3, 0.5)]];
-    [self.contentNode addChild:[self effectNodeWithEffects:@[effects[3]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.4, 0.5)]];
-    [self.contentNode addChild:[self effectNodeWithEffects:@[effects[4]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.5, 0.5)]];
-    [self.contentNode addChild:[self effectNodeWithEffects:@[effects[5]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.6, 0.5)]];
-    [self.contentNode addChild:[self effectNodeWithEffects:@[effects[6]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.7, 0.5)]];
-    [self.contentNode addChild:[self effectNodeWithEffects:@[effects[7]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.8, 0.5)]];
-    [self.contentNode addChild:[self effectNodeWithEffects:@[effects[8]] appliedToSpriteWithImage:@"Images/grossini.png" atPosition:ccp(0.9, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[0]] image:@"Images/grossini.png" atPosition:ccp(0.1, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[1]] image:@"Images/grossini.png" atPosition:ccp(0.2, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[2]] image:@"Images/grossini.png" atPosition:ccp(0.3, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[3]] image:@"Images/grossini.png" atPosition:ccp(0.4, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[4]] image:@"Images/grossini.png" atPosition:ccp(0.5, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[5]] image:@"Images/grossini.png" atPosition:ccp(0.6, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[6]] image:@"Images/grossini.png" atPosition:ccp(0.7, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[7]] image:@"Images/grossini.png" atPosition:ccp(0.8, 0.5)]];
+    [self.contentNode addChild:[self spriteWithEffects:@[effects[8]] image:@"Images/grossini.png" atPosition:ccp(0.9, 0.5)]];
 }
 
 -(void)setupHueEffectTest

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -527,8 +527,7 @@
     sprite.position = ccp(0.5f, 0.5f);
     sprite.scale = 0.5f;
 
-    sprite.effect = [CCEffectStack effectStackWithEffects:@[effects[8], effects[9]]];
-//    sprite.effect = [CCEffectStack effectStackWithEffects:@[effects[7]]];
+    sprite.effect = [CCEffectStack effects:effects[8], effects[9], nil];
     
     sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:@"Images/ShinyBallNormals.png"];
     sprite.colorRGBA = [CCColor colorWithRed:0.75f green:0.75f blue:0.75f alpha:0.75f];
@@ -662,7 +661,7 @@
     }
     else if (effects.count > 1)
     {
-        CCEffectStack *stack = [CCEffectStack effectStackWithEffects:effects];
+        CCEffectStack *stack = [CCEffectStack effectWithArray:effects];
         effectNode.effect = stack;
     }
     
@@ -683,7 +682,7 @@
     }
     else if (effects.count > 1)
     {
-        CCEffectStack *stack = [CCEffectStack effectStackWithEffects:effects];
+        CCEffectStack *stack = [CCEffectStack effectWithArray:effects];
         sprite.effect = stack;
     }
     

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -333,9 +333,9 @@
     [self.contentNode addChild:effectNode4];
 }
 
--(void)setupGlowEffectNodeTest
+-(void)setupBloomEffectTest
 {
-    self.subTitle = @"Glow Effect Node Test";
+    self.subTitle = @"Bloom Effect Test";
     
     CCSprite *sampleSprite_base = [CCSprite spriteWithImageNamed:@"Images/sample_hollow_circle.png"];
     sampleSprite_base.anchorPoint = ccp(0.0, 0.0);
@@ -389,6 +389,22 @@
     glowEffectNode2.effect = glowEffect2;
     
     [self.contentNode addChild:glowEffectNode2];
+
+    // Create a sprite to blur
+    const int steps = 5;
+    for (int i = 0; i < steps; i++)
+    {
+        CCSprite *sampleSprite3 = [CCSprite spriteWithImageNamed:@"Images/grossini_dance_08.png"];
+        sampleSprite3.anchorPoint = ccp(0.5, 0.5);
+        sampleSprite3.position = ccp(0.1f + i * (0.8f / (steps - 1)), 0.2f);
+        sampleSprite3.positionType = CCPositionTypeNormalized;
+        
+        // Blend glow maps test
+        CCEffectBloom* glowEffect3 = [CCEffectBloom effectWithBlurRadius:8 intensity:1.0f luminanceThreshold:1.0f - ((float)i/(float)(steps-1))];
+        sampleSprite3.effect = glowEffect3;
+        
+        [self.contentNode addChild:sampleSprite3];
+    }
 }
 
 -(void)setupBrightnessAndContrastEffectNodeTest

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -81,7 +81,7 @@
     [self.contentNode addChild:environment];
     
     CCSpriteFrame *normalMap = [CCSpriteFrame frameWithImageNamed:@"Images/ShinyBallNormals.png"];
-    CCEffectReflection *reflection = [[CCEffectReflection alloc] initWithShininess:0.4f environment:environment];
+    CCEffectReflection *reflection = [[CCEffectReflection alloc] initWithShininess:1.0f environment:environment];
     reflection.fresnelBias = 0.0f;
     reflection.fresnelPower = 0.0f;
     
@@ -543,7 +543,7 @@
     sprite.position = ccp(0.5f, 0.5f);
     sprite.scale = 0.5f;
 
-    sprite.effect = [CCEffectStack effects:effects[8], effects[9], nil];
+    sprite.effect = [CCEffectStack effects:effects[7], effects[4], nil];
     
     sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:@"Images/ShinyBallNormals.png"];
     sprite.colorRGBA = [CCColor colorWithRed:0.75f green:0.75f blue:0.75f alpha:0.75f];

--- a/cocos2d/CCEffectBloom.m
+++ b/cocos2d/CCEffectBloom.m
@@ -105,7 +105,7 @@
 -(void)setIntensity:(float)intensity
 {
     _intensity = clampf(intensity, 0.0f, 1.0f);
-    _transformedIntensity = 1.0f - _intensity;
+    _transformedIntensity = _intensity;
 }
 
 -(void)setBlurRadius:(NSUInteger)blurRadius
@@ -214,7 +214,7 @@
     // Choose one?
     // TODO: try using min(src, dst) to create a gloomEffect
     // NSString* additiveBlending =  @"src + dst";
-    NSString* screenBlending = @"(src + dst) - ((src * dst) * u_intensity)";
+    NSString* screenBlending = @"(src * u_intensity + dst) - ((src * dst) * u_intensity)";
     
     [shaderString appendFormat:@"\
      return %@;\n", screenBlending];

--- a/cocos2d/CCEffectBloom.m
+++ b/cocos2d/CCEffectBloom.m
@@ -169,17 +169,27 @@
     
     [shaderString appendString:@"if(u_enableGlowMap == 0.0) {\n"];
      
+    [shaderString appendString:@"const vec3 luminanceWeighting = vec3(0.2125, 0.7154, 0.0721);\n"];
+    [shaderString appendString:@"vec4 srcPixel; float luminanceCheck;\n"];
+
     // Inner texture loop
-    [shaderString appendFormat:@"src += texture2D(cc_PreviousPassTexture, v_blurCoordinates[0]) * %f;\n", standardGaussianWeights[0]];
+    [shaderString appendFormat:@"srcPixel = texture2D(cc_PreviousPassTexture, v_blurCoordinates[0]);\n"];
+    [shaderString appendString:@"luminanceCheck = step(u_luminanceThreshold, dot(srcPixel.rgb, luminanceWeighting));\n"];
+    [shaderString appendFormat:@"src += luminanceCheck * srcPixel * %f;\n", standardGaussianWeights[0]];
     
     for (NSUInteger currentBlurCoordinateIndex = 0; currentBlurCoordinateIndex < numberOfOptimizedOffsets; currentBlurCoordinateIndex++)
     {
         GLfloat firstWeight = standardGaussianWeights[currentBlurCoordinateIndex * 2 + 1];
         GLfloat secondWeight = standardGaussianWeights[currentBlurCoordinateIndex * 2 + 2];
         GLfloat optimizedWeight = firstWeight + secondWeight;
-        
-        [shaderString appendFormat:@"src += texture2D(cc_PreviousPassTexture, v_blurCoordinates[%lu]) * %f;\n", (unsigned long)((currentBlurCoordinateIndex * 2) + 1), optimizedWeight];
-        [shaderString appendFormat:@"src += texture2D(cc_PreviousPassTexture, v_blurCoordinates[%lu]) * %f;\n", (unsigned long)((currentBlurCoordinateIndex * 2) + 2), optimizedWeight];
+
+        [shaderString appendFormat:@"srcPixel = texture2D(cc_PreviousPassTexture, v_blurCoordinates[%lu]);\n", (unsigned long)((currentBlurCoordinateIndex * 2) + 1)];
+        [shaderString appendString:@"luminanceCheck = step(u_luminanceThreshold, dot(srcPixel.rgb, luminanceWeighting));\n"];
+        [shaderString appendFormat:@"src += luminanceCheck * srcPixel * %f;\n", optimizedWeight];
+
+        [shaderString appendFormat:@"srcPixel = texture2D(cc_PreviousPassTexture, v_blurCoordinates[%lu]);\n", (unsigned long)((currentBlurCoordinateIndex * 2) + 2)];
+        [shaderString appendString:@"luminanceCheck = step(u_luminanceThreshold, dot(srcPixel.rgb, luminanceWeighting));\n"];
+        [shaderString appendFormat:@"src += luminanceCheck * srcPixel * %f;\n", optimizedWeight];        
     }
     
     // If the number of required samples exceeds the amount we can pass in via varyings, we have to do dependent texture reads in the fragment shader
@@ -194,15 +204,16 @@
             
             GLfloat optimizedWeight = firstWeight + secondWeight;
             GLfloat optimizedOffset = (firstWeight * (currentOverlowTextureRead * 2 + 1) + secondWeight * (currentOverlowTextureRead * 2 + 2)) / optimizedWeight;
-            
-            [shaderString appendFormat:@"src += texture2D(cc_PreviousPassTexture, v_blurCoordinates[0] + singleStepOffset * %f) * %f;\n", optimizedOffset, optimizedWeight];
-            [shaderString appendFormat:@"src += texture2D(cc_PreviousPassTexture, v_blurCoordinates[0] - singleStepOffset * %f) * %f;\n", optimizedOffset, optimizedWeight];
+
+            [shaderString appendFormat:@"srcPixel = texture2D(cc_PreviousPassTexture, v_blurCoordinates[0] + singleStepOffset * %f);\n", optimizedOffset];
+            [shaderString appendString:@"luminanceCheck = step(u_luminanceThreshold, dot(srcPixel.rgb, luminanceWeighting));\n"];
+            [shaderString appendFormat:@"src += luminanceCheck * srcPixel * %f;\n", optimizedWeight];
+
+            [shaderString appendFormat:@"srcPixel = texture2D(cc_PreviousPassTexture, v_blurCoordinates[0] - singleStepOffset * %f);\n", optimizedOffset];
+            [shaderString appendString:@"luminanceCheck = step(u_luminanceThreshold, dot(srcPixel.rgb, luminanceWeighting));\n"];
+            [shaderString appendFormat:@"src += luminanceCheck * srcPixel * %f;\n", optimizedWeight];
         }
     }
-    
-    [shaderString appendString:@"const vec3 luminanceWeighting = vec3(0.2125, 0.7154, 0.0721);\n\
-     float luminance = dot(src.rgb, luminanceWeighting);\n\
-     if(luminance < u_luminanceThreshold)\n discard;\n"];
     
     [shaderString appendString:@"} else {\n"];
     [shaderString appendString:@"\
@@ -328,7 +339,7 @@
 
         pass.shaderUniforms[CCShaderUniformPreviousPassTexture] = previousPassTexture;
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_enableGlowMap"]] = [NSNumber numberWithFloat:0.0f];
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_luminanceThreshold"]] = [NSNumber numberWithFloat:_luminanceThreshold];
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_luminanceThreshold"]] = [NSNumber numberWithFloat:0.0f];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_intensity"]] = [NSNumber numberWithFloat:_transformedIntensity];
         
         GLKVector2 dur = GLKVector2Make(0.0, 1.0 / (previousPassTexture.pixelHeight / previousPassTexture.contentScale));
@@ -344,7 +355,7 @@
         
         pass.shaderUniforms[CCShaderUniformPreviousPassTexture] = previousPassTexture;
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_enableGlowMap"]] = [NSNumber numberWithFloat:1.0f];
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_luminanceThreshold"]] = [NSNumber numberWithFloat:_luminanceThreshold];
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_luminanceThreshold"]] = [NSNumber numberWithFloat:0.0f];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_intensity"]] = [NSNumber numberWithFloat:_transformedIntensity];
         
     } copy]];

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -15,7 +15,6 @@
 #import "CCTexture.h"
 
 #import "CCEffect_Private.h"
-#import "CCRenderer_Private.h"
 #import "CCSprite_Private.h"
 
 
@@ -196,9 +195,6 @@
         
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_envMap"]] = weakSelf.environment.texture ?: [CCTexture none];
         
-        CGFloat scale = [CCDirector sharedDirector].contentScaleFactor;
-        CGAffineTransform screenToWorld = CGAffineTransformMake(1.0f / scale, 0.0f, 0.0f, 1.0f / scale, 0.0f, 0.0f);
-        
         // Get the transform from world space to environment texture space. This is
         // concatenated with the current transform to move from local node space to
         // environment texture space.
@@ -213,12 +209,9 @@
         
         // Setup the transform from normalized device coordinates (NDC, which is the space our vertex
         // positions are in) to environment texture space. We use this to compute environment texture
-        // coordinates in the vertex shader.
-        GLKMatrix4 ndcToWorldMat;
-        [pass.renderer.globalShaderUniforms[CCShaderUniformProjectionInv] getValue:&ndcToWorldMat];
-        
+        // coordinates in the vertex shader.s
         GLKMatrix4 worldToReflectEnvTextureMat = CCEffectUtilsMat4FromAffineTransform(worldToReflectEnvTexture);
-        GLKMatrix4 ndcToReflectEnvTextureMat = GLKMatrix4Multiply(worldToReflectEnvTextureMat, ndcToWorldMat);
+        GLKMatrix4 ndcToReflectEnvTextureMat = GLKMatrix4Multiply(worldToReflectEnvTextureMat, pass.ndcToWorld);
 
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_ndcToEnv"]] = [NSValue valueWithGLKMatrix4:ndcToReflectEnvTextureMat];
         

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -15,6 +15,7 @@
 #import "CCTexture.h"
 
 #import "CCEffect_Private.h"
+#import "CCRenderer_Private.h"
 #import "CCSprite_Private.h"
 
 
@@ -51,17 +52,24 @@
 
 -(id)initWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
 {
-    NSArray *uniforms = @[
-                          [CCEffectUniform uniform:@"float" name:@"u_shininess" value:[NSNumber numberWithFloat:1.0f]],
-                          [CCEffectUniform uniform:@"float" name:@"u_fresnelBias" value:[NSNumber numberWithFloat:1.0f]],
-                          [CCEffectUniform uniform:@"float" name:@"u_fresnelPower" value:[NSNumber numberWithFloat:0.0f]],
-                          [CCEffectUniform uniform:@"sampler2D" name:@"u_envMap" value:(NSValue*)[CCTexture none]],
-                          [CCEffectUniform uniform:@"vec2" name:@"u_tangent" value:[NSValue valueWithGLKVector2:GLKVector2Make(1.0f, 0.0f)]],
-                          [CCEffectUniform uniform:@"vec2" name:@"u_binormal" value:[NSValue valueWithGLKVector2:GLKVector2Make(0.0f, 1.0f)]],
-                          [CCEffectUniform uniform:@"mat4" name:@"u_screenToEnv" value:[NSValue valueWithGLKMatrix4:GLKMatrix4Identity]],
-                          ];
+    NSArray *fragUniforms = @[
+                              [CCEffectUniform uniform:@"float" name:@"u_shininess" value:[NSNumber numberWithFloat:1.0f]],
+                              [CCEffectUniform uniform:@"float" name:@"u_fresnelBias" value:[NSNumber numberWithFloat:1.0f]],
+                              [CCEffectUniform uniform:@"float" name:@"u_fresnelPower" value:[NSNumber numberWithFloat:0.0f]],
+                              [CCEffectUniform uniform:@"sampler2D" name:@"u_envMap" value:(NSValue*)[CCTexture none]],
+                              [CCEffectUniform uniform:@"vec2" name:@"u_tangent" value:[NSValue valueWithGLKVector2:GLKVector2Make(1.0f, 0.0f)]],
+                              [CCEffectUniform uniform:@"vec2" name:@"u_binormal" value:[NSValue valueWithGLKVector2:GLKVector2Make(0.0f, 1.0f)]],
+                              ];
     
-    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varyings:nil]))
+    NSArray *vertUniforms = @[
+                              [CCEffectUniform uniform:@"mat4" name:@"u_ndcToEnv" value:[NSValue valueWithGLKMatrix4:GLKMatrix4Identity]]
+                              ];
+    
+    NSArray *varyings = @[
+                          [CCEffectVarying varying:@"vec2" name:@"v_envSpaceTexCoords"]
+                         ];
+    
+    if((self = [super initWithFragmentUniforms:fragUniforms vertexUniforms:vertUniforms varyings:varyings]))
     {
         _shininess = shininess;
         _conditionedShininess = CCEffectUtilsConditionShininess(shininess);
@@ -107,10 +115,6 @@
     CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
     
     NSString* effectBody = CC_GLSL(
-                                   // Compute environment space texture coordinates from the screen space
-                                   // fragment position.
-                                   vec4 envSpaceTexCoords = u_screenToEnv * gl_FragCoord;
-                                   
                                    // Index the normal map and expand the color value from [0..1] to [-1..1]
                                    vec4 normalMap = texture2D(cc_NormalMapTexture, cc_FragTexCoord2);
                                    vec4 tangentSpaceNormal = normalMap * 2.0 - 1.0;
@@ -119,11 +123,11 @@
                                    vec3 normal = normalize(vec3(u_tangent * tangentSpaceNormal.x + u_binormal * tangentSpaceNormal.y, tangentSpaceNormal.z));
                                    
                                    float nDotV = dot(normal, vec3(0,0,1));
-                                   vec3 reflectOffset = normal * pow(1.0 - nDotV, 3.0) / 8.0;
+                                   vec2 reflectOffset = normal.xy * pow(1.0 - nDotV, 3.0) / 8.0;
                                    
                                    // Perturb the screen space texture coordinate by the scaled normal
                                    // vector.
-                                   vec2 reflectTexCoords = envSpaceTexCoords.xy + reflectOffset.xy;
+                                   vec2 reflectTexCoords = v_envSpaceTexCoords + reflectOffset;
 
                                    // Feed the resulting coordinates through cos() so they reflect when
                                    // they would otherwise be outside of [0..1].
@@ -143,8 +147,23 @@
                                    return primaryColor;
                                    );
     
-    CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"reflectionEffect" body:effectBody inputs:@[input] returnType:@"vec4"];
+    CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"reflectionEffectFrag" body:effectBody inputs:@[input] returnType:@"vec4"];
     [self.fragmentFunctions addObject:fragmentFunction];
+}
+
+-(void)buildVertexFunctions
+{
+    self.vertexFunctions = [[NSMutableArray alloc] init];
+
+    NSString* effectBody = CC_GLSL(
+                                   // Compute environment space texture coordinates from the vertex positions.
+                                   vec4 envSpaceTexCoords = u_ndcToEnv * cc_Position;
+                                   v_envSpaceTexCoords = envSpaceTexCoords.xy;
+                                   return cc_Position;
+                                   );
+    
+    CCEffectFunction *vertexFunction = [[CCEffectFunction alloc] initWithName:@"reflectionEffectVtx" body:effectBody inputs:nil returnType:@"vec4"];
+    [self.vertexFunctions addObject:vertexFunction];
 }
 
 -(void)buildRenderPasses
@@ -180,10 +199,10 @@
         CGFloat scale = [CCDirector sharedDirector].contentScaleFactor;
         CGAffineTransform screenToWorld = CGAffineTransformMake(1.0f / scale, 0.0f, 0.0f, 1.0f / scale, 0.0f, 0.0f);
         
-        // Setup the screen space to environment space matrix.
+        // Get the transform from world space to environment texture space. This is
+        // concatenated with the current transform to move from local node space to
+        // environment texture space.
         CGAffineTransform worldToReflectEnvTexture =  CCEffectUtilsWorldToEnvironmentTransform(weakSelf.environment);
-        CGAffineTransform screenToReflectEnvTexture = CGAffineTransformConcat(screenToWorld, worldToReflectEnvTexture);
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_screenToEnv"]] = [NSValue valueWithGLKMatrix4:CCEffectUtilsMat4FromAffineTransform(screenToReflectEnvTexture)];
         
         // Setup the tangent and binormal vectors for the refraction environment
         GLKVector4 reflectTangent = CCEffectUtilsTangentInEnvironmentSpace(pass.transform, CCEffectUtilsMat4FromAffineTransform(worldToReflectEnvTexture));
@@ -192,6 +211,16 @@
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_tangent"]] = [NSValue valueWithGLKVector2:GLKVector2Make(reflectTangent.x, reflectTangent.y)];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_binormal"]] = [NSValue valueWithGLKVector2:GLKVector2Make(reflectBinormal.x, reflectBinormal.y)];
         
+        // Setup the transform from normalized device coordinates (NDC, which is the space our vertex
+        // positions are in) to environment texture space. We use this to compute environment texture
+        // coordinates in the vertex shader.
+        GLKMatrix4 ndcToWorldMat;
+        [pass.renderer.globalShaderUniforms[CCShaderUniformProjectionInv] getValue:&ndcToWorldMat];
+        
+        GLKMatrix4 worldToReflectEnvTextureMat = CCEffectUtilsMat4FromAffineTransform(worldToReflectEnvTexture);
+        GLKMatrix4 ndcToReflectEnvTextureMat = GLKMatrix4Multiply(worldToReflectEnvTextureMat, ndcToWorldMat);
+
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_ndcToEnv"]] = [NSValue valueWithGLKMatrix4:ndcToReflectEnvTextureMat];
     } copy]];
     
     self.renderPasses = @[pass0];

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -221,6 +221,57 @@
         GLKMatrix4 ndcToReflectEnvTextureMat = GLKMatrix4Multiply(worldToReflectEnvTextureMat, ndcToWorldMat);
 
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_ndcToEnv"]] = [NSValue valueWithGLKMatrix4:ndcToReflectEnvTextureMat];
+        
+#if 0
+        GLKVector4 result1, result2, result3, result4;
+
+        NSLog(@"Vertex transforms:");
+
+        result1 = GLKMatrix4MultiplyVector4(pass.transform, pass.verts.bl.position);
+        NSLog(@"      input: %f %f %f", pass.verts.bl.position.x, pass.verts.bl.position.y, pass.verts.bl.position.z);
+        NSLog(@"cc_Position: %f %f %f", result1.x, result1.y, result1.z);
+        result2 = GLKMatrix4MultiplyVector4(ndcToWorldMat, result1);
+        NSLog(@"     fergus: %f %f %f", result2.x, result2.y, result2.z);
+        result3 = GLKMatrix4MultiplyVector4(nodeToWorldMat, pass.verts.bl.position);
+        NSLog(@"    blergus: %f %f %f", result3.x, result3.y, result3.z);
+        result4 = GLKMatrix4MultiplyVector4(ndcToReflectEnvTextureMat, result1);
+        NSLog(@"     yergus: %f %f %f", result4.x, result4.y, result4.z);
+        NSLog(@"end");
+        
+        result1 = GLKMatrix4MultiplyVector4(pass.transform, pass.verts.br.position);
+        NSLog(@"      input: %f %f %f", pass.verts.br.position.x, pass.verts.br.position.y, pass.verts.br.position.z);
+        NSLog(@"cc_Position: %f %f %f", result1.x, result1.y, result1.z);
+        result2 = GLKMatrix4MultiplyVector4(ndcToWorldMat, result1);
+        NSLog(@"     fergus: %f %f %f", result2.x, result2.y, result2.z);
+        result3 = GLKMatrix4MultiplyVector4(nodeToWorldMat, pass.verts.br.position);
+        NSLog(@"    blergus: %f %f %f", result3.x, result3.y, result3.z);
+        result4 = GLKMatrix4MultiplyVector4(ndcToReflectEnvTextureMat, result1);
+        NSLog(@"     yergus: %f %f %f", result4.x, result4.y, result4.z);
+        NSLog(@"end");
+
+        result1 = GLKMatrix4MultiplyVector4(pass.transform, pass.verts.tr.position);
+        NSLog(@"      input: %f %f %f", pass.verts.tr.position.x, pass.verts.tr.position.y, pass.verts.tr.position.z);
+        NSLog(@"cc_Position: %f %f %f", result1.x, result1.y, result1.z);
+        result2 = GLKMatrix4MultiplyVector4(ndcToWorldMat, result1);
+        NSLog(@"     fergus: %f %f %f", result2.x, result2.y, result2.z);
+        result3 = GLKMatrix4MultiplyVector4(nodeToWorldMat, pass.verts.tr.position);
+        NSLog(@"    blergus: %f %f %f", result3.x, result3.y, result3.z);
+        result4 = GLKMatrix4MultiplyVector4(ndcToReflectEnvTextureMat, result1);
+        NSLog(@"     yergus: %f %f %f", result4.x, result4.y, result4.z);
+        NSLog(@"end");
+        
+        result1 = GLKMatrix4MultiplyVector4(pass.transform, pass.verts.tl.position);
+        NSLog(@"      input: %f %f %f", pass.verts.tl.position.x, pass.verts.tl.position.y, pass.verts.tl.position.z);
+        NSLog(@"cc_Position: %f %f %f", result1.x, result1.y, result1.z);
+        result2 = GLKMatrix4MultiplyVector4(ndcToWorldMat, result1);
+        NSLog(@"     fergus: %f %f %f", result2.x, result2.y, result2.z);
+        result3 = GLKMatrix4MultiplyVector4(nodeToWorldMat, pass.verts.tl.position);
+        NSLog(@"    blergus: %f %f %f", result3.x, result3.y, result3.z);
+        result4 = GLKMatrix4MultiplyVector4(ndcToReflectEnvTextureMat, result1);
+        NSLog(@"     yergus: %f %f %f", result4.x, result4.y, result4.z);
+        NSLog(@"end");
+#endif
+        
     } copy]];
     
     self.renderPasses = @[pass0];

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -215,56 +215,6 @@
 
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_ndcToEnv"]] = [NSValue valueWithGLKMatrix4:ndcToReflectEnvTextureMat];
         
-#if 0
-        GLKVector4 result1, result2, result3, result4;
-
-        NSLog(@"Vertex transforms:");
-
-        result1 = GLKMatrix4MultiplyVector4(pass.transform, pass.verts.bl.position);
-        NSLog(@"      input: %f %f %f", pass.verts.bl.position.x, pass.verts.bl.position.y, pass.verts.bl.position.z);
-        NSLog(@"cc_Position: %f %f %f", result1.x, result1.y, result1.z);
-        result2 = GLKMatrix4MultiplyVector4(ndcToWorldMat, result1);
-        NSLog(@"     fergus: %f %f %f", result2.x, result2.y, result2.z);
-        result3 = GLKMatrix4MultiplyVector4(nodeToWorldMat, pass.verts.bl.position);
-        NSLog(@"    blergus: %f %f %f", result3.x, result3.y, result3.z);
-        result4 = GLKMatrix4MultiplyVector4(ndcToReflectEnvTextureMat, result1);
-        NSLog(@"     yergus: %f %f %f", result4.x, result4.y, result4.z);
-        NSLog(@"end");
-        
-        result1 = GLKMatrix4MultiplyVector4(pass.transform, pass.verts.br.position);
-        NSLog(@"      input: %f %f %f", pass.verts.br.position.x, pass.verts.br.position.y, pass.verts.br.position.z);
-        NSLog(@"cc_Position: %f %f %f", result1.x, result1.y, result1.z);
-        result2 = GLKMatrix4MultiplyVector4(ndcToWorldMat, result1);
-        NSLog(@"     fergus: %f %f %f", result2.x, result2.y, result2.z);
-        result3 = GLKMatrix4MultiplyVector4(nodeToWorldMat, pass.verts.br.position);
-        NSLog(@"    blergus: %f %f %f", result3.x, result3.y, result3.z);
-        result4 = GLKMatrix4MultiplyVector4(ndcToReflectEnvTextureMat, result1);
-        NSLog(@"     yergus: %f %f %f", result4.x, result4.y, result4.z);
-        NSLog(@"end");
-
-        result1 = GLKMatrix4MultiplyVector4(pass.transform, pass.verts.tr.position);
-        NSLog(@"      input: %f %f %f", pass.verts.tr.position.x, pass.verts.tr.position.y, pass.verts.tr.position.z);
-        NSLog(@"cc_Position: %f %f %f", result1.x, result1.y, result1.z);
-        result2 = GLKMatrix4MultiplyVector4(ndcToWorldMat, result1);
-        NSLog(@"     fergus: %f %f %f", result2.x, result2.y, result2.z);
-        result3 = GLKMatrix4MultiplyVector4(nodeToWorldMat, pass.verts.tr.position);
-        NSLog(@"    blergus: %f %f %f", result3.x, result3.y, result3.z);
-        result4 = GLKMatrix4MultiplyVector4(ndcToReflectEnvTextureMat, result1);
-        NSLog(@"     yergus: %f %f %f", result4.x, result4.y, result4.z);
-        NSLog(@"end");
-        
-        result1 = GLKMatrix4MultiplyVector4(pass.transform, pass.verts.tl.position);
-        NSLog(@"      input: %f %f %f", pass.verts.tl.position.x, pass.verts.tl.position.y, pass.verts.tl.position.z);
-        NSLog(@"cc_Position: %f %f %f", result1.x, result1.y, result1.z);
-        result2 = GLKMatrix4MultiplyVector4(ndcToWorldMat, result1);
-        NSLog(@"     fergus: %f %f %f", result2.x, result2.y, result2.z);
-        result3 = GLKMatrix4MultiplyVector4(nodeToWorldMat, pass.verts.tl.position);
-        NSLog(@"    blergus: %f %f %f", result3.x, result3.y, result3.z);
-        result4 = GLKMatrix4MultiplyVector4(ndcToReflectEnvTextureMat, result1);
-        NSLog(@"     yergus: %f %f %f", result4.x, result4.y, result4.z);
-        NSLog(@"end");
-#endif
-        
     } copy]];
     
     self.renderPasses = @[pass0];

--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -38,15 +38,23 @@
 
 -(id)initWithRefraction:(float)refraction environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
 {
-    NSArray *uniforms = @[
-                          [CCEffectUniform uniform:@"float" name:@"u_refraction" value:[NSNumber numberWithFloat:1.0f]],
-                          [CCEffectUniform uniform:@"sampler2D" name:@"u_envMap" value:(NSValue*)[CCTexture none]],
-                          [CCEffectUniform uniform:@"vec2" name:@"u_tangent" value:[NSValue valueWithGLKVector2:GLKVector2Make(1.0f, 0.0f)]],
-                          [CCEffectUniform uniform:@"vec2" name:@"u_binormal" value:[NSValue valueWithGLKVector2:GLKVector2Make(0.0f, 1.0f)]],
-                          [CCEffectUniform uniform:@"mat4" name:@"u_screenToEnv" value:[NSValue valueWithGLKMatrix4:GLKMatrix4Identity]],
+    NSArray *fragUniforms = @[
+                              [CCEffectUniform uniform:@"float" name:@"u_refraction" value:[NSNumber numberWithFloat:1.0f]],
+                              [CCEffectUniform uniform:@"sampler2D" name:@"u_envMap" value:(NSValue*)[CCTexture none]],
+                              [CCEffectUniform uniform:@"vec2" name:@"u_tangent" value:[NSValue valueWithGLKVector2:GLKVector2Make(1.0f, 0.0f)]],
+                              [CCEffectUniform uniform:@"vec2" name:@"u_binormal" value:[NSValue valueWithGLKVector2:GLKVector2Make(0.0f, 1.0f)]]
+                              ];
+
+    NSArray *vertUniforms = @[
+                              [CCEffectUniform uniform:@"mat4" name:@"u_ndcToEnv" value:[NSValue valueWithGLKMatrix4:GLKMatrix4Identity]],
+                              ];
+    
+    NSArray *varyings = @[
+                          [CCEffectVarying varying:@"vec2" name:@"v_envSpaceTexCoords"],
                           ];
     
-    if((self = [super initWithFragmentUniforms:uniforms vertexUniforms:nil varyings:nil]))
+
+    if((self = [super initWithFragmentUniforms:fragUniforms vertexUniforms:vertUniforms varyings:varyings]))
     {
         _refraction = refraction;
         _conditionedRefraction = CCEffectUtilsConditionRefraction(refraction);
@@ -75,21 +83,17 @@
     CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
     
     NSString* effectBody = CC_GLSL(
-                                   // Compute environment space texture coordinates from the screen space
-                                   // fragment position.
-                                   vec4 envSpaceTexCoords = u_screenToEnv * gl_FragCoord;
-
                                    // Index the normal map and expand the color value from [0..1] to [-1..1]
                                    vec4 normalMap = texture2D(cc_NormalMapTexture, cc_FragTexCoord2);
                                    vec4 tangentSpaceNormal = normalMap * 2.0 - 1.0;
                                    
                                    // Convert the normal vector from tangent space to environment space
                                    vec3 normal = normalize(vec3(u_tangent * tangentSpaceNormal.x + u_binormal * tangentSpaceNormal.y, tangentSpaceNormal.z));
-                                   vec3 refractOffset = refract(vec3(0,0,1), normal, 1.0) * u_refraction;
+                                   vec2 refractOffset = refract(vec3(0,0,1), normal, 1.0).xy * u_refraction;
                                    
                                    // Perturb the screen space texture coordinate by the scaled normal
                                    // vector.
-                                   vec2 refractTexCoords = envSpaceTexCoords.xy + refractOffset.xy;
+                                   vec2 refractTexCoords = v_envSpaceTexCoords + refractOffset;
                                    
                                    // This is positive if refractTexCoords is in [0..1] and negative otherwise.
                                    vec2 compare = 0.5 - abs(refractTexCoords - 0.5);
@@ -108,8 +112,23 @@
                                    return primaryColor;
                                    );
     
-    CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"refractionEffect" body:effectBody inputs:@[input] returnType:@"vec4"];
+    CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"refractionEffectFrag" body:effectBody inputs:@[input] returnType:@"vec4"];
     [self.fragmentFunctions addObject:fragmentFunction];
+}
+
+-(void)buildVertexFunctions
+{
+    self.vertexFunctions = [[NSMutableArray alloc] init];
+    
+    NSString* effectBody = CC_GLSL(
+                                   // Compute environment space texture coordinates from the vertex positions.
+                                   vec4 envSpaceTexCoords = u_ndcToEnv * cc_Position;
+                                   v_envSpaceTexCoords = envSpaceTexCoords.xy;
+                                   return cc_Position;
+                                   );
+    
+    CCEffectFunction *vertexFunction = [[CCEffectFunction alloc] initWithName:@"refractionEffectVtx" body:effectBody inputs:nil returnType:@"vec4"];
+    [self.vertexFunctions addObject:vertexFunction];
 }
 
 -(void)buildRenderPasses
@@ -139,20 +158,25 @@
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_refraction"]] = [NSNumber numberWithFloat:weakSelf.conditionedRefraction];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_envMap"]] = weakSelf.environment.texture ?: [CCTexture none];
         
-        CGFloat scale = [CCDirector sharedDirector].contentScaleFactor;
-        CGAffineTransform screenToWorld = CGAffineTransformMake(1.0f / scale, 0.0f, 0.0f, 1.0f / scale, 0.0f, 0.0f);
-        
-        // Setup the screen space to environment space matrix.
+        // Get the transform from world space to environment texture space. This is
+        // concatenated with the current transform to move from local node space to
+        // environment texture space.
         CGAffineTransform worldToRefractEnvTexture =  CCEffectUtilsWorldToEnvironmentTransform(weakSelf.environment);
-        CGAffineTransform screenToRefractEnvTexture = CGAffineTransformConcat(screenToWorld, worldToRefractEnvTexture);
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_screenToEnv"]] = [NSValue valueWithGLKMatrix4:CCEffectUtilsMat4FromAffineTransform(screenToRefractEnvTexture)];
-
+        
         // Setup the tangent and binormal vectors for the refraction environment
         GLKVector4 refractTangent = CCEffectUtilsTangentInEnvironmentSpace(pass.transform, CCEffectUtilsMat4FromAffineTransform(worldToRefractEnvTexture));
         GLKVector4 refractNormal = GLKVector4Make(0.0f, 0.0f, 1.0f, 1.0f);
         GLKVector4 refractBinormal = GLKVector4CrossProduct(refractNormal, refractTangent);
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_tangent"]] = [NSValue valueWithGLKVector2:GLKVector2Make(refractTangent.x, refractTangent.y)];
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_binormal"]] = [NSValue valueWithGLKVector2:GLKVector2Make(refractBinormal.x, refractBinormal.y)];
+        
+        // Setup the transform from normalized device coordinates (NDC, which is the space our vertex
+        // positions are in) to environment texture space. We use this to compute environment texture
+        // coordinates in the vertex shader.s
+        GLKMatrix4 worldToRefractEnvTextureMat = CCEffectUtilsMat4FromAffineTransform(worldToRefractEnvTexture);
+        GLKMatrix4 ndcToRefractEnvTextureMat = GLKMatrix4Multiply(worldToRefractEnvTextureMat, pass.ndcToWorld);
+        
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_ndcToEnv"]] = [NSValue valueWithGLKMatrix4:ndcToRefractEnvTextureMat];
 
     } copy]];
     

--- a/cocos2d/CCEffectStack.h
+++ b/cocos2d/CCEffectStack.h
@@ -40,11 +40,21 @@
 /**
  *  Initializes an effect stack object with the specified array of effects.
  *
- *  @param effects The array of effects to add to the stack.
+ *  @param arrayOfEffects The array of effects to add to the stack.
  *
  *  @return The CCEffectStack object.
  */
-- (id)initWithEffects:(NSArray *)effects;
+- (id)initWithArray:(NSArray *)arrayOfEffects;
+
+/**
+ *  Initializes an effect stack object with the specified effects.
+ *
+ *  @param effect1 First effect to add to the stack.
+ *  @param ...     Nil terminated list of effects to stack.
+ *
+ *  @return The CCEffectStack object.
+ */
+- (id)initWithEffects:(CCEffect*)effect1, ... NS_REQUIRES_NIL_TERMINATION;
 
 
 /// -----------------------------------------------------------------------
@@ -54,11 +64,21 @@
 /**
  *  Creates an effect stack object with the specified array of effects.
  *
- *  @param effects The array of effects to add to the stack.
+ *  @param arrayOfEffects The array of effects to add to the stack.
  *
  *  @return The CCEffectStack object.
  */
-+ (id)effectStackWithEffects:(NSArray *)effects;
++ (id)effectWithArray:(NSArray*)arrayOfEffects;
+
+/**
+ *  Creates an effect stack object with the specified effects.
+ *
+ *  @param effect1 First effect to add to the stack.
+ *  @param ...     Nil terminated list of effects to stack.
+ *
+ *  @return The CCEffectStack object.
+ */
++ (id)effects:(CCEffect*)effect1, ... NS_REQUIRES_NIL_TERMINATION;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectStack.m
+++ b/cocos2d/CCEffectStack.m
@@ -17,10 +17,10 @@
 
 - (id)init
 {
-    return [self initWithEffects:nil];
+    return [self initWithArray:nil];
 }
 
-- (id)initWithEffects:(NSArray *)effects
+- (id)initWithArray:(NSArray *)effects
 {
     if ((self = [super init]))
     {
@@ -46,9 +46,48 @@
     return self;
 }
 
-+ (id)effectStackWithEffects:(NSArray *)effects
+- (id)initWithEffect:(CCEffect*)effect1 vaList:(va_list)args
 {
-    return [[self alloc] initWithEffects:effects];
+    NSMutableArray *effects = [[NSMutableArray alloc] init];
+	
+    CCEffect *effect = effect1;
+	while(effect)
+    {
+        [effects addObject:effect];
+		effect = va_arg(args, CCEffect*);
+	}
+    
+	return [self initWithArray:effects];
+}
+
+- (id)initWithEffects:(CCEffect*)effect1, ...
+{
+	va_list args;
+	va_start(args, effect1);
+    
+	id ret = [self initWithEffect:effect1 vaList:args];
+    
+	va_end(args);
+    
+	return ret;
+}
+
+
++ (id)effectWithArray:(NSArray *)arrayOfEffects
+{
+    return [[self alloc] initWithArray:arrayOfEffects];
+}
+
++ (id)effects:(CCEffect*)effect1, ...
+{
+	va_list args;
+	va_start(args, effect1);
+    
+	id ret = [[self alloc] initWithEffect:effect1 vaList:args];
+    
+	va_end(args);
+    
+	return ret;
 }
 
 - (NSUInteger)effectCount
@@ -58,8 +97,16 @@
 
 - (CCEffect *)effectAtIndex:(NSUInteger)effectIndex
 {
-    NSAssert(effectIndex < _effects.count,@"Pass index out of range.");
+    NSAssert(effectIndex < _effects.count,@"Effect index out of range.");
     return _effects[effectIndex];
+}
+
+- (void)dealloc
+{
+    for (CCEffect *effect in _effects)
+    {
+        effect.owningStack = nil;
+    }
 }
 
 #pragma mark - CCEffect overrides

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -96,6 +96,7 @@ typedef void (^CCEffectRenderPassEndBlock)(CCEffectRenderPass *pass);
 @property (nonatomic) CCRenderer* renderer;
 @property (nonatomic) CCSpriteVertexes verts;
 @property (nonatomic) GLKMatrix4 transform;
+@property (nonatomic) GLKMatrix4 ndcToWorld;
 @property (nonatomic) CCBlendMode* blendMode;
 @property (nonatomic) CCShader* shader;
 @property (nonatomic) NSMutableDictionary* shaderUniforms;

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -239,13 +239,18 @@
 
 -(void) setTextureRect:(CGRect)rect rotated:(BOOL)rotated untrimmedSize:(CGSize)untrimmedSize
 {
-	_textureRectRotated = rotated;
+    [self setTextureRect:rect forTexture:self.texture rotated:rotated untrimmedSize:untrimmedSize];
+}
 
+- (void)setTextureRect:(CGRect)rect forTexture:(CCTexture*)texture rotated:(BOOL)rotated untrimmedSize:(CGSize)untrimmedSize
+{
+	_textureRectRotated = rotated;
+    
 	self.contentSizeType = CCSizeTypePoints;
 	[self setContentSize:untrimmedSize];
 	_textureRect = rect;
     
-	CCSpriteTexCoordSet texCoords = [CCSprite textureCoordsForTexture:self.texture withRect:rect rotated:rotated xFlipped:_flipX yFlipped:_flipY];
+	CCSpriteTexCoordSet texCoords = [CCSprite textureCoordsForTexture:texture withRect:rect rotated:rotated xFlipped:_flipX yFlipped:_flipY];
     _verts.bl.texCoord1 = texCoords.bl;
     _verts.br.texCoord1 = texCoords.br;
     _verts.tr.texCoord1 = texCoords.tr;
@@ -533,7 +538,7 @@ EnqueueTriangles(CCSprite *self, CCRenderer *renderer, const GLKMatrix4 *transfo
         // If there is no texture set on the sprite, set the sprite's texture rect from the
         // normal map's sprite frame. Note that setting the main texture, then the normal map,
         // and then removing the main texture will leave the texture rect from the main texture.
-        [self setTextureRect:frame.rect rotated:frame.rotated untrimmedSize:frame.originalSize];
+        [self setTextureRect:frame.rect forTexture:frame.texture rotated:frame.rotated untrimmedSize:frame.originalSize];
     }
 
     // Set the second texture coordinate set from the normal map's sprite frame.


### PR DESCRIPTION
- Add constructors to CCEffectStack that match those of CCActionSequence
- Fix intensity and threshold math in CCEffectBloom
- Fix texture coordinate math in reflection, refraction, and glass so they render correctly into intermediate render targets.
- Fix a bug in CCSprite with texture coordinate setup when there is a normal map but no main texture.
- Add tests of the luminance threshold to the bloom effect test.
