### PR TITLE
CCEffectNode - Fix a bunch of sizing issues and add tests for them

### DIFF
--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -990,7 +990,9 @@
     NSArray *subTitles = @[
                            @"Effect Node Resize Test\nSmall transparent blue node with grossini",
                            @"Effect Node Resize Test\nMedium transparent blue node with grossini",
-                           @"Effect Node Resize Test\nBig transparent blue node with grossini"
+                           @"Effect Node Resize Test\nBig transparent blue node with grossini",
+                           @"Effect Node Resize Test\nNothing",
+                           @"Effect Node Resize Test\nTransparent blue square with grossini"
                            ];
     
     self.subTitle = subTitles[0];
@@ -1025,10 +1027,117 @@
     __weak CCEffectsTest *weakSelf = self;
     __block NSUInteger callCount = 0;
     CCActionCallBlock *blockAction = [CCActionCallBlock actionWithBlock:^{
-        callCount = (callCount + 1) % 3;
+        callCount = (callCount + 1) % 5;
         
-        float nodeSize = 0.25f + 0.25f * callCount;
-        effectNode.contentSize = CGSizeMake(nodeSize, nodeSize);
+        if (callCount == 0)
+        {
+            effectNode.contentSizeType = CCSizeTypeNormalized;
+        }
+        
+        if (callCount == 3)
+        {
+            effectNode.contentSizeType = CCSizeTypePoints;
+        }
+        else if (callCount == 4)
+        {
+            effectNode.contentSize = CGSizeMake(256.0f, 256.0f);
+        }
+        else
+        {
+            float nodeSize = 0.25f + 0.25f * callCount;
+            effectNode.contentSize = CGSizeMake(nodeSize, nodeSize);
+        }
+        
+        weakSelf.subTitle = subTitles[callCount];
+    }];
+    [effectNode runAction:[CCActionRepeatForever actionWithAction:[CCActionSequence actions:
+                                                                   [CCActionDelay actionWithDuration:1.0f],
+                                                                   blockAction,
+                                                                   nil
+                                                                   ]]];
+}
+
+-(void)setupEffectNodeParentResizeTest
+{
+    NSArray *subTitles = @[
+                           @"Effect Node Parent Resize Test\nSmall transparent red rect with grossini",
+                           @"Effect Node Parent Resize Test\nMedium transparent red rect with grossini",
+                           @"Effect Node Parent Resize Test\nBig transparent red rect with grossini",
+                           @"Effect Node Parent Resize Test\nNothing",
+                           @"Effect Node Parent Resize Test\nTransparent red square with grossini"
+                           ];
+    
+    self.subTitle = subTitles[0];
+    
+    CCSprite *background = [CCSprite spriteWithImageNamed:@"Images/gridBackground.png"];
+    background.positionType = CCPositionTypeNormalized;
+    background.position = ccp(0.5f, 0.5f);
+    [self.contentNode addChild:background];
+
+    
+    CCNode *grandparent = [[CCNode alloc] init];
+    grandparent.contentSizeType = CCSizeTypeNormalized;
+    grandparent.contentSize = CGSizeMake(0.25f, 0.25f);
+    grandparent.anchorPoint = ccp(0.5f, 0.5f);
+    grandparent.positionType = CCPositionTypeNormalized;
+    grandparent.position = ccp(0.5f, 0.5f);
+    [self.contentNode addChild:grandparent];
+    
+    
+    CCNode *parent = [[CCNode alloc] init];
+    parent.contentSizeType = CCSizeTypeNormalized;
+    parent.contentSize = CGSizeMake(1.0f, 1.0f);
+    parent.anchorPoint = ccp(0.5f, 0.5f);
+    parent.positionType = CCPositionTypeNormalized;
+    parent.position = ccp(0.5f, 0.5f);
+    [grandparent addChild:parent];
+    
+    
+    CCEffectNode *effectNode = [[CCEffectNode alloc] init];
+    effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+    effectNode.clearColor = [CCColor colorWithRed:0.0f green:0.0f blue:0.5f alpha:0.5f];
+    effectNode.contentSizeType = CCSizeTypeNormalized;
+    effectNode.contentSize = CGSizeMake(1.0f, 1.0f);
+    effectNode.anchorPoint = ccp(0.5f, 0.5f);
+    effectNode.positionType = CCPositionTypeNormalized;
+    effectNode.position = ccp(0.5f, 0.5f);
+    
+    CCEffectHue *effect = [CCEffectHue effectWithHue:120.0f];
+    effectNode.effect = effect;
+    
+    [parent addChild:effectNode];
+    
+    
+    CCSprite *sprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+    sprite.anchorPoint = ccp(0.5, 0.5);
+    sprite.positionType = CCPositionTypeNormalized;
+    sprite.position = ccp(0.5f, 0.5f);
+    [effectNode addChild:sprite];
+    
+    
+    __weak CCEffectsTest *weakSelf = self;
+    __block NSUInteger callCount = 0;
+    CCActionCallBlock *blockAction = [CCActionCallBlock actionWithBlock:^{
+        callCount = (callCount + 1) % 5;
+        
+        if (callCount == 0)
+        {
+            grandparent.contentSizeType = CCSizeTypeNormalized;
+        }
+        
+        if (callCount == 3)
+        {
+            grandparent.contentSizeType = CCSizeTypePoints;
+        }
+        else if (callCount == 4)
+        {
+            grandparent.contentSize = CGSizeMake(256.0f, 256.0f);
+        }
+        else
+        {
+            float grandparentSize = 0.25f + 0.25f * callCount;
+            grandparent.contentSize = CGSizeMake(grandparentSize, grandparentSize);
+        }
         
         weakSelf.subTitle = subTitles[callCount];
     }];

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -785,6 +785,60 @@
     }
 }
 
+-(void)setupEffectNodeResizeTest
+{
+    NSArray *subTitles = @[
+                           @"Effect Node Resize Test\nSmall transparent blue node with grossini",
+                           @"Effect Node Resize Test\nMedium transparent blue node with grossini",
+                           @"Effect Node Resize Test\nBig transparent blue node with grossini"
+                           ];
+    
+    self.subTitle = subTitles[0];
+    
+    CCSprite *background = [CCSprite spriteWithImageNamed:@"Images/gridBackground.png"];
+    background.positionType = CCPositionTypeNormalized;
+    background.position = ccp(0.5f, 0.5f);
+    [self.contentNode addChild:background];
+    
+    CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+    effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+    effectNode.clearColor = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+    effectNode.contentSizeType = CCSizeTypeNormalized;
+    effectNode.contentSize = CGSizeMake(0.25f, 0.25f);
+    effectNode.anchorPoint = ccp(0.5f, 0.5f);
+    effectNode.positionType = CCPositionTypeNormalized;
+    effectNode.position = ccp(0.5f, 0.5f);
+    
+    CCEffectHue *effect = [CCEffectHue effectWithHue:-120.0f];
+    effectNode.effect = effect;
+    
+    [self.contentNode addChild:effectNode];
+    
+    
+    CCSprite *sprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+    sprite.anchorPoint = ccp(0.5, 0.5);
+    sprite.positionType = CCPositionTypeNormalized;
+    sprite.position = ccp(0.5f, 0.5f);
+    [effectNode addChild:sprite];
+    
+    
+    __weak CCEffectsTest *weakSelf = self;
+    __block NSUInteger callCount = 0;
+    CCActionCallBlock *blockAction = [CCActionCallBlock actionWithBlock:^{
+        callCount = (callCount + 1) % 3;
+        
+        float nodeSize = 0.25f + 0.25f * callCount;
+        effectNode.contentSize = CGSizeMake(nodeSize, nodeSize);
+        
+        weakSelf.subTitle = subTitles[callCount];
+    }];
+    [effectNode runAction:[CCActionRepeatForever actionWithAction:[CCActionSequence actions:
+                                                                   [CCActionDelay actionWithDuration:1.0f],
+                                                                   blockAction,
+                                                                   nil
+                                                                   ]]];
+}
+
 -(void)setupEffectNodeChildPositioningTest
 {
     self.subTitle = @"Effect Node Child Positioning Test\nBig transparent purple quad and small opaque green quad (both with grossini).\n";

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -4,6 +4,7 @@
 #import "CCEffectNode.h"
 #import "CCEffectBlur.h"
 
+#import "CCEffectStack_Private.h"
 
 @interface CCEffectsTest : TestBase @end
 @implementation CCEffectsTest
@@ -654,6 +655,156 @@
     }
     
     NSLog(@"setupPerformanceTest: Laid out %d sprites.", count);
+}
+
+-(void)setupSpriteColorTest
+{
+    self.subTitle = @"Sprite Color + Effects Test\nThe bottom row should look like the top";
+
+    // Make a solid gray background (there's got to be a better way to do this).
+    CCEffectNode* background = [[CCEffectNode alloc] init];
+    background.clearFlags = GL_COLOR_BUFFER_BIT;
+    background.clearColor = [CCColor grayColor];
+    background.contentSizeType = CCSizeTypeNormalized;
+    background.contentSize = CGSizeMake(1.0f, 1.0f);
+    background.anchorPoint = ccp(0.5f, 0.5f);
+    background.positionType = CCPositionTypeNormalized;
+    background.position = ccp(0.5f, 0.5f);
+    
+    [self.contentNode addChild:background];
+
+    // Add row titles
+    CCLabelTTF *plainTitle = [CCLabelTTF labelWithString:@"No FX" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
+    plainTitle.color = [CCColor blackColor];
+    plainTitle.positionType = CCPositionTypeNormalized;
+    plainTitle.position = ccp(0.1f, 0.7f);
+    plainTitle.horizontalAlignment = CCTextAlignmentRight;
+    
+    [self.contentNode addChild:plainTitle];
+    
+    
+    CCLabelTTF *effectTitle = [CCLabelTTF labelWithString:@"FX" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
+    effectTitle.color = [CCColor blackColor];
+    effectTitle.positionType = CCPositionTypeNormalized;
+    effectTitle.position = ccp(0.1f, 0.3f);
+    effectTitle.horizontalAlignment = CCTextAlignmentRight;
+    
+    [self.contentNode addChild:effectTitle];
+
+    
+    // Sprite with solid red
+    {
+        CCEffect *saturation = [CCEffectSaturation effectWithSaturation:0.0f];
+
+        CCSprite *plainSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        plainSprite.positionType = CCPositionTypeNormalized;
+        plainSprite.position = ccp(0.2f, 0.7f);
+        plainSprite.color = [CCColor redColor];
+        [self.contentNode addChild:plainSprite];
+
+        CCSprite *effectSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        effectSprite.positionType = CCPositionTypeNormalized;
+        effectSprite.position = ccp(0.2f, 0.3f);
+        effectSprite.color = [CCColor redColor];
+        effectSprite.effect = saturation;
+        [self.contentNode addChild:effectSprite];
+
+        CCLabelTTF *title = [CCLabelTTF labelWithString:@"Is color preserved?" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
+        title.color = [CCColor blackColor];
+        title.positionType = CCPositionTypeNormalized;
+        title.position = ccp(0.2f, 0.05f);
+        title.horizontalAlignment = CCTextAlignmentCenter;
+        
+        [self.contentNode addChild:title];
+    }
+
+    
+    // Sprite with opacity = 0.5
+    {
+        CCEffect *saturation = [CCEffectSaturation effectWithSaturation:0.0f];
+
+        CCSprite *plainSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        plainSprite.positionType = CCPositionTypeNormalized;
+        plainSprite.position = ccp(0.4f, 0.7f);
+        plainSprite.opacity = 0.5f;
+        [self.contentNode addChild:plainSprite];
+        
+        CCSprite *effectSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        effectSprite.positionType = CCPositionTypeNormalized;
+        effectSprite.position = ccp(0.4f, 0.3f);
+        effectSprite.opacity = 0.5f;
+        effectSprite.effect = saturation;
+        [self.contentNode addChild:effectSprite];
+
+        CCLabelTTF *title = [CCLabelTTF labelWithString:@"Opacity?" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
+        title.color = [CCColor blackColor];
+        title.positionType = CCPositionTypeNormalized;
+        title.position = ccp(0.4f, 0.05f);
+        title.horizontalAlignment = CCTextAlignmentCenter;
+        
+        [self.contentNode addChild:title];
+    }
+
+
+    // Sprite with 50% transparent red
+    {
+        CCEffect *saturation = [CCEffectSaturation effectWithSaturation:0.0f];
+        CCEffect *hue = [CCEffectHue effectWithHue:0.0f];
+
+        CCEffectStack *stack = [CCEffectStack effectWithArray:@[saturation, hue]];
+        
+        CCSprite *plainSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        plainSprite.positionType = CCPositionTypeNormalized;
+        plainSprite.position = ccp(0.6f, 0.7f);
+        plainSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        [self.contentNode addChild:plainSprite];
+        
+        CCSprite *effectSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        effectSprite.positionType = CCPositionTypeNormalized;
+        effectSprite.position = ccp(0.6f, 0.3f);
+        effectSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        effectSprite.effect = stack;
+        [self.contentNode addChild:effectSprite];
+        
+        CCLabelTTF *title = [CCLabelTTF labelWithString:@"Stack (with stitching)" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
+        title.color = [CCColor blackColor];
+        title.positionType = CCPositionTypeNormalized;
+        title.position = ccp(0.6f, 0.05f);
+        title.horizontalAlignment = CCTextAlignmentCenter;
+        
+        [self.contentNode addChild:title];
+    }
+    
+    
+    // Sprite with 50% transparent red and two stacked effects
+    {
+        CCEffect *saturation = [CCEffectSaturation effectWithSaturation:0.0f];
+        CCEffect *hue = [CCEffectHue effectWithHue:0.0f];
+
+        CCEffectStack *stack = [CCEffectStack effectWithArray:@[saturation, hue]];
+        stack.stitchingEnabled = NO;
+        
+        CCSprite *plainSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        plainSprite.positionType = CCPositionTypeNormalized;
+        plainSprite.position = ccp(0.8f, 0.7f);
+        plainSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        [self.contentNode addChild:plainSprite];
+        
+        CCSprite *effectSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        effectSprite.positionType = CCPositionTypeNormalized;
+        effectSprite.position = ccp(0.8f, 0.3f);
+        effectSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        effectSprite.effect = stack;
+        [self.contentNode addChild:effectSprite];
+        
+        CCLabelTTF *title = [CCLabelTTF labelWithString:@"Stack (no stitching)" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
+        title.color = [CCColor blackColor];
+        title.positionType = CCPositionTypeNormalized;
+        title.position = ccp(0.8f, 0.05f);
+        title.horizontalAlignment = CCTextAlignmentCenter;
+        
+        [self.contentNode addChild:title];
+    }
 }
 
 -(void)setupEffectNodeAnchorTest

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -856,6 +856,41 @@
     }
 }
 
+-(void)setupClipWithEffectsTest
+{
+    self.subTitle = @"Clipping + Effects Test.";
+	
+	CGSize size = [CCDirector sharedDirector].designSize;
+    
+    CCNodeGradient *grad = [CCNodeGradient nodeWithColor:[CCColor redColor] fadingTo:[CCColor blueColor] alongVector:ccp(1, 0)];
+    
+	CCNode *stencil = [CCSprite spriteWithImageNamed:@"Sprites/grossini.png"];
+	stencil.position = ccp(size.width/2, size.height/2);
+	stencil.scale = 4.0;
+	[stencil runAction:[CCActionRepeatForever actionWithAction:[CCActionRotateBy actionWithDuration:1.0 angle:90.0]]];
+	
+	CCClippingNode *clip = [CCClippingNode clippingNodeWithStencil:stencil];
+	clip.alphaThreshold = 0.5;
+    
+    CCEffectNode* parent = [CCEffectNode effectNodeWithWidth:size.width height:size.height pixelFormat:CCTexturePixelFormat_RGBA8888 depthStencilFormat:GL_DEPTH24_STENCIL8];
+	parent.clearFlags = GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
+	parent.clearColor = [CCColor blackColor];
+	parent.clearDepth = 1.0;
+	parent.clearStencil = 0;
+    parent.contentSizeType = CCSizeTypeNormalized;
+    parent.contentSize = CGSizeMake(1.0f, 1.0f);
+    parent.anchorPoint = ccp(0.5f, 0.5f);
+    parent.positionType = CCPositionTypeNormalized;
+    parent.position = ccp(0.5f, 0.5f);
+    
+    CCEffectPixellate *effect = [CCEffectStack effectWithArray:@[[CCEffectPixellate effectWithBlockSize:4.0f], [CCEffectSaturation effectWithSaturation:1.0f]]];
+    parent.effect = effect;
+    
+    [clip addChild:grad];
+    [parent addChild:clip];
+    [self.contentNode addChild:parent];
+}
+
 -(void)setupEffectNodeAnchorTest
 {
     self.subTitle = @"Effect Node Anchor Point Test\nTransparent RGB quads from lower-left to upper-right.";

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -713,7 +713,7 @@
 
 -(void)setupEffectNodeSizeTypeTest
 {
-    self.subTitle = @"Effect Node Size Type Test\nSmall red and big blue transparent quads.\nRed bar on left. Green bar on bottom.";
+    self.subTitle = @"Effect Node Size Type Test\nSmall red and big blue transparent quads centered on screen.\nRed bar on left. Green bar on bottom.";
     
     CCSprite *background = [CCSprite spriteWithImageNamed:@"Images/gridBackground.png"];
     background.positionType = CCPositionTypeNormalized;

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -656,6 +656,190 @@
     NSLog(@"setupPerformanceTest: Laid out %d sprites.", count);
 }
 
+-(void)setupEffectNodeAnchorTest
+{
+    self.subTitle = @"Effect Node Anchor Point Test\nTransparent RGB quads from lower-left to upper-right.";
+    
+    CCSprite *background = [CCSprite spriteWithImageNamed:@"Images/gridBackground.png"];
+    background.positionType = CCPositionTypeNormalized;
+    background.position = ccp(0.5f, 0.5f);
+    [self.contentNode addChild:background];
+
+    {
+        CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+        effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+        effectNode.clearColor = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        effectNode.contentSize = CGSizeMake(80, 80);
+        effectNode.anchorPoint = ccp(1.0, 1.0);
+        effectNode.positionType = CCPositionTypeNormalized;
+        effectNode.position = ccp(0.5, 0.5);
+        
+        CCEffectHue *effect = [CCEffectHue effectWithHue:0.0f];
+        effectNode.effect = effect;
+
+        [self.contentNode addChild:effectNode];
+    }
+    
+    {
+        CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+        effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+        effectNode.clearColor = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        effectNode.contentSize = CGSizeMake(80, 80);
+        effectNode.anchorPoint = ccp(0.5, 0.5);
+        effectNode.positionType = CCPositionTypeNormalized;
+        effectNode.position = ccp(0.5, 0.5);
+        
+        CCEffectHue *effect = [CCEffectHue effectWithHue:120.0f];
+        effectNode.effect = effect;
+
+        [self.contentNode addChild:effectNode];
+    }
+
+    {
+        CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+        effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+        effectNode.clearColor = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        effectNode.contentSize = CGSizeMake(80, 80);
+        effectNode.anchorPoint = ccp(0.0, 0.0);
+        effectNode.positionType = CCPositionTypeNormalized;
+        effectNode.position = ccp(0.5, 0.5);
+        
+        CCEffectHue *effect = [CCEffectHue effectWithHue:-120.0f];
+        effectNode.effect = effect;
+        
+        [self.contentNode addChild:effectNode];
+    }
+}
+
+-(void)setupEffectNodeSizeTypeTest
+{
+    self.subTitle = @"Effect Node Size Type Test\nSmall red and big blue transparent quads.\nRed bar on left. Green bar on bottom.";
+    
+    CCSprite *background = [CCSprite spriteWithImageNamed:@"Images/gridBackground.png"];
+    background.positionType = CCPositionTypeNormalized;
+    background.position = ccp(0.5f, 0.5f);
+    [self.contentNode addChild:background];
+    
+    {
+        CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+        effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+        effectNode.clearColor = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        effectNode.contentSizeType = CCSizeTypeNormalized;
+        effectNode.contentSize = CGSizeMake(0.5f, 0.5f);
+        effectNode.anchorPoint = ccp(0.5f, 0.5f);
+        effectNode.positionType = CCPositionTypeNormalized;
+        effectNode.position = ccp(0.5f, 0.5f);
+        
+        CCEffectHue *effect = [CCEffectHue effectWithHue:-120.0f];
+        effectNode.effect = effect;
+        
+        [self.contentNode addChild:effectNode];
+    }
+
+    {
+        CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+        effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+        effectNode.clearColor = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        effectNode.contentSizeType = CCSizeTypePoints;
+        effectNode.contentSize = CGSizeMake(80.0f, 80.0f);
+        effectNode.anchorPoint = ccp(0.5f, 0.5f);
+        effectNode.positionType = CCPositionTypeNormalized;
+        effectNode.position = ccp(0.5f, 0.5f);
+        
+        CCEffectHue *effect = [CCEffectHue effectWithHue:0.0f];
+        effectNode.effect = effect;
+        
+        [self.contentNode addChild:effectNode];
+    }
+    
+    {
+        CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+        effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+        effectNode.clearColor = [CCColor colorWithRed:1.0f green:0.0f blue:0.0f alpha:1.0f];
+        effectNode.contentSizeType = CCSizeTypeMake(CCSizeUnitPoints, CCSizeUnitNormalized);
+        effectNode.contentSize = CGSizeMake(20.0f, 0.9f);
+        effectNode.anchorPoint = ccp(0.0f, 0.0f);
+        effectNode.positionType = CCPositionTypeNormalized;
+        effectNode.position = ccp(0.05f, 0.05f);
+        
+        CCEffectHue *effect = [CCEffectHue effectWithHue:0.0f];
+        effectNode.effect = effect;
+        
+        [self.contentNode addChild:effectNode];
+    }
+
+    {
+        CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+        effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+        effectNode.clearColor = [CCColor colorWithRed:1.0f green:0.0f blue:0.0f alpha:1.0f];
+        effectNode.contentSizeType = CCSizeTypeMake(CCSizeUnitNormalized, CCSizeUnitPoints);
+        effectNode.contentSize = CGSizeMake(0.9f, 20.0f);
+        effectNode.anchorPoint = ccp(0.0f, 0.0f);
+        effectNode.positionType = CCPositionTypeNormalized;
+        effectNode.position = ccp(0.05f, 0.05f);
+        
+        CCEffectHue *effect = [CCEffectHue effectWithHue:120.0f];
+        effectNode.effect = effect;
+        
+        [self.contentNode addChild:effectNode];
+    }
+}
+
+-(void)setupEffectNodeChildPositioningTest
+{
+    self.subTitle = @"Effect Node Child Positioning Test\nBig transparent purple quad and small opaque green quad (both with grossini).\n";
+    
+    CCSprite *background = [CCSprite spriteWithImageNamed:@"Images/gridBackground.png"];
+    background.positionType = CCPositionTypeNormalized;
+    background.position = ccp(0.5f, 0.5f);
+    [self.contentNode addChild:background];
+    
+    {
+        CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+        effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+        effectNode.clearColor = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        effectNode.contentSizeType = CCSizeTypeNormalized;
+        effectNode.contentSize = CGSizeMake(0.75, 0.75);
+        effectNode.anchorPoint = ccp(0.5, 0.5);
+        effectNode.positionType = CCPositionTypeNormalized;
+        effectNode.position = ccp(0.5, 0.5);
+        
+        CCEffectHue *effect = [CCEffectHue effectWithHue:-60.0f];
+        effectNode.effect = effect;
+        
+        [self.contentNode addChild:effectNode];
+        
+        CCSprite *sprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        sprite.anchorPoint = ccp(0.5, 0.5);
+        sprite.positionType = CCPositionTypeNormalized;
+        sprite.position = ccp(0.25f, 0.5f);
+        [effectNode addChild:sprite];
+    }
+
+    {
+        CCEffectNode* effectNode = [[CCEffectNode alloc] init];
+        effectNode.clearFlags = GL_COLOR_BUFFER_BIT;
+        effectNode.clearColor = [CCColor colorWithRed:1.0f green:0.0f blue:0.0f alpha:1.0f];
+        effectNode.contentSizeType = CCSizeTypeMake(CCSizeUnitPoints, CCSizeUnitNormalized);
+        effectNode.contentSize = CGSizeMake(128, 0.5);
+        effectNode.anchorPoint = ccp(0.5, 0.5);
+        effectNode.positionType = CCPositionTypeNormalized;
+        effectNode.position = ccp(0.75, 0.5);
+        
+        CCEffectHue *effect = [CCEffectHue effectWithHue:120.0f];
+        effectNode.effect = effect;
+        
+        [self.contentNode addChild:effectNode];
+        
+        CCSprite *sprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        sprite.anchorPoint = ccp(0.5, 0.5);
+        sprite.positionType = CCPositionTypeNormalized;
+        sprite.position = ccp(0.5f, 0.5f);
+        [effectNode addChild:sprite];
+    }
+}
+
+
 - (CCNode *)effectNodeWithEffects:(NSArray *)effects appliedToSpriteWithImage:(NSString *)spriteImage atPosition:(CGPoint)position
 {
     // Another sprite that will be added directly

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -4,6 +4,7 @@
 #import "CCEffectNode.h"
 #import "CCEffectBlur.h"
 
+#import "CCEffect_Private.h"
 #import "CCEffectStack_Private.h"
 
 @interface CCEffectsTest : TestBase @end
@@ -677,7 +678,7 @@
     CCLabelTTF *plainTitle = [CCLabelTTF labelWithString:@"No FX" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
     plainTitle.color = [CCColor blackColor];
     plainTitle.positionType = CCPositionTypeNormalized;
-    plainTitle.position = ccp(0.1f, 0.7f);
+    plainTitle.position = ccp(0.05f, 0.7f);
     plainTitle.horizontalAlignment = CCTextAlignmentRight;
     
     [self.contentNode addChild:plainTitle];
@@ -686,11 +687,13 @@
     CCLabelTTF *effectTitle = [CCLabelTTF labelWithString:@"FX" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
     effectTitle.color = [CCColor blackColor];
     effectTitle.positionType = CCPositionTypeNormalized;
-    effectTitle.position = ccp(0.1f, 0.3f);
+    effectTitle.position = ccp(0.05f, 0.3f);
     effectTitle.horizontalAlignment = CCTextAlignmentRight;
     
     [self.contentNode addChild:effectTitle];
 
+    float x = 0.15f;
+    float step = 0.1875f;
     
     // Sprite with solid red
     {
@@ -698,13 +701,13 @@
 
         CCSprite *plainSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
         plainSprite.positionType = CCPositionTypeNormalized;
-        plainSprite.position = ccp(0.2f, 0.7f);
+        plainSprite.position = ccp(x, 0.7f);
         plainSprite.color = [CCColor redColor];
         [self.contentNode addChild:plainSprite];
 
         CCSprite *effectSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
         effectSprite.positionType = CCPositionTypeNormalized;
-        effectSprite.position = ccp(0.2f, 0.3f);
+        effectSprite.position = ccp(x, 0.3f);
         effectSprite.color = [CCColor redColor];
         effectSprite.effect = saturation;
         [self.contentNode addChild:effectSprite];
@@ -712,10 +715,12 @@
         CCLabelTTF *title = [CCLabelTTF labelWithString:@"Is color preserved?" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
         title.color = [CCColor blackColor];
         title.positionType = CCPositionTypeNormalized;
-        title.position = ccp(0.2f, 0.05f);
+        title.position = ccp(x, 0.05f);
         title.horizontalAlignment = CCTextAlignmentCenter;
         
         [self.contentNode addChild:title];
+    
+        x += step;
     }
 
     
@@ -725,13 +730,13 @@
 
         CCSprite *plainSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
         plainSprite.positionType = CCPositionTypeNormalized;
-        plainSprite.position = ccp(0.4f, 0.7f);
+        plainSprite.position = ccp(x, 0.7f);
         plainSprite.opacity = 0.5f;
         [self.contentNode addChild:plainSprite];
         
         CCSprite *effectSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
         effectSprite.positionType = CCPositionTypeNormalized;
-        effectSprite.position = ccp(0.4f, 0.3f);
+        effectSprite.position = ccp(x, 0.3f);
         effectSprite.opacity = 0.5f;
         effectSprite.effect = saturation;
         [self.contentNode addChild:effectSprite];
@@ -739,10 +744,12 @@
         CCLabelTTF *title = [CCLabelTTF labelWithString:@"Opacity?" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
         title.color = [CCColor blackColor];
         title.positionType = CCPositionTypeNormalized;
-        title.position = ccp(0.4f, 0.05f);
+        title.position = ccp(x, 0.05f);
         title.horizontalAlignment = CCTextAlignmentCenter;
         
         [self.contentNode addChild:title];
+        
+        x += step;
     }
 
 
@@ -755,44 +762,84 @@
         
         CCSprite *plainSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
         plainSprite.positionType = CCPositionTypeNormalized;
-        plainSprite.position = ccp(0.6f, 0.7f);
+        plainSprite.position = ccp(x, 0.7f);
         plainSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
         [self.contentNode addChild:plainSprite];
         
         CCSprite *effectSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
         effectSprite.positionType = CCPositionTypeNormalized;
-        effectSprite.position = ccp(0.6f, 0.3f);
+        effectSprite.position = ccp(x, 0.3f);
         effectSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
         effectSprite.effect = stack;
         [self.contentNode addChild:effectSprite];
         
-        CCLabelTTF *title = [CCLabelTTF labelWithString:@"Stack (with stitching)" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
+        CCLabelTTF *title = [CCLabelTTF labelWithString:@"Stack (all stitching)" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
         title.color = [CCColor blackColor];
         title.positionType = CCPositionTypeNormalized;
-        title.position = ccp(0.6f, 0.05f);
+        title.position = ccp(x, 0.05f);
         title.horizontalAlignment = CCTextAlignmentCenter;
         
         [self.contentNode addChild:title];
+        
+        x += step;
     }
     
     
-    // Sprite with 50% transparent red and two stacked effects
+    // Sprite with 50% transparent red and three stacked effects but stitching disabled
+    // manually after the second effect
+    {
+        CCEffect *saturation = [CCEffectSaturation effectWithSaturation:0.0f];
+        CCEffect *brightness = [CCEffectBrightness effectWithBrightness:0.0f];
+        CCEffect *hue = [CCEffectHue effectWithHue:0.0f];
+
+        // Manually manipulate the brightness effect's stitch flags so it is stitched with
+        // saturation but not with hue.
+        brightness.stitchFlags = CCEffectFunctionStitchBefore;
+        
+        CCEffectStack *stack = [CCEffectStack effectWithArray:@[saturation, brightness, hue]];
+        
+        CCSprite *plainSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        plainSprite.positionType = CCPositionTypeNormalized;
+        plainSprite.position = ccp(x, 0.7f);
+        plainSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        [self.contentNode addChild:plainSprite];
+        
+        CCSprite *effectSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
+        effectSprite.positionType = CCPositionTypeNormalized;
+        effectSprite.position = ccp(x, 0.3f);
+        effectSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
+        effectSprite.effect = stack;
+        [self.contentNode addChild:effectSprite];
+        
+        CCLabelTTF *title = [CCLabelTTF labelWithString:@"Stack (some stitching)" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
+        title.color = [CCColor blackColor];
+        title.positionType = CCPositionTypeNormalized;
+        title.position = ccp(x, 0.05f);
+        title.horizontalAlignment = CCTextAlignmentCenter;
+        
+        [self.contentNode addChild:title];
+        
+        x += step;
+    }
+
+    
+    // Sprite with 50% transparent red and two stacked effects but no stitching
     {
         CCEffect *saturation = [CCEffectSaturation effectWithSaturation:0.0f];
         CCEffect *hue = [CCEffectHue effectWithHue:0.0f];
-
+        
         CCEffectStack *stack = [CCEffectStack effectWithArray:@[saturation, hue]];
         stack.stitchingEnabled = NO;
         
         CCSprite *plainSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
         plainSprite.positionType = CCPositionTypeNormalized;
-        plainSprite.position = ccp(0.8f, 0.7f);
+        plainSprite.position = ccp(x, 0.7f);
         plainSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
         [self.contentNode addChild:plainSprite];
         
         CCSprite *effectSprite = [CCSprite spriteWithImageNamed:@"Images/grossini.png"];
         effectSprite.positionType = CCPositionTypeNormalized;
-        effectSprite.position = ccp(0.8f, 0.3f);
+        effectSprite.position = ccp(x, 0.3f);
         effectSprite.color = [CCColor colorWithRed:0.5f green:0.0f blue:0.0f alpha:0.5f];
         effectSprite.effect = stack;
         [self.contentNode addChild:effectSprite];
@@ -800,10 +847,12 @@
         CCLabelTTF *title = [CCLabelTTF labelWithString:@"Stack (no stitching)" fontName:@"HelveticaNeue-Light" fontSize:10 * [CCDirector sharedDirector].UIScaleFactor];
         title.color = [CCColor blackColor];
         title.positionType = CCPositionTypeNormalized;
-        title.position = ccp(0.8f, 0.05f);
+        title.position = ccp(x, 0.05f);
         title.horizontalAlignment = CCTextAlignmentCenter;
         
         [self.contentNode addChild:title];
+        
+        x += step;
     }
 }
 

--- a/cocos2d/CCEffect.m
+++ b/cocos2d/CCEffect.m
@@ -99,12 +99,13 @@ static NSString* vertBase =
 
 @implementation CCEffectFunctionInput
 
--(id)initWithType:(NSString*)type name:(NSString*)name snippet:(NSString*)snippet
+-(id)initWithType:(NSString*)type name:(NSString*)name initialSnippet:(NSString*)initialSnippet snippet:(NSString*)snippet
 {
     if((self = [super init]))
     {
         _type = [type copy];
         _name = [name copy];
+        _initialSnippet = [initialSnippet copy];
         _snippet = [snippet copy];
         return self;
     }
@@ -112,9 +113,9 @@ static NSString* vertBase =
     return self;
 }
 
-+(id)inputWithType:(NSString*)type name:(NSString*)name snippet:(NSString*)snippet
++(id)inputWithType:(NSString*)type name:(NSString*)name initialSnippet:(NSString*)initialSnippet snippet:(NSString*)snippet
 {
-    return [[self alloc] initWithType:type name:name snippet:snippet];
+    return [[self alloc] initWithType:type name:name initialSnippet:initialSnippet snippet:snippet];
 }
 
 @end
@@ -316,12 +317,22 @@ static NSString* vertBase =
 {
     if((self = [super init]))
     {
-        [self buildEffectWithFragmentFunction:fragmentFunctions vertexFunctions:vertexFunctions fragmentUniforms:fragmentUniforms vertexUniforms:vertexUniforms varyings:varyings];
+        [self buildEffectWithFragmentFunction:fragmentFunctions vertexFunctions:vertexFunctions fragmentUniforms:fragmentUniforms vertexUniforms:vertexUniforms varyings:varyings firstInStack:YES];
     }
     return self;
 }
 
-- (void)buildEffectWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings
+-(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings firstInStack:(BOOL)firstInStack
+{
+    if((self = [super init]))
+    {
+        [self buildEffectWithFragmentFunction:fragmentFunctions vertexFunctions:vertexFunctions fragmentUniforms:fragmentUniforms vertexUniforms:vertexUniforms varyings:varyings firstInStack:firstInStack];
+    }
+    return self;
+}
+
+
+- (void)buildEffectWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings firstInStack:(BOOL)firstInStack
 {
     if (fragmentFunctions)
     {
@@ -363,6 +374,7 @@ static NSString* vertBase =
     [self setVaryings:varyings];
     
     _stitchFlags = CCEffectFunctionStitchBoth;
+    _firstInStack = firstInStack;
     
     [self buildShaderUniforms:_fragmentUniforms vertexUniforms:_vertexUniforms];
     [self buildUniformTranslationTable];
@@ -414,17 +426,17 @@ static NSString* vertBase =
 
 -(void)buildEffectShader
 {
-    NSString *fragBody = [self  buildShaderSourceFromBase:fragBase functions:_fragmentFunctions uniforms:_fragmentUniforms varyings:_varyingVars];
+    NSString *fragBody = [self  buildShaderSourceFromBase:fragBase functions:_fragmentFunctions uniforms:_fragmentUniforms varyings:_varyingVars firstInStack:_firstInStack];
 //    NSLog(@"\n------------fragBody:\n%@", fragBody);
     
-    NSString *vertBody = [self  buildShaderSourceFromBase:vertBase functions:_vertexFunctions uniforms:_vertexUniforms varyings:_varyingVars];
+    NSString *vertBody = [self  buildShaderSourceFromBase:vertBase functions:_vertexFunctions uniforms:_vertexUniforms varyings:_varyingVars firstInStack:_firstInStack];
 //    NSLog(@"\n------------vertBody:\n%@", vertBody);
     
     _shader = [[CCShader alloc] initWithVertexShaderSource:vertBody fragmentShaderSource:fragBody];
 
 }
 
--(NSString *)buildShaderSourceFromBase:(NSString *)shaderBase functions:(NSArray *)functions uniforms:(NSArray *)uniforms varyings:(NSArray *)varyings
+-(NSString *)buildShaderSourceFromBase:(NSString *)shaderBase functions:(NSArray *)functions uniforms:(NSArray *)uniforms varyings:(NSArray *)varyings firstInStack:(BOOL)firstInStack
 {
     // Build the varying string
     NSMutableString* varyingString = [[NSMutableString alloc] init];
@@ -451,9 +463,19 @@ static NSString* vertBase =
         
         if([functions firstObject] == curFunction)
         {
-            for (CCEffectFunctionInput *input in curFunction.inputs)
+            if (firstInStack)
             {
-                [effectFunctionBody appendFormat:@"tmp = %@;\n", input.snippet];
+                for (CCEffectFunctionInput *input in curFunction.inputs)
+                {
+                    [effectFunctionBody appendFormat:@"tmp = %@;\n", input.initialSnippet];
+                }
+            }
+            else
+            {
+                for (CCEffectFunctionInput *input in curFunction.inputs)
+                {
+                    [effectFunctionBody appendFormat:@"tmp = %@;\n", input.snippet];
+                }
             }
         }
         

--- a/cocos2d/CCEffectBloom.h
+++ b/cocos2d/CCEffectBloom.h
@@ -25,17 +25,17 @@
  *  This value is in the range [0..1]. Lower values mean that more pixels will
  *  contribute to the blurry bloom image.
  */
-@property (nonatomic) float luminanceThreshold;
+@property (nonatomic, assign) float luminanceThreshold;
 
 /** The intensity of the blurred out bloom image when added to the original
  *  unmodified image. This value is in the range [0..1]. 0 results in no bloom
  *  while higher values result in more bloom.
  */
-@property (nonatomic) float intensity;
+@property (nonatomic, assign) float intensity;
 
 /** The size of the blur of the bloom image. This value is in the range [0..6].
  */
-@property (nonatomic) NSUInteger blurRadius;
+@property (nonatomic, assign) NSUInteger blurRadius;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectBlur.h
+++ b/cocos2d/CCEffectBlur.h
@@ -22,7 +22,7 @@
 
 /** The size of the blur. This value is in the range [0..6].
  */
-@property (nonatomic) NSUInteger blurRadius;
+@property (nonatomic, assign) NSUInteger blurRadius;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectBrightness.h
+++ b/cocos2d/CCEffectBrightness.h
@@ -26,7 +26,7 @@
  *  of -1 reduces the affected color to 0 (black), 0 results in no change, 1
  *  increases the affected color to 1 (white).
  */
-@property (nonatomic) float brightness;
+@property (nonatomic, assign) float brightness;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectBrightness.m
+++ b/cocos2d/CCEffectBrightness.m
@@ -15,7 +15,7 @@ static float conditionBrightness(float brightness);
 
 @interface CCEffectBrightness ()
 
-@property (nonatomic) NSNumber *conditionedBrightness;
+@property (nonatomic, strong) NSNumber *conditionedBrightness;
 
 @end
 

--- a/cocos2d/CCEffectBrightness.m
+++ b/cocos2d/CCEffectBrightness.m
@@ -50,7 +50,7 @@ static float conditionBrightness(float brightness);
 {
     self.fragmentFunctions = [[NSMutableArray alloc] init];
 
-    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
+    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" initialSnippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
 
     NSString* effectBody = CC_GLSL(
                                    return vec4((inputValue.rgb + vec3(u_brightness * inputValue.a)), inputValue.a);

--- a/cocos2d/CCEffectContrast.h
+++ b/cocos2d/CCEffectContrast.h
@@ -26,7 +26,7 @@
  *  an adjustment value of -1 scales the affected color by 0.25, 0 results in no
  *  change, and 1 scales the affected color by 4.
  */
-@property (nonatomic) float contrast;
+@property (nonatomic, assign) float contrast;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectContrast.m
+++ b/cocos2d/CCEffectContrast.m
@@ -51,7 +51,7 @@ static float conditionContrast(float contrast);
 {
     self.fragmentFunctions = [[NSMutableArray alloc] init];
 
-    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
+    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" initialSnippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
 
     NSString* effectBody = CC_GLSL(
                                    return vec4(((inputValue.rgb - vec3(0.5)) * vec3(u_contrast) + vec3(0.5)), inputValue.a);

--- a/cocos2d/CCEffectContrast.m
+++ b/cocos2d/CCEffectContrast.m
@@ -16,7 +16,7 @@ static float conditionContrast(float contrast);
 
 @interface CCEffectContrast ()
 
-@property (nonatomic) NSNumber *conditionedContrast;
+@property (nonatomic, strong) NSNumber *conditionedContrast;
 
 @end
 

--- a/cocos2d/CCEffectGlass.h
+++ b/cocos2d/CCEffectGlass.h
@@ -26,26 +26,26 @@
  *  resulting in maximum minification of the refracted image, 0 resulting in no
  *  refraction, and 1 resulting in maximum magnification of the refracted image.
  */
-@property (nonatomic) float refraction;
+@property (nonatomic, assign) float refraction;
 
 /** The overall shininess of the attached sprite. This value is in the range [0..1] and it controls
  *  how much of the reflected environment contributes to the final color of the affected pixels.
  */
-@property (nonatomic) float shininess;
+@property (nonatomic, assign) float shininess;
 
 /** The bias term in the fresnel reflectance equation:
  *    reflectance = max(0.0, fresnelBias + (1 - fresnelBias) * pow((1 - nDotV), fresnelPower))
  *  This value is in the range [0..1] and it controls the constant (view angle independent) contribution 
  *  to the reflectance equation.
  */
-@property (nonatomic) float fresnelBias;
+@property (nonatomic, assign) float fresnelBias;
 
 /** The power term in the fresnel reflectance equation:
  *    reflectance = max(0.0, fresnelBias + (1 - fresnelBias) * pow((1 - nDotV), fresnelPower))
  *  This value is in the range [0..inf] and it controls the view angle dependent contribution
  *  to the reflectance equation.
  */
-@property (nonatomic) float fresnelPower;
+@property (nonatomic, assign) float fresnelPower;
 
 /** The environment that will be refracted by the affected node. Typically this is a 
  *  sprite that serves as the background for the affected node so it appears that the viewer

--- a/cocos2d/CCEffectGlass.m
+++ b/cocos2d/CCEffectGlass.m
@@ -24,10 +24,10 @@ static const float CCEffectGlassDefaultFresnelPower = 2.0f;
 
 @interface CCEffectGlass ()
 
-@property (nonatomic) float conditionedRefraction;
-@property (nonatomic) float conditionedShininess;
-@property (nonatomic) float conditionedFresnelBias;
-@property (nonatomic) float conditionedFresnelPower;
+@property (nonatomic, assign) float conditionedRefraction;
+@property (nonatomic, assign) float conditionedShininess;
+@property (nonatomic, assign) float conditionedFresnelBias;
+@property (nonatomic, assign) float conditionedFresnelPower;
 
 @end
 

--- a/cocos2d/CCEffectGlass.m
+++ b/cocos2d/CCEffectGlass.m
@@ -110,7 +110,7 @@ static const float CCEffectGlassDefaultFresnelPower = 2.0f;
 {
     self.fragmentFunctions = [[NSMutableArray alloc] init];
     
-    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
+    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" initialSnippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
     
     NSString* effectBody = CC_GLSL(
                                    // Index the normal map and expand the color value from [0..1] to [-1..1]

--- a/cocos2d/CCEffectHue.h
+++ b/cocos2d/CCEffectHue.h
@@ -26,7 +26,7 @@
  *  hue adjustment of 120 you will get a green sprite. Instead if you apply a hue adjustment
  *  of -120 you will get a blue sprite.
  */
-@property (nonatomic) float hue;
+@property (nonatomic, assign) float hue;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectHue.m
+++ b/cocos2d/CCEffectHue.m
@@ -57,9 +57,9 @@ static GLKMatrix4 matrixWithHue(float hue);
 
 @interface CCEffectHue ()
 #if CCEFFECTHUE_USES_COLOR_MATRIX
-@property (nonatomic) NSValue *hueRotationMtx;
+@property (nonatomic, strong) NSValue *hueRotationMtx;
 #else
-@property (nonatomic) NSNumber *conditionedHue;
+@property (nonatomic, strong) NSNumber *conditionedHue;
 #endif
 @end
 

--- a/cocos2d/CCEffectHue.m
+++ b/cocos2d/CCEffectHue.m
@@ -103,7 +103,7 @@ static GLKMatrix4 matrixWithHue(float hue);
 {
     self.fragmentFunctions = [[NSMutableArray alloc] init];
 
-    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
+    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" initialSnippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
 
     // The non-color matrix shader is based on the hue filter in GPUImage - https://github.com/BradLarson/GPUImage
 #if CCEFFECTHUE_USES_COLOR_MATRIX

--- a/cocos2d/CCEffectNode.h
+++ b/cocos2d/CCEffectNode.h
@@ -41,4 +41,66 @@
  */
 -(id)initWithWidth:(int)w height:(int)h;
 
+/**
+ *  Initializes a CCEffectNode object with width and height in Points and a pixel format( only RGB and RGBA formats are valid ) and no depth-stencil buffer.
+ *
+ *  @param w                  Width of render target.
+ *  @param h                  Height of render target.
+ *  @param format             Pixel format of render target.
+ *
+ *  @return An initialized CCRenderTarget object.
+ */
+-(id)initWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format;
+
+/**
+ *  Initializes a CCEffectNode object with width and height in Points and a pixel format( only RGB and RGBA formats are valid ) and depthStencil format
+ *
+ *  @param w                  Width of render target.
+ *  @param h                  Height of render target.
+ *  @param format             Pixel format of render target.
+ *  @param depthStencilFormat Stencil format of render target.
+ *
+ *  @return An initialized CCRenderTarget object.
+ */
+-(id)initWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format depthStencilFormat:(GLuint)depthStencilFormat;
+
+
+/// -----------------------------------------------------------------------
+/// @name Creating a CCEffectNode object
+/// -----------------------------------------------------------------------
+
+/**
+ *  Creates a CCEffectNode object with width and height in points, the default color format and no depth-stencil buffer.
+ *
+ *  @param w      Width of render target.
+ *  @param h      Height of render target.
+ *
+ *  @return An initialized CCRenderTarget object.
+ */
++(id)effectNodeWithWidth:(int)w height:(int)h;
+
+/**
+ *  Creates a CCEffectNode object with width and height in Points and a pixel format( only RGB and RGBA formats are valid ) and no depth-stencil buffer.
+ *
+ *  @param w                  Width of render target.
+ *  @param h                  Height of render target.
+ *  @param format             Pixel format of render target.
+ *
+ *  @return An initialized CCRenderTarget object.
+ */
++(id)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format;
+
+/**
+ *  Creates a CCEffectNode object with width and height in Points and a pixel format( only RGB and RGBA formats are valid ) and depthStencil format
+ *
+ *  @param w                  Width of render target.
+ *  @param h                  Height of render target.
+ *  @param format             Pixel format of render target.
+ *  @param depthStencilFormat Stencil format of render target.
+ *
+ *  @return An initialized CCRenderTarget object.
+ */
++(id)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format depthStencilFormat:(GLuint)depthStencilFormat;
+
+
 @end

--- a/cocos2d/CCEffectNode.m
+++ b/cocos2d/CCEffectNode.m
@@ -61,6 +61,7 @@
     {
         _effectRenderer = [[CCEffectRenderer alloc] init];
         _allocatedSize = CGSizeMake(0.0f, 0.0f);
+        self.clearFlags = GL_COLOR_BUFFER_BIT;
 	}
 	return self;
 }
@@ -208,7 +209,7 @@
     // remainder of the effects.
     [self begin];
 
-    [_renderer enqueueClear:GL_COLOR_BUFFER_BIT color:_clearColor depth:self.clearDepth stencil:self.clearStencil globalSortOrder:NSIntegerMin];
+    [_renderer enqueueClear:self.clearFlags color:_clearColor depth:self.clearDepth stencil:self.clearStencil globalSortOrder:NSIntegerMin];
     
     //! make sure all children are drawn
     [self sortAllChildren];

--- a/cocos2d/CCEffectNode.m
+++ b/cocos2d/CCEffectNode.m
@@ -70,6 +70,18 @@
     }
 }
 
+-(void)create
+{
+    CGSize pointSize = self.contentSizeInPoints;
+    CGSize pixelSize = CGSizeMake(pointSize.width * _contentScale, pointSize.height * _contentScale);
+    [self createTextureAndFboWithPixelSize:pixelSize];
+
+    CGRect rect = CGRectMake(0, 0, pointSize.width, pointSize.height);
+	[_sprite setTextureRect:rect];
+    
+    _projection = GLKMatrix4MakeOrtho(0.0f, pointSize.width, 0.0f, pointSize.height, -1024.0f, 1024.0f);
+}
+
 -(void)begin
 {
 	CGSize pixelSize = self.texture.contentSizeInPixels;
@@ -204,6 +216,12 @@
     
     // And then copy the new effect's uniforms into the node's uniforms dictionary.
     [_shaderUniforms addEntriesFromDictionary:_effect.shaderUniforms];
+}
+
+- (void)setContentSizeType:(CCSizeType)contentSizeType
+{
+    [super setContentSizeType:contentSizeType];
+    _contentSizeChanged = YES;
 }
 
 @end

--- a/cocos2d/CCEffectNode.m
+++ b/cocos2d/CCEffectNode.m
@@ -47,11 +47,37 @@
 
 -(id)initWithWidth:(int)width height:(int)height
 {
-	if((self = [super initWithWidth:width height:height pixelFormat:CCTexturePixelFormat_Default])) {
+    return [self initWithWidth:width height:height pixelFormat:CCTexturePixelFormat_Default];
+}
+
+-(id)initWithWidth:(int)width height:(int)height pixelFormat:(CCTexturePixelFormat)format
+{
+    return [self initWithWidth:width height:height pixelFormat:format depthStencilFormat:0];
+}
+
+-(id)initWithWidth:(int)width height:(int)height pixelFormat:(CCTexturePixelFormat) format depthStencilFormat:(GLuint)depthStencilFormat
+{
+    if((self = [super initWithWidth:width height:height pixelFormat:CCTexturePixelFormat_Default depthStencilFormat:depthStencilFormat]))
+    {
         _effectRenderer = [[CCEffectRenderer alloc] init];
         _allocatedSize = CGSizeMake(0.0f, 0.0f);
 	}
 	return self;
+}
+
++(id)effectNodeWithWidth:(int)w height:(int)h
+{
+    return [[CCEffectNode alloc] initWithWidth:w height:h];
+}
+
++(id)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format
+{
+    return [[CCEffectNode alloc] initWithWidth:w height:h pixelFormat:format];
+}
+
++(id)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format depthStencilFormat:(GLuint)depthStencilFormat
+{
+    return [[CCEffectNode alloc] initWithWidth:w height:h pixelFormat:format depthStencilFormat:depthStencilFormat];
 }
 
 -(CCEffect *)effect

--- a/cocos2d/CCEffectNode.m
+++ b/cocos2d/CCEffectNode.m
@@ -122,6 +122,12 @@
 	// override visit.
 	// Don't call visit on its children
 	if(!_visible) return;
+    
+    if(_contentSizeChanged)
+    {
+        [self destroy];
+        _contentSizeChanged = NO;
+    }
 	
     GLKMatrix4 transform = [self transform:parentTransform];
     

--- a/cocos2d/CCEffectNode.m
+++ b/cocos2d/CCEffectNode.m
@@ -180,7 +180,7 @@
     
     if (_effect)
     {
-        _effectRenderer.contentSize = self.contentSize;
+        _effectRenderer.contentSize = self.contentSizeInPoints;
         if ([_effect prepareForRendering] == CCEffectPrepareSuccess)
         {
             // Preparing an effect for rendering can modify its uniforms

--- a/cocos2d/CCEffectPixellate.h
+++ b/cocos2d/CCEffectPixellate.h
@@ -22,7 +22,7 @@
  *  and is in the range [1..inf]. A value of 1 results in no change to the affected pixels
  *  and larger values result in larger output pixel blocks.
  */
-@property (nonatomic) float blockSize;
+@property (nonatomic, assign) float blockSize;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectPixellate.m
+++ b/cocos2d/CCEffectPixellate.m
@@ -49,7 +49,7 @@ static float conditionBlockSize(float blockSize);
 
 @interface CCEffectPixellate ()
 
-@property (nonatomic) float conditionedBlockSize;
+@property (nonatomic, assign) float conditionedBlockSize;
 
 @end
 

--- a/cocos2d/CCEffectReflection.h
+++ b/cocos2d/CCEffectReflection.h
@@ -35,21 +35,21 @@
 /** The overall shininess of the attached sprite. This value is in the range [0..1] and it controls
  *  how much of the reflected environment contributes to the final color of the affected pixels.
  */
-@property (nonatomic) float shininess;
+@property (nonatomic, assign) float shininess;
 
 /** The bias term in the fresnel reflectance equation:
  *    reflectance = max(0.0, fresnelBias + (1 - fresnelBias) * pow((1 - nDotV), fresnelPower))
  *  This value is in the range [0..1] and it controls the constant (view angle independent) contribution
  *  to the reflectance equation.
  */
-@property (nonatomic) float fresnelBias;
+@property (nonatomic, assign) float fresnelBias;
 
 /** The power term in the fresnel reflectance equation:
  *    reflectance = max(0.0, fresnelBias + (1 - fresnelBias) * pow((1 - nDotV), fresnelPower))
  *  This value is in the range [0..inf] and it controls the view angle dependent contribution
  *  to the reflectance equation.
  */
-@property (nonatomic) float fresnelPower;
+@property (nonatomic, assign) float fresnelPower;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -20,9 +20,9 @@
 
 @interface CCEffectReflection ()
 
-@property (nonatomic) float conditionedShininess;
-@property (nonatomic) float conditionedFresnelBias;
-@property (nonatomic) float conditionedFresnelPower;
+@property (nonatomic, assign) float conditionedShininess;
+@property (nonatomic, assign) float conditionedFresnelBias;
+@property (nonatomic, assign) float conditionedFresnelPower;
 
 @end
 

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -111,7 +111,7 @@
 {
     self.fragmentFunctions = [[NSMutableArray alloc] init];
     
-    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
+    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" initialSnippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
     
     NSString* effectBody = CC_GLSL(
                                    // Index the normal map and expand the color value from [0..1] to [-1..1]

--- a/cocos2d/CCEffectRefraction.h
+++ b/cocos2d/CCEffectRefraction.h
@@ -23,7 +23,7 @@
  *  resulting in maximum minification of the refracted image, 0 resulting in no
  *  refraction, and 1 resulting in maximum magnification of the refracted image.
  */
-@property (nonatomic) float refraction;
+@property (nonatomic, assign) float refraction;
 
 /** The environment that will be refracted by the affected node. Typically this is a
  *  sprite that serves as the background for the affected node so it appears that the viewer

--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -80,7 +80,7 @@
 {
     self.fragmentFunctions = [[NSMutableArray alloc] init];
 
-    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
+    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" initialSnippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
     
     NSString* effectBody = CC_GLSL(
                                    // Index the normal map and expand the color value from [0..1] to [-1..1]

--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -19,7 +19,7 @@
 
 @interface CCEffectRefraction ()
 
-@property (nonatomic) float conditionedRefraction;
+@property (nonatomic, assign) float conditionedRefraction;
 
 @end
 

--- a/cocos2d/CCEffectSaturation.h
+++ b/cocos2d/CCEffectSaturation.h
@@ -23,7 +23,7 @@
  *  desaturates all affected pixels resulting in a grayscale image, 0 results in
  *  no change, 1 results in an increase in saturation by 100%.
  */
-@property (nonatomic) float saturation;
+@property (nonatomic, assign) float saturation;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCEffectSaturation.m
+++ b/cocos2d/CCEffectSaturation.m
@@ -51,7 +51,7 @@ static float conditionSaturation(float saturation);
 
 @interface CCEffectSaturation ()
 
-@property (nonatomic) NSNumber *conditionedSaturation;
+@property (nonatomic, strong) NSNumber *conditionedSaturation;
 
 @end
 

--- a/cocos2d/CCEffectSaturation.m
+++ b/cocos2d/CCEffectSaturation.m
@@ -86,7 +86,7 @@ static float conditionSaturation(float saturation);
 {
     self.fragmentFunctions = [[NSMutableArray alloc] init];
 
-    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
+    CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" initialSnippet:@"cc_FragColor * texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)" snippet:@"texture2D(cc_PreviousPassTexture, cc_FragTexCoord1)"];
     
     // Image saturation shader based on saturation filter in GPUImage - https://github.com/BradLarson/GPUImage
     NSString* effectBody = CC_GLSL(

--- a/cocos2d/CCEffectStack_Private.h
+++ b/cocos2d/CCEffectStack_Private.h
@@ -12,8 +12,8 @@
 
 @interface CCEffectStack () <CCEffectStackProtocol>
 
-@property (nonatomic) BOOL passesDirty;
-@property (nonatomic) BOOL stitchingEnabled;
-@property (nonatomic) NSMutableArray *effects;
+@property (nonatomic, assign) BOOL passesDirty;
+@property (nonatomic, assign) BOOL stitchingEnabled;
+@property (nonatomic, strong) NSMutableArray *effects;
 
 @end

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -50,10 +50,11 @@ typedef NS_ENUM(NSUInteger, CCEffectPrepareStatus)
 
 @property (nonatomic, readonly) NSString* type;
 @property (nonatomic, readonly) NSString* name;
+@property (nonatomic, readonly) NSString* initialSnippet;
 @property (nonatomic, readonly) NSString* snippet;
 
--(id)initWithType:(NSString*)type name:(NSString*)name snippet:(NSString*)snippet;
-+(id)inputWithType:(NSString*)type name:(NSString*)name snippet:(NSString*)snippet;
+-(id)initWithType:(NSString*)type name:(NSString*)name initialSnippet:(NSString*)initialSnippet snippet:(NSString*)snippet;
++(id)inputWithType:(NSString*)type name:(NSString*)name initialSnippet:(NSString*)initialSnippet snippet:(NSString*)snippet;
 
 @end
 
@@ -131,10 +132,13 @@ typedef void (^CCEffectRenderPassEndBlock)(CCEffectRenderPass *pass);
 @property (nonatomic) CCEffectFunctionStitchFlags stitchFlags;
 @property (nonatomic) NSMutableDictionary* uniformTranslationTable;
 
+@property (nonatomic, readonly) BOOL firstInStack;
+
 
 -(id)initWithFragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings;
 -(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings;
 -(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings;
+-(id)initWithFragmentFunction:(NSMutableArray*) fragmentFunctions vertexFunctions:(NSMutableArray*)vertexFunctions fragmentUniforms:(NSArray*)fragmentUniforms vertexUniforms:(NSArray*)vertexUniforms varyings:(NSArray*)varyings firstInStack:(BOOL)firstInStack;
 
 -(CCEffectPrepareStatus)prepareForRendering;
 -(CCEffectRenderPass *)renderPassAtIndex:(NSUInteger)passIndex;

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -93,19 +93,19 @@ typedef void (^CCEffectRenderPassEndBlock)(CCEffectRenderPass *pass);
 // Note to self: I don't like this pattern, refactor it. I think there should be a CCRenderPass that is used by CCEffect instead. NOTE: convert this to a CCRnderPassProtocol
 @interface CCEffectRenderPass : NSObject
 
-@property (nonatomic) NSInteger renderPassId;
+@property (nonatomic, assign) NSInteger renderPassId;
 @property (nonatomic, strong) CCRenderer* renderer;
-@property (nonatomic) CCSpriteVertexes verts;
-@property (nonatomic) GLKMatrix4 transform;
-@property (nonatomic) GLKMatrix4 ndcToWorld;
+@property (nonatomic, assign) CCSpriteVertexes verts;
+@property (nonatomic, assign) GLKMatrix4 transform;
+@property (nonatomic, assign) GLKMatrix4 ndcToWorld;
 @property (nonatomic, strong) CCBlendMode* blendMode;
 @property (nonatomic, strong) CCShader* shader;
 @property (nonatomic, strong) NSMutableDictionary* shaderUniforms;
-@property (nonatomic) BOOL needsClear;
-@property (nonatomic,copy) NSArray* beginBlocks;
-@property (nonatomic,copy) NSArray* updateBlocks;
-@property (nonatomic,copy) NSArray* endBlocks;
-@property (nonatomic,copy) NSString *debugLabel;
+@property (nonatomic, assign) BOOL needsClear;
+@property (nonatomic, copy) NSArray* beginBlocks;
+@property (nonatomic, copy) NSArray* updateBlocks;
+@property (nonatomic, copy) NSArray* endBlocks;
+@property (nonatomic, copy) NSString *debugLabel;
 
 -(void)begin:(CCTexture *)previousPassTexture;
 -(void)update;
@@ -123,14 +123,14 @@ typedef void (^CCEffectRenderPassEndBlock)(CCEffectRenderPass *pass);
 @property (nonatomic, readonly) BOOL readyForRendering;
 
 @property (nonatomic, weak) id<CCEffectStackProtocol> owningStack;
-@property (nonatomic) NSMutableArray* vertexFunctions;
-@property (nonatomic) NSMutableArray* fragmentFunctions;
-@property (nonatomic) NSArray* fragmentUniforms;
-@property (nonatomic) NSArray* vertexUniforms;
-@property (nonatomic) NSArray* varyingVars;
-@property (nonatomic) NSArray* renderPasses;
-@property (nonatomic) CCEffectFunctionStitchFlags stitchFlags;
-@property (nonatomic) NSMutableDictionary* uniformTranslationTable;
+@property (nonatomic, strong) NSMutableArray* vertexFunctions;
+@property (nonatomic, strong) NSMutableArray* fragmentFunctions;
+@property (nonatomic, strong) NSArray* fragmentUniforms;
+@property (nonatomic, strong) NSArray* vertexUniforms;
+@property (nonatomic, strong) NSArray* varyingVars;
+@property (nonatomic, strong) NSArray* renderPasses;
+@property (nonatomic, assign) CCEffectFunctionStitchFlags stitchFlags;
+@property (nonatomic, strong) NSMutableDictionary* uniformTranslationTable;
 
 @property (nonatomic, readonly) BOOL firstInStack;
 

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -117,7 +117,7 @@ typedef void (^CCEffectRenderPassEndBlock)(CCEffectRenderPass *pass);
 @interface CCEffect ()
 
 @property (nonatomic, readonly) CCShader* shader; // Note: consider adding multiple shaders (one for reach renderpass, this will help break up logic and avoid branching in a potential uber shader).
-@property (nonatomic, readonly) NSMutableDictionary* shaderUniforms;
+@property (nonatomic, strong) NSMutableDictionary* shaderUniforms;
 @property (nonatomic, readonly) NSUInteger renderPassesRequired;
 @property (nonatomic, readonly) BOOL supportsDirectRendering;
 @property (nonatomic, readonly) BOOL readyForRendering;

--- a/cocos2d/CCNoARC.m
+++ b/cocos2d/CCNoARC.m
@@ -78,7 +78,7 @@ EnqueueTriangles(CCSprite *self, CCRenderer *renderer, const GLKMatrix4 *transfo
 	
 	if (_effect)
 	{
-		_effectRenderer.contentSize = self.contentSize;
+		_effectRenderer.contentSize = self.contentSizeInPoints;
 		if ([self.effect prepareForRendering] == CCEffectPrepareSuccess)
 		{
 			// Preparing an effect for rendering can modify its uniforms

--- a/cocos2d/CCNode_Private.h
+++ b/cocos2d/CCNode_Private.h
@@ -107,4 +107,6 @@ CGAffineTransform CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
  */
 -(void) detachChild:(CCNode *)child cleanup:(BOOL)doCleanup;
 
+- (void) contentSizeChanged;
+
 @end

--- a/cocos2d/CCRenderTexture.m
+++ b/cocos2d/CCRenderTexture.m
@@ -169,12 +169,14 @@
 
 -(void)create
 {
+    CGSize pixelSize = CGSizeMake(_contentSize.width * _contentScale, _contentSize.height * _contentScale);
+    [self createTextureAndFboWithPixelSize:pixelSize];
+}
+
+-(void)createTextureAndFboWithPixelSize:(CGSize)pixelSize
+{
 	glPushGroupMarkerEXT(0, "CCRenderTexture: Create");
 	
-	int pixelW = _contentSize.width*_contentScale;
-	int pixelH = _contentSize.height*_contentScale;
-
-
 	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_oldFBO);
 
 	// textures must be power of two
@@ -182,16 +184,16 @@
 	NSUInteger powH;
 
 	if( [[CCConfiguration sharedConfiguration] supportsNPOT] ) {
-		powW = pixelW;
-		powH = pixelH;
+		powW = pixelSize.width;
+		powH = pixelSize.height;
 	} else {
-		powW = CCNextPOT(pixelW);
-		powH = CCNextPOT(pixelH);
+		powW = CCNextPOT(pixelSize.width);
+		powH = CCNextPOT(pixelSize.height);
 	}
 
 	void *data = calloc(powW*powH, 4);
 
-	CCTexture *texture = [[CCTexture alloc] initWithData:data pixelFormat:_pixelFormat pixelsWide:powW pixelsHigh:powH contentSizeInPixels:CGSizeMake(pixelW, pixelH) contentScale:_contentScale];
+	CCTexture *texture = [[CCTexture alloc] initWithData:data pixelFormat:_pixelFormat pixelsWide:powW pixelsHigh:powH contentSizeInPixels:pixelSize contentScale:_contentScale];
     self.texture = texture;
     
 	free(data);
@@ -234,6 +236,10 @@
 	CC_CHECK_GL_ERROR_DEBUG();
 	glPopGroupMarkerEXT();
 	
+    // XXX Thayer says: I think this is incorrect for any situations where the content
+    // size type isn't (points, points). The call to setTextureRect below eventually arrives
+    // at some code that assumes the supplied size is in points so, if the size is not in points,
+    // things break.
 	CGRect rect = CGRectMake(0, 0, _contentSize.width, _contentSize.height);
 	
 	[self assignSpriteTexture];
@@ -618,6 +624,10 @@
     // TODO: Fix CCRenderTexture so that it correctly handles this
 	// NSAssert(NO, @"You cannot change the content size of an already created CCRenderTexture. Recreate it");
     [super setContentSize:size];
+    
+    // XXX Thayer says: I'm pretty sure this is broken since the supplied content size could
+    // be normalized, in points, in UI points, etc. We should get the size in points then convert
+    // to pixels and use that to make the ortho matrix.
 	_projection = GLKMatrix4MakeOrtho(0.0f, size.width, 0.0f, size.height, -1024.0f, 1024.0f);
     _contentSizeChanged = YES;
 

--- a/cocos2d/CCRenderTexture_Private.h
+++ b/cocos2d/CCRenderTexture_Private.h
@@ -36,6 +36,7 @@
     BOOL _contentSizeChanged;
 }
 
+-(void)createTextureAndFboWithPixelSize:(CGSize)pixelSize;
 -(void)destroy;
 
 -(GLuint)fbo;


### PR DESCRIPTION
- Refactor CCRenderTexture's create method into create and createTextureAndFboWithPixelSize. In CCEffectNode, override the create method so pixel size is computed correctly. This fixes effect node's parent relative sizing while leaving render texture the same (because render texture needs even more changes that I don't want to tackle right now).
- Override setContentSizeType on effect node so it also marks the content size as dirty when it changes.
- If content size has changed since the last visit, destroy any allocated resources and recreate them (as CCRenderTexture already does).
- Pass the content size in points to CCEffectRenderer from sprite and effect node.
- Add a bunch of effect node sizing tests.

**Update**:
- Fix handling of sprite color and opacity when combined with effects.
- Fix handling of clipping nodes as children of effect nodes.
- Fix effect node resizing when an effect node's size is parent relative and the size of a parent changes.
- Add tests for all of this.
