### PR TITLE
CCEffects - Stacking bug fixes plus test additions

### DIFF
--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -942,7 +942,7 @@
                          [CCEffectBrightness effectWithBrightness:0.25f],
                          [CCEffectContrast effectWithContrast:1.0f],
                          [CCEffectPixellate effectWithBlockSize:8.0f],
-                         [CCEffectSaturation effectWithSaturation:-1.0f],
+                         [CCEffectSaturation effectWithSaturation:1.0f],
                          [CCEffectHue effectWithHue:90.0f],
                          [CCEffectGlass effectWithShininess:1.0f refraction:0.75f refractionEnvironment:refractEnvironment reflectionEnvironment:reflectEnvironment],
                          [CCEffectRefraction effectWithRefraction:0.75f environment:refractEnvironment],
@@ -956,7 +956,9 @@
     sprite.position = ccp(0.5f, 0.5f);
     sprite.scale = 0.5f;
 
-    sprite.effect = [CCEffectStack effects:effects[7], effects[4], nil];
+    CCEffectStack *stack1 = [CCEffectStack effects:effects[7], effects[6], nil];
+    CCEffectStack *stack2 = [CCEffectStack effects:effects[5], effects[4], nil];
+    sprite.effect = [CCEffectStack effects:stack1, stack2, nil];
     
     sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:@"Images/ShinyBallNormals.png"];
     sprite.colorRGBA = [CCColor colorWithRed:0.75f green:0.75f blue:0.75f alpha:0.75f];
@@ -1026,7 +1028,7 @@
     
     CGSize containerSize = self.contentNode.contentSizeInPoints;
     
-    const float footprintScale = 1.1f;
+    const float footprintScale = 0.5f;
     
     NSString *spriteImage = @"Images/r1.png";
     CCSprite *sprite = [CCSprite spriteWithImageNamed:spriteImage];

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -810,10 +810,12 @@
         sampleSprite3.positionType = CCPositionTypeNormalized;
         
         // Blend glow maps test
+        CCEffectHue *hueEffect = [CCEffectHue effectWithHue:60.0f];
         CCEffectBloom* glowEffect3 = [CCEffectBloom effectWithBlurRadius:8 intensity:1.0f luminanceThreshold:1.0f - ((float)i/(float)(steps-1))];
         glowEffect3.padding = CGSizeMake(10.0f, 10.0f);
-        sampleSprite3.effect = glowEffect3;
         
+        sampleSprite3.effect = [CCEffectStack effectWithArray:@[glowEffect3, hueEffect]];
+
         [self.contentNode addChild:sampleSprite3];
     }
 }

--- a/cocos2d/CCEffect.m
+++ b/cocos2d/CCEffect.m
@@ -250,6 +250,20 @@ static NSString* vertBase =
     return self;
 }
 
+-(instancetype)copyWithZone:(NSZone *)zone
+{
+	CCEffectRenderPass *newPass = [[CCEffectRenderPass allocWithZone:zone] initWithIndex:_indexInEffect];
+    newPass.texCoord1Mapping = _texCoord1Mapping;
+    newPass.texCoord2Mapping = _texCoord2Mapping;
+    newPass.blendMode = _blendMode;
+    newPass.shader = _shader;
+    newPass.beginBlocks = _beginBlocks;
+    newPass.updateBlocks = _updateBlocks;
+    newPass.endBlocks = _endBlocks;
+    newPass.debugLabel = _debugLabel;
+    return newPass;
+}
+
 -(void)begin:(CCTexture *)previousPassTexture
 {
     for (CCEffectRenderPassBeginBlock block in _beginBlocks)

--- a/cocos2d/CCEffectStack.m
+++ b/cocos2d/CCEffectStack.m
@@ -186,7 +186,6 @@
             int effectIndex = 0;
             for (NSArray *stitchList in stitchLists)
             {
-                NSAssert(stitchList.count > 0, @"Encountered an empty stitch list which shouldn't happen.");
                 [stitchedEffects addObject:[CCEffectStack stitchEffects:stitchList startIndex:effectIndex]];
                 effectIndex += stitchList.count;
             }
@@ -222,16 +221,20 @@
 
 #pragma mark - Internal
 
-+ (CCEffect *)stitchEffects:(NSArray*)effects startIndex:(int)startIndex
++ (CCEffect *)stitchEffects:(NSArray*)stitchList startIndex:(int)startIndex
 {
+    NSAssert(stitchList.count > 0, @"Encountered an empty stitch list which shouldn't happen.");
+
     NSMutableArray* allFragFunctions = [[NSMutableArray alloc] init];
     NSMutableArray* allFragUniforms = [[NSMutableArray alloc] init];
     NSMutableArray* allVertexFunctions = [[NSMutableArray alloc] init];
     NSMutableArray* allVertexUniforms = [[NSMutableArray alloc] init];
     NSMutableArray* allVaryings = [[NSMutableArray alloc] init];
     
+    // Even if we're only handed one effect in this stitch list, we have to run it through the
+    // name mangling code below because all effects in a stack share one uniform namespace.
     int effectIndex = startIndex;
-    for(CCEffect* effect in effects)
+    for(CCEffect* effect in stitchList)
     {
         // Construct the prefix to use for name mangling.
         NSString *effectPrefix = [NSString stringWithFormat:@"%@_%d_", effect.debugName, effectIndex];
@@ -291,34 +294,53 @@
     // and last effects in the stitch list. If the "stitch before" flag is set on the
     // first effect then set it in the resulting effect. If the "stitch after" flag is
     // set in the last effect then set it in the resulting effect.
-    CCEffect *firstEffect = [effects firstObject];
-    CCEffect *lastEffect = [effects lastObject];
+    CCEffect *firstEffect = [stitchList firstObject];
+    CCEffect *lastEffect = [stitchList lastObject];
     stitchedEffect.stitchFlags = (firstEffect.stitchFlags & CCEffectFunctionStitchBefore) | (lastEffect.stitchFlags & CCEffectFunctionStitchAfter);
     
-    // Create a new render pass object and set its shader from the stitched effect
-    // that was created above.
-    CCEffectRenderPass *newPass = [[CCEffectRenderPass alloc] init];
-    newPass.debugLabel = @"CCEffectStack_Stitched pass 0";
-    newPass.shader = stitchedEffect.shader;
-    
-    NSMutableArray *beginBlocks = [[NSMutableArray alloc] init];
-    NSMutableArray *endBlocks = [[NSMutableArray alloc] init];
-    
-    for (CCEffect *effect in effects)
+    if (stitchList.count == 1)
     {
-        // Copy the begin and end blocks from the input passes into the new pass.
-        for (CCEffectRenderPass *pass in effect.renderPasses)
+        // If there was only one effect in the stitch list copy its render
+        // passes into the output stitched effect. Update the copied passes
+        // so they point to the new shader in the stitched effect.
+
+        NSMutableArray *renderPasses = [[NSMutableArray alloc] init];
+        for (CCEffectRenderPass *pass in firstEffect.renderPasses)
         {
-            [beginBlocks addObjectsFromArray:pass.beginBlocks];
-            [endBlocks addObjectsFromArray:pass.endBlocks];
+            CCEffectRenderPass *newPass = [pass copy];
+            newPass.shader = stitchedEffect.shader;
+            [renderPasses addObject:newPass];
         }
+        stitchedEffect.renderPasses = renderPasses;
     }
-    
-    newPass.beginBlocks = beginBlocks;
-    newPass.endBlocks = endBlocks;
-    
-    stitchedEffect.renderPasses = @[newPass];
-    
+    else
+    {
+        // If there were multiple effects in the stitch list, create a new render
+        // pass object, set its shader to the shader from the stitched effect, and
+        // copy all blocks from the input passes.
+        CCEffectRenderPass *newPass = [[CCEffectRenderPass alloc] init];
+        newPass.debugLabel = @"CCEffectStack_Stitched pass 0";
+        newPass.shader = stitchedEffect.shader;
+
+        NSMutableArray *beginBlocks = [[NSMutableArray alloc] init];
+        NSMutableArray *endBlocks = [[NSMutableArray alloc] init];
+
+        for (CCEffect *effect in stitchList)
+        {
+            // Copy the begin and end blocks from the input passes into the new pass.
+            for (CCEffectRenderPass *pass in effect.renderPasses)
+            {
+                [beginBlocks addObjectsFromArray:pass.beginBlocks];
+                [endBlocks addObjectsFromArray:pass.endBlocks];
+            }
+        }
+
+        newPass.beginBlocks = beginBlocks;
+        newPass.endBlocks = endBlocks;
+
+        stitchedEffect.renderPasses = @[newPass];
+    }
+
     return stitchedEffect;
 }
 
@@ -328,7 +350,7 @@
     for(CCEffectVarying *varying in varyings)
     {
         NSString *prefixedName = [NSString stringWithFormat:@"%@%@", prefix, varying.name];
-        CCEffectVarying *prefixedVarying = [[CCEffectVarying alloc] initWithType:varying.type name:prefixedName];
+        CCEffectVarying *prefixedVarying = [[CCEffectVarying alloc] initWithType:varying.type name:prefixedName count:varying.count];
         [varyingReplacements setObject:prefixedVarying forKey:varying.name];
     }
     return [varyingReplacements copy];

--- a/cocos2d/CCEffectStack.m
+++ b/cocos2d/CCEffectStack.m
@@ -187,7 +187,7 @@
             for (NSArray *stitchList in stitchLists)
             {
                 NSAssert(stitchList.count > 0, @"Encountered an empty stitch list which shouldn't happen.");
-                [stitchedEffects addObject:[self stitchEffects:stitchList startIndex:effectIndex]];
+                [stitchedEffects addObject:[CCEffectStack stitchEffects:stitchList startIndex:effectIndex]];
                 effectIndex += stitchList.count;
             }
         }
@@ -222,7 +222,7 @@
 
 #pragma mark - Internal
 
--(CCEffect *)stitchEffects:(NSArray*)effects startIndex:(int)startIndex
++ (CCEffect *)stitchEffects:(NSArray*)effects startIndex:(int)startIndex
 {
     NSMutableArray* allFragFunctions = [[NSMutableArray alloc] init];
     NSMutableArray* allFragUniforms = [[NSMutableArray alloc] init];


### PR DESCRIPTION
- Fix a bug in varying name mangling. Varying arrays were losing their array-ness and becoming scalars after mangling. This broke bloom and blur in SpriteBuilder (and in other use cases too). This fixes [SpriteBuilder issue #843](https://github.com/spritebuilder/SpriteBuilder/issues/843).
- Fix a bug with stitching of bloom and blur. These effects cannot be stitched to others but their render passes were being altered as if they could be.
- Misc cleanup of the stitching code. Rename a few variables to make their meanings more obvious, change some methods that do not need to be instance methods to class methods instead.
- Add stacks of stacks to the effects test. We now stack glass and hue in one stack, saturation and pixellate in the other, and then we stack these two stacks together on the sprite.
- Add more sprites to the performance test. Some effects were already running at 60Hz with the lower number of sprites which meant that performance improvements could not be detected.
