### PR TITLE
Handle odd line seperators in CCLabelBMFont.

### DIFF
--- a/cocos2d-ui-tests/tests/CCBMFontTest.m
+++ b/cocos2d-ui-tests/tests/CCBMFontTest.m
@@ -12,6 +12,7 @@
 static NSString *TEST_STRINGS[] = {
 	@"ABCDEFGHIJKLM\nNOPQRSTUVWXYZ",
 	@"abcdefghijklm\nnopqrstuvwxyz",
+	@"first line\u2028second line",
 	@",.?!;:'\"",
 	@"()[]{}<>\\|/\n",
 	@"@#$%^&*+-=_",

--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -762,7 +762,7 @@ void FNTConfigRemoveCache( void )
 	// since the Y position needs to be calcualted before hand
 	for(NSUInteger i=0; i < stringLen-1;i++) {
 		unichar c = [_string characterAtIndex:i];
-		if( c=='\n')
+		if([[NSCharacterSet newlineCharacterSet] characterIsMember:c])
 			quantityOfLines++;
 	}
     
@@ -776,7 +776,7 @@ void FNTConfigRemoveCache( void )
 	for(NSUInteger i = 0; i<stringLen; i++) {
 		unichar c = [_string characterAtIndex:i];
         
-		if (c == '\n') {
+        if ([[NSCharacterSet newlineCharacterSet] characterIsMember:c]) {
 			nextFontPositionX = 0;
 			nextFontPositionY -= _configuration->_commonHeight;
 			continue;


### PR DESCRIPTION
The XCode plist editor and some other editors can create string data
with Unicode line seperators in it, eg: \u2028.

http://en.wikipedia.org/wiki/Newline#Unicode

You can easily enter one using <ctrl>+<enter> in your plist or code
editor.  The plist editor will not let you type <enter> as it will just
commit the current cell being edited.  To get an actual newline you can
type <option>+<enter>.

Code in CCLabelBMFont correctly tests using NSCharacterSet
newlineCharacterSet in most places, but in two places incorrectly
tests for equality against '\n'.

So strings with one of these "odd" newlines will be rendered with all
the text on one line.  Fix this, and make the code consistent.
