### PR TITLE
Instant fix

### DIFF
--- a/cocos2d/CCActionEase.m
+++ b/cocos2d/CCActionEase.m
@@ -460,7 +460,7 @@
 @implementation CCActionEaseInstant
 -(void) update: (CCTime) t
 {
-    if (t < 0)
+    if (t < 1)
     {
         [self.inner update:0];
     }


### PR DESCRIPTION
CCActionEaseInstant's timing is wrong and calls update:1 when t is not less than 0. This means the action goes to the end immediately. The instant change should happen at the end. This is particularly noticeable if you're using SpriteBuilder, as your keyframes are applied at the beginning of the transition – at the time of the previous keyframe.
