### PR TITLE
Expose device orientation methods to the AppDelegate

### DIFF
--- a/cocos2d/CCProtocols.h
+++ b/cocos2d/CCProtocols.h
@@ -133,6 +133,7 @@
 -(GLKMatrix4) updateProjection;
 
 #ifdef __CC_PLATFORM_IOS
+-(NSUInteger)supportedInterfaceOrientations;
 /** Returns a Boolean value indicating whether the CCDirector supports the specified orientation. Default value is YES (supports all possible orientations) */
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
 

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -76,6 +76,9 @@ const CGSize FIXED_SIZE = {568, 384};
 // Only valid for iOS 6+. NOT VALID for iOS 4 / 5.
 -(NSUInteger)supportedInterfaceOrientations
 {
+	if ([_appDelegate respondsToSelector:_cmd])
+		return (NSUInteger)[_appDelegate supportedInterfaceOrientations];
+		
     if ([_screenOrientation isEqual:CCScreenOrientationAll])
     {
         return UIInterfaceOrientationMaskAll;
@@ -94,6 +97,9 @@ const CGSize FIXED_SIZE = {568, 384};
 // Only valid on iOS 4 / 5. NOT VALID for iOS 6.
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
+	if ([_appDelegate respondsToSelector:_cmd])
+		return (BOOL)[_appDelegate shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+
     if ([_screenOrientation isEqual:CCScreenOrientationAll])
     {
         return YES;


### PR DESCRIPTION
Forwards CCNavigationController's device orientation methods to the AppDelegate. Gives an option for different behaviors than default
