### PR TITLE
support Swift classes in CCBReader

### DIFF
--- a/cocos2d-ui/CCBReader/CCBReader.m
+++ b/cocos2d-ui/CCBReader/CCBReader.m
@@ -1246,6 +1246,14 @@ static inline float readFloat(CCBReader *self)
     Class class = NSClassFromString(className);
     if (!class)
     {
+        // Class was not found. Maybe it's a Swift class?
+        // See http://stackoverflow.com/questions/24030814/swift-language-nsclassfromstring
+        NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+        NSString *classStringName = [NSString stringWithFormat:@"_TtC%d%@%d%@", appName.length, appName, className.length, className];
+        class = NSClassFromString(classStringName);
+    }
+    if (!class)
+    {
 #if DEBUG
         NSLog(@"*** [CLASS] ERROR HINT: Did you set a custom class for a CCNode? Please check if the specified class name is spelled correctly and available in your project.");
 #endif


### PR DESCRIPTION
This fixes a "Could not create class named" error when creating classes with CCBReader.
