### PR TITLE
Stop the CCDirector from running when the app is backgrounded

### DIFF
--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -266,28 +266,24 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 // getting a call, pause the game
 -(void) applicationWillResignActive:(UIApplication *)application
 {
-	if( [navController_ visibleViewController] == [CCDirector sharedDirector] )
-		[[CCDirector sharedDirector] pause];
+	[[CCDirector sharedDirector] pause];
 }
 
 // call got rejected
 -(void) applicationDidBecomeActive:(UIApplication *)application
 {
 	[[CCDirector sharedDirector] setNextDeltaTimeZero:YES];
-	if( [navController_ visibleViewController] == [CCDirector sharedDirector] )
-		[[CCDirector sharedDirector] resume];
+	[[CCDirector sharedDirector] resume];
 }
 
 -(void) applicationDidEnterBackground:(UIApplication*)application
 {
-	if( [navController_ visibleViewController] == [CCDirector sharedDirector] )
-		[[CCDirector sharedDirector] stopAnimation];
+	[[CCDirector sharedDirector] stopAnimation];
 }
 
 -(void) applicationWillEnterForeground:(UIApplication*)application
 {
-	if( [navController_ visibleViewController] == [CCDirector sharedDirector] )
-		[[CCDirector sharedDirector] startAnimation];
+	[[CCDirector sharedDirector] startAnimation];
 }
 
 // application will be killed


### PR DESCRIPTION
Stop the CCDirector from running when the app is backgrounded, regardless of what view controller is visible (because it will still crash if it tries to render in the background when it isn't the "visible" view controller).
