### PR TITLE
Always stop CCDirector when app is backgrounded

### DIFF
--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -291,8 +291,9 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 -(void) applicationWillEnterForeground:(UIApplication*)application
 {
-	if([CCDirector sharedDirector].animating == NO)
+	if([CCDirector sharedDirector].animating == NO) {
 		[[CCDirector sharedDirector] startAnimation];
+	}
 }
 
 // application will be killed

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -268,27 +268,30 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 // getting a call, pause the game
 -(void) applicationWillResignActive:(UIApplication *)application
 {
-	if( [navController_ visibleViewController] == [CCDirector sharedDirector] )
+	if([CCDirector sharedDirector].paused == NO) {
 		[[CCDirector sharedDirector] pause];
+	}
 }
 
 // call got rejected
 -(void) applicationDidBecomeActive:(UIApplication *)application
 {
 	[[CCDirector sharedDirector] setNextDeltaTimeZero:YES];
-	if( [navController_ visibleViewController] == [CCDirector sharedDirector] )
+	if([CCDirector sharedDirector].paused) {
 		[[CCDirector sharedDirector] resume];
+	}
 }
 
 -(void) applicationDidEnterBackground:(UIApplication*)application
 {
-	if( [navController_ visibleViewController] == [CCDirector sharedDirector] )
+	if([CCDirector sharedDirector].animating) {
 		[[CCDirector sharedDirector] stopAnimation];
+	}
 }
 
 -(void) applicationWillEnterForeground:(UIApplication*)application
 {
-	if( [navController_ visibleViewController] == [CCDirector sharedDirector] )
+	if([CCDirector sharedDirector].animating == NO)
 		[[CCDirector sharedDirector] startAnimation];
 }
 


### PR DESCRIPTION
With the way things currently are, the CCDirector will keep trying to render the scene if it isn't the "visible" view controller when the app gets backgrounded, leading to a crash. Such scenarios include the user being shown the GameCenter login screen and switching away from the app to look up their password in 1Password, or if the user is being shown a Tweet Sheet and switches away.

In my own game the user can send a tweet to share their game progress, and if they switch away while the Tweet Sheet (`SLComposeViewController`) is being shown (such as getting a phone call) the game will crash. My code **does** call `[[CCDirector sharedDirector] pause]` when it shows the tweet sheet so that the tweet sheet's appearance animation is smooth, but I had (incorrectly) assumed that CCAppDelegate would call `-stopAnimation` on the CCDirector if the user switched away.

I don't see a reason for CCAppDelegate to _not_ stop the CCDirector, hence this pull request.
