### PR TITLE
CCEffectContrast - Fix for negative contrast values

### DIFF
--- a/cocos2d/CCEffectContrast.m
+++ b/cocos2d/CCEffectContrast.m
@@ -54,7 +54,8 @@ static float conditionContrast(float contrast);
     CCEffectFunctionInput *input = [[CCEffectFunctionInput alloc] initWithType:@"vec4" name:@"inputValue" initialSnippet:CCEffectDefaultInitialInputSnippet snippet:CCEffectDefaultInputSnippet];
 
     NSString* effectBody = CC_GLSL(
-                                   return vec4(((inputValue.rgb - vec3(0.5)) * vec3(u_contrast) + vec3(0.5)), inputValue.a);
+                                   vec3 offset = vec3(0.5) * inputValue.a;
+                                   return vec4(((inputValue.rgb - offset) * vec3(u_contrast) + offset), inputValue.a);
                                    );
     
     CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"contrastEffect" body:effectBody inputs:@[input] returnType:@"vec4"];


### PR DESCRIPTION
Multiply the constant offset value, 0.5, by the input alpha value to make sure it is
also in premultiplied alpha space as the RGB values are. Without this correction,
input RGB values of (0,0,0) can become non-(0,0,0) when the contrast adjustment
is less than 1.0.
