### PR TITLE
Use autorelease CCRenderState method in CCLabelTTF

### DIFF
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -337,7 +337,7 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
 		BOOL copyUniforms = self.hasDefaultShaderUniforms;
 		
 		// Create an uncached renderstate so the texture can be released before the renderstate cache is flushed.
-		_renderState = [[CCRenderState alloc] initWithBlendMode:_blendMode shader:_shader shaderUniforms:self.shaderUniforms copyUniforms:copyUniforms];
+		_renderState = [CCRenderState renderStateWithBlendMode:_blendMode shader:_shader shaderUniforms:self.shaderUniforms copyUniforms:copyUniforms];
 	}
 	
 	return _renderState;


### PR DESCRIPTION
This fixes a build error introduced in f52a39197f

```
cocos2d-iphone/cocos2d/CCLabelTTF.m:340:41: No visible @interface for 'CCRenderState' declares the selector 'initWithBlendMode:shader:shaderUniforms:copyUniforms:'
```
