### PR TITLE
CCEffectLighting - Add automatic light collection

### DIFF
--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -261,6 +261,7 @@
     {
         CCLightNode *light = [[CCLightNode alloc] init];
         light.type = type;
+        light.groups = @[title];
         light.positionType = CCPositionTypeNormalized;
         light.position = ccp(0.5f, 0.5f);
         light.anchorPoint = ccp(0.5f, 0.5f);
@@ -271,7 +272,8 @@
         
         CCSprite *lightSprite = [CCSprite spriteWithImageNamed:@"Images/snow.png"];
         
-        CCEffectLighting *lightingEffect = [[CCEffectLighting alloc] initWithLights:@[light]];
+        CCEffectLighting *lightingEffect = [[CCEffectLighting alloc] init];
+        lightingEffect.groups = @[title];
         lightingEffect.shininess = 10.0f;
         
         CCSprite *sprite = [CCSprite spriteWithImageNamed:diffuseImage];
@@ -322,6 +324,7 @@
     CCLightNode* (^setupBlock)(CGPoint position, NSString *title, CCAction *action) = ^CCLightNode*(CGPoint position, NSString *title, CCAction *action)
     {
         CCLightNode *light = [[CCLightNode alloc] init];
+        light.groups = @[title];
         light.positionType = CCPositionTypeNormalized;
         light.position = ccp(1.0f, 1.0f);
         light.anchorPoint = ccp(0.5f, 0.5f);
@@ -333,7 +336,8 @@
         CCSprite *lightSprite = [CCSprite spriteWithImageNamed:@"Images/snow.png"];
         [light addChild:lightSprite];
         
-        CCEffectLighting *lightingEffect = [[CCEffectLighting alloc] initWithLights:@[light]];
+        CCEffectLighting *lightingEffect = [[CCEffectLighting alloc] init];
+        lightingEffect.groups = @[title];
         
         CCSprite *sprite = [CCSprite spriteWithImageNamed:diffuseImage];
         sprite.positionType = CCPositionTypeNormalized;

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -31,6 +31,8 @@
 
 #if CC_EFFECTS_EXPERIMENTAL
 
+#define TEMPORARILY_DISABLE_SDF_TESTS 1
+#if !TEMPORARILY_DISABLE_SDF_TESTS
 -(void)setupDFInnerGlowTest
 {
     self.subTitle = @"Distance Field Inner Glow Test";
@@ -249,6 +251,7 @@
 {
     _distanceFieldEffect.outline = !_distanceFieldEffect.outline;
 }
+#endif
 
 -(void)setupSimpleLightingTest
 {

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -574,7 +574,7 @@
     NSString *normalMapImage = @"Images/ShinyTorusNormals.png";
     NSString *diffuseImage = @"Images/ShinyTorusColor.png";
     
-    CCLightNode* (^setupBlock)(CGPoint position, float depth) = ^CCLightNode *(CGPoint position, float depth)
+    CCLightNode* (^setupBlock)(CGPoint position, float depth, float radius) = ^CCLightNode *(CGPoint position, float depth, float radius)
     {
         CCLightNode *light = [[CCLightNode alloc] init];
         light.type = CCLightPoint;
@@ -583,7 +583,7 @@
         light.anchorPoint = ccp(0.5f, 0.5f);
         light.intensity = 0.2f;
         light.ambientIntensity = 0.0f;
-        light.cutoffRadius = 0.0f;
+        light.cutoffRadius = radius;
         light.depth = depth;
         
         CCSprite *lightSprite = [CCSprite spriteWithImageNamed:@"Images/snow.png"];
@@ -593,25 +593,26 @@
         return light;
     };
     
+    static const float nearRadius = 0.0f;
+    static const float farRadius = 10.0f;
+    
     // Bottom row
-    [self.contentNode addChild:setupBlock(ccp(0.25f, 0.25f), 50.0f)];
-    [self.contentNode addChild:setupBlock(ccp(0.5f,  0.25f), 50.0f)];
-    [self.contentNode addChild:setupBlock(ccp(0.75f, 0.25f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.25f,  0.25f), 50.0f, nearRadius)];
+    [self.contentNode addChild:setupBlock(ccp(0.375f, 0.25f), 50.0f, farRadius)];
+    [self.contentNode addChild:setupBlock(ccp(0.5f,   0.25f), 50.0f, nearRadius)];
+    [self.contentNode addChild:setupBlock(ccp(0.625f, 0.25f), 50.0f, farRadius)];
+    [self.contentNode addChild:setupBlock(ccp(0.75f,  0.25f), 50.0f, nearRadius)];
     
     // Middle row
-    [self.contentNode addChild:setupBlock(ccp(0.25f, 0.5f), 50.0f)];
-    [self.contentNode addChild:setupBlock(ccp(0.75f, 0.5f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.25f, 0.5f), 50.0f, nearRadius)];
+    [self.contentNode addChild:setupBlock(ccp(0.75f, 0.5f), 50.0f, nearRadius)];
     
     // Top row
-    [self.contentNode addChild:setupBlock(ccp(0.25f, 0.75f), 50.0f)];
-    [self.contentNode addChild:setupBlock(ccp(0.5f,  0.75f), 50.0f)];
-    [self.contentNode addChild:setupBlock(ccp(0.75f, 0.75f), 50.0f)];
-    
-    // Outliers
-    [self.contentNode addChild:setupBlock(ccp(0.2f, 0.4f), 50.0f)];
-    [self.contentNode addChild:setupBlock(ccp(0.8f, 0.4f), 50.0f)];
-    [self.contentNode addChild:setupBlock(ccp(0.2f, 0.6f), 50.0f)];
-    [self.contentNode addChild:setupBlock(ccp(0.8f, 0.6f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.25f,  0.75f), 50.0f, nearRadius)];
+    [self.contentNode addChild:setupBlock(ccp(0.375f, 0.75f), 50.0f, farRadius)];
+    [self.contentNode addChild:setupBlock(ccp(0.5f,   0.75f), 50.0f, nearRadius)];
+    [self.contentNode addChild:setupBlock(ccp(0.625f, 0.75f), 50.0f, farRadius)];
+    [self.contentNode addChild:setupBlock(ccp(0.75f,  0.75f), 50.0f, nearRadius)];
     
     
     CCEffectLighting *lightingEffect = [[CCEffectLighting alloc] init];

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -553,6 +553,7 @@
                                                                                              nil
                                                                                              ]]);
     light.cutoffRadius = 1.0f;
+    light.halfRadius = 1.0f;
     light.ambientIntensity = 0.0f;
     light.intensity = 1.0f;
     light = setupBlock(ccp(0.9f, 0.65f), @"Depth", [CCActionRepeatForever actionWithAction:[CCActionSequence actions:

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -668,10 +668,6 @@
     
     CCNode* (^setupLightBlock)(CGPoint position, float radius, float speed, CCColor *specularColor) = ^CCNode *(CGPoint position, float radius, float speed, CCColor *specularColor)
     {
-        CCSprite *lightSprite = [CCSprite spriteWithImageNamed:@"Images/snow.png"];
-        lightSprite.scale = 0.2f;
-        lightSprite.color = specularColor;
-        
         CCLightNode *light = [[CCLightNode alloc] init];
         light.type = CCLightPoint;
         light.positionType = CCPositionTypePoints;
@@ -685,8 +681,6 @@
         light.specularColor = specularColor;
         light.cutoffRadius = 0.0f;
         light.depth = 50.0;
-        
-        [light addChild:lightSprite];
         
         CCNode *parent = [[CCNode alloc] init];
         parent.positionType = CCPositionTypeNormalized;
@@ -705,7 +699,7 @@
         [CCColor yellowColor]
     };
     
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 8; i++)
     {
         int c = arc4random_uniform(4);
         

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -567,6 +567,66 @@
     
 }
 
+-(void)setupLightingCollectionTest
+{
+    self.subTitle = @"Lighting Collection Test";
+    
+    NSString *normalMapImage = @"Images/ShinyTorusNormals.png";
+    NSString *diffuseImage = @"Images/ShinyTorusColor.png";
+    
+    CCLightNode* (^setupBlock)(CGPoint position, float depth) = ^CCLightNode *(CGPoint position, float depth)
+    {
+        CCLightNode *light = [[CCLightNode alloc] init];
+        light.type = CCLightPoint;
+        light.positionType = CCPositionTypeNormalized;
+        light.position = position;
+        light.anchorPoint = ccp(0.5f, 0.5f);
+        light.intensity = 0.2f;
+        light.ambientIntensity = 0.0f;
+        light.cutoffRadius = 0.0f;
+        light.depth = depth;
+        
+        CCSprite *lightSprite = [CCSprite spriteWithImageNamed:@"Images/snow.png"];
+        
+        [light addChild:lightSprite];
+        
+        return light;
+    };
+    
+    // Bottom row
+    [self.contentNode addChild:setupBlock(ccp(0.25f, 0.25f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.5f,  0.25f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.75f, 0.25f), 50.0f)];
+    
+    // Middle row
+    [self.contentNode addChild:setupBlock(ccp(0.25f, 0.5f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.75f, 0.5f), 50.0f)];
+    
+    // Top row
+    [self.contentNode addChild:setupBlock(ccp(0.25f, 0.75f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.5f,  0.75f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.75f, 0.75f), 50.0f)];
+    
+    // Outliers
+    [self.contentNode addChild:setupBlock(ccp(0.2f, 0.4f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.8f, 0.4f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.2f, 0.6f), 50.0f)];
+    [self.contentNode addChild:setupBlock(ccp(0.8f, 0.6f), 50.0f)];
+    
+    
+    CCEffectLighting *lightingEffect = [[CCEffectLighting alloc] init];
+    lightingEffect.shininess = 100.0f;
+    
+    CCSprite *sprite = [CCSprite spriteWithImageNamed:diffuseImage];
+    sprite.positionType = CCPositionTypeNormalized;
+    sprite.position = ccp(0.5f, 0.5f);
+    sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:normalMapImage];
+    sprite.effect = lightingEffect;
+    sprite.scale = 0.3f;
+    
+    [self.contentNode addChild:sprite];
+}
+
 #endif
 
 -(void)setupInvertTest

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -629,6 +629,98 @@
     [self.contentNode addChild:sprite];
 }
 
+-(void)setupLightingPerformanceTest
+{
+    self.subTitle = @"Lighting Performance Test";
+    
+    NSString *normalMapImage = @"Images/ShinyTorusNormals.png";
+    NSString *diffuseImage = @"Images/ShinyTorusColor.png";
+    
+    CCSprite* (^setupSpriteBlock)(CGPoint position) = ^CCSprite*(CGPoint position)
+    {
+        CCEffectLighting *lightingEffect = [[CCEffectLighting alloc] init];
+        lightingEffect.shininess = 100.0f;
+        
+        CCSprite *sprite = [CCSprite spriteWithImageNamed:diffuseImage];
+        sprite.positionType = CCPositionTypeNormalized;
+        sprite.position = position;
+        sprite.anchorPoint = ccp(0.0f, 0.0f);
+        sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:normalMapImage];
+        sprite.effect = lightingEffect;
+        sprite.scale = 0.1f;
+        
+        return sprite;
+    };
+    
+    int xCount = 20;
+    int yCount = 10;
+    for (int y = 0; y < yCount; y++)
+    {
+        for (int x = 0; x < xCount; x++)
+        {
+            CCSprite *sprite = setupSpriteBlock(ccp((float)x/(float)xCount, (float)y/(float)yCount));
+            [self.contentNode addChild:sprite];
+        }
+    }
+    
+    NSLog(@"setupPerformanceTest: Laid out %d sprites.", xCount * yCount);
+
+    
+    CCNode* (^setupLightBlock)(CGPoint position, float radius, float speed, CCColor *specularColor) = ^CCNode *(CGPoint position, float radius, float speed, CCColor *specularColor)
+    {
+        CCSprite *lightSprite = [CCSprite spriteWithImageNamed:@"Images/snow.png"];
+        lightSprite.scale = 0.2f;
+        lightSprite.color = specularColor;
+        
+        CCLightNode *light = [[CCLightNode alloc] init];
+        light.type = CCLightPoint;
+        light.positionType = CCPositionTypePoints;
+        light.position = ccp(radius, 0.0f);
+        light.anchorPoint = ccp(0.5f, 0.5f);
+        light.intensity = 0.2f;
+        light.color = [CCColor whiteColor];
+        light.ambientIntensity = 0.0f;
+        light.ambientColor = [CCColor whiteColor];
+        light.specularIntensity = 1.0f;
+        light.specularColor = specularColor;
+        light.cutoffRadius = 0.0f;
+        light.depth = 50.0;
+        
+        [light addChild:lightSprite];
+        
+        CCNode *parent = [[CCNode alloc] init];
+        parent.positionType = CCPositionTypeNormalized;
+        parent.position = position;
+        [parent addChild:light];
+        
+        [parent runAction:[CCActionRepeatForever actionWithAction:[CCActionRotateBy actionWithDuration:speed angle:90.0]]];
+        
+        return parent;
+    };
+    
+    CCColor *colors[] = {
+        [CCColor whiteColor],
+        [CCColor redColor],
+        [CCColor greenColor],
+        [CCColor yellowColor]
+    };
+    
+    for (int i = 0; i < 4; i++)
+    {
+        int c = arc4random_uniform(4);
+        
+        float x = arc4random_uniform(1000) / 1000.0f;
+        float y = arc4random_uniform(1000) / 1000.0f;
+        
+        float r = arc4random_uniform(1000) / 10.0f + 50.0f;
+        float d = 2.0f * r * M_PI;
+        float v = arc4random_uniform(1000) / 2.0f + 100.0f;
+        float t = d / v;
+        
+        [self.contentNode addChild:setupLightBlock(ccp(x,y), r, t, colors[c])];
+    }
+}
+
 #endif
 
 -(void)setupInvertTest

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -652,8 +652,8 @@
         return sprite;
     };
     
-    int xCount = 20;
-    int yCount = 10;
+    int xCount = 2;
+    int yCount = 2;
     for (int y = 0; y < yCount; y++)
     {
         for (int x = 0; x < xCount; x++)

--- a/cocos2d.xcodeproj/project.pbxproj
+++ b/cocos2d.xcodeproj/project.pbxproj
@@ -465,12 +465,28 @@
 		83E1A88719C8ACDC000A3BCA /* CCPackageCocos2dEnabler.m in Sources */ = {isa = PBXBuildFile; fileRef = 83E1A87F19C8ACDC000A3BCA /* CCPackageCocos2dEnabler.m */; };
 		83E1A88A19C8ACDC000A3BCA /* CCPackageInstaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 83E1A88219C8ACDC000A3BCA /* CCPackageInstaller.h */; };
 		83E1A88B19C8ACDC000A3BCA /* CCPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 83E1A88319C8ACDC000A3BCA /* CCPackageInstaller.m */; };
+		9D03A5EB1A02F61700C651C8 /* CCLightNode_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D1B4A941A02D51600B2DD9B /* CCLightNode_Private.h */; };
+		9D03A5EC1A02F61A00C651C8 /* CCLightNode_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D1B4A941A02D51600B2DD9B /* CCLightNode_Private.h */; };
+		9D03A5ED1A02F61B00C651C8 /* CCLightNode_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D1B4A941A02D51600B2DD9B /* CCLightNode_Private.h */; };
+		9D03A5F31A02F8C100C651C8 /* CCEffectLighting.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DDD047C19DE154400687820 /* CCEffectLighting.h */; };
+		9D03A5F61A02F8C200C651C8 /* CCEffectLighting.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DDD047C19DE154400687820 /* CCEffectLighting.h */; };
+		9D03A5F71A02F8C500C651C8 /* CCEffectLighting.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DDD047D19DE154400687820 /* CCEffectLighting.m */; };
+		9D03A5F81A02F8C600C651C8 /* CCEffectLighting.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DDD047D19DE154400687820 /* CCEffectLighting.m */; };
+		9D1B4A991A02E90300B2DD9B /* CCLightGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D1B4A971A02E90300B2DD9B /* CCLightGroups.h */; };
+		9D1B4A9A1A02E90300B2DD9B /* CCLightGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D1B4A971A02E90300B2DD9B /* CCLightGroups.h */; };
+		9D1B4A9B1A02E90300B2DD9B /* CCLightGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D1B4A971A02E90300B2DD9B /* CCLightGroups.h */; };
 		9D69E6D619DF604800C2749C /* CCLightNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D69E6D419DF604800C2749C /* CCLightNode.h */; };
 		9D69E6D719DF604800C2749C /* CCLightNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D69E6D519DF604800C2749C /* CCLightNode.m */; };
 		9D85671D191B018200573093 /* CCEffectBrightness.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D85671B191B018200573093 /* CCEffectBrightness.h */; };
 		9D85671E191B018200573093 /* CCEffectBrightness.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D85671C191B018200573093 /* CCEffectBrightness.m */; };
 		9D856721191B019900573093 /* CCEffectContrast.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D85671F191B019900573093 /* CCEffectContrast.h */; };
 		9D856722191B019900573093 /* CCEffectContrast.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D856720191B019900573093 /* CCEffectContrast.m */; };
+		9D9205D21A0173D600FF2D6D /* CCLightCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D9205D01A0173D600FF2D6D /* CCLightCollection.h */; };
+		9D9205D31A0173D600FF2D6D /* CCLightCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D9205D01A0173D600FF2D6D /* CCLightCollection.h */; };
+		9D9205D41A0173D600FF2D6D /* CCLightCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D9205D01A0173D600FF2D6D /* CCLightCollection.h */; };
+		9D9205D51A0173D600FF2D6D /* CCLightCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D9205D11A0173D600FF2D6D /* CCLightCollection.m */; };
+		9D9205D61A0173D600FF2D6D /* CCLightCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D9205D11A0173D600FF2D6D /* CCLightCollection.m */; };
+		9D9205D71A0173D600FF2D6D /* CCLightCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D9205D11A0173D600FF2D6D /* CCLightCollection.m */; };
 		9DBCA31419B68BE400EFE96D /* CCEffectColorChannelOffset.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DBCA31219B68BE400EFE96D /* CCEffectColorChannelOffset.h */; };
 		9DBCA31519B68BE400EFE96D /* CCEffectColorChannelOffset.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DBCA31319B68BE400EFE96D /* CCEffectColorChannelOffset.m */; };
 		9DDD047E19DE154400687820 /* CCEffectLighting.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DDD047C19DE154400687820 /* CCEffectLighting.h */; };
@@ -1261,6 +1277,8 @@
 		83E1A88319C8ACDC000A3BCA /* CCPackageInstaller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCPackageInstaller.m; sourceTree = "<group>"; };
 		83E1A88D19C8C19D000A3BCA /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		92FF6C7318F33A2A005B7139 /* CCActionManager_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CCActionManager_Private.h; sourceTree = "<group>"; };
+		9D1B4A941A02D51600B2DD9B /* CCLightNode_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CCLightNode_Private.h; sourceTree = "<group>"; };
+		9D1B4A971A02E90300B2DD9B /* CCLightGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCLightGroups.h; sourceTree = "<group>"; };
 		9D69E6D419DF604800C2749C /* CCLightNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCLightNode.h; sourceTree = "<group>"; };
 		9D69E6D519DF604800C2749C /* CCLightNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCLightNode.m; sourceTree = "<group>"; };
 		9D85671A191AE2CC00573093 /* CCEffectStack_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CCEffectStack_Private.h; sourceTree = "<group>"; };
@@ -1268,6 +1286,8 @@
 		9D85671C191B018200573093 /* CCEffectBrightness.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectBrightness.m; sourceTree = "<group>"; };
 		9D85671F191B019900573093 /* CCEffectContrast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectContrast.h; sourceTree = "<group>"; };
 		9D856720191B019900573093 /* CCEffectContrast.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectContrast.m; sourceTree = "<group>"; };
+		9D9205D01A0173D600FF2D6D /* CCLightCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCLightCollection.h; sourceTree = "<group>"; };
+		9D9205D11A0173D600FF2D6D /* CCLightCollection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCLightCollection.m; sourceTree = "<group>"; };
 		9DBCA31219B68BE400EFE96D /* CCEffectColorChannelOffset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectColorChannelOffset.h; sourceTree = "<group>"; };
 		9DBCA31319B68BE400EFE96D /* CCEffectColorChannelOffset.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCEffectColorChannelOffset.m; sourceTree = "<group>"; };
 		9DDD047C19DE154400687820 /* CCEffectLighting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCEffectLighting.h; sourceTree = "<group>"; };
@@ -1866,6 +1886,8 @@
 				D2B840C31909F447008063EA /* CCRenderTexture_Private.h */,
 				9D69E6D419DF604800C2749C /* CCLightNode.h */,
 				9D69E6D519DF604800C2749C /* CCLightNode.m */,
+				9D1B4A941A02D51600B2DD9B /* CCLightNode_Private.h */,
+				9D1B4A971A02E90300B2DD9B /* CCLightGroups.h */,
 			);
 			name = "Misc Nodes";
 			sourceTree = "<group>";
@@ -2244,6 +2266,8 @@
 				D309054F18AC23110081BF11 /* CCRenderer_Private.h */,
 				D38058191889AD6000822437 /* CCRenderer.m */,
 				D36DFA2719996EC500DEC135 /* CCRendererGLSupport.m */,
+				9D9205D01A0173D600FF2D6D /* CCLightCollection.h */,
+				9D9205D11A0173D600FF2D6D /* CCLightCollection.m */,
 			);
 			name = Rendering;
 			sourceTree = "<group>";
@@ -2359,6 +2383,7 @@
 				83E1A86619C8ACA0000A3BCA /* CCPackageManager.h in Headers */,
 				50C508C60F7C194400799124 /* CCFileUtils.h in Headers */,
 				D268FE231980791C00ECBCD0 /* CCEffectStack_Private.h in Headers */,
+				9D9205D21A0173D600FF2D6D /* CCLightCollection.h in Headers */,
 				503798C60F912C2000986724 /* CGPointExtension.h in Headers */,
 				50D413260F9A3FE00040C3C8 /* CCParticleSystem.h in Headers */,
 				502C6C6C0FB87970002BF3C2 /* CCParallaxNode.h in Headers */,
@@ -2371,8 +2396,10 @@
 				D272032518FC89A000B100FF /* CCEffect.h in Headers */,
 				D268FE191980791400ECBCD0 /* CCEffectRefraction.h in Headers */,
 				D2DDB09F19805E8400233D80 /* CCVector3.h in Headers */,
+				9D1B4A991A02E90300B2DD9B /* CCLightGroups.h in Headers */,
 				D3903B10199528A0003AA81A /* CCRenderDispatch.h in Headers */,
 				D272032418FC89A000B100FF /* CCEffect_Private.h in Headers */,
+				9D03A5EB1A02F61700C651C8 /* CCLightNode_Private.h in Headers */,
 				D272032D18FC89A000B100FF /* CCEffectStack.h in Headers */,
 				B7E260D818171D2000A0E872 /* CCTextField.h in Headers */,
 				D34CAD6C19C3AA10009BED7A /* CCRendererBasicTypes_Private.h in Headers */,
@@ -2509,6 +2536,7 @@
 				7A59465519E372EE00F65F90 /* CCEffectGlass.h in Headers */,
 				7A59465719E372EE00F65F90 /* CCEffectHue.h in Headers */,
 				7A59465919E372EE00F65F90 /* CCEffectReflection.h in Headers */,
+				9D9205D41A0173D600FF2D6D /* CCLightCollection.h in Headers */,
 				7A59465B19E372EE00F65F90 /* CCEffectRenderer.h in Headers */,
 				7A59465D19E372EE00F65F90 /* CCEffectSaturation.h in Headers */,
 				7A59465F19E372EE00F65F90 /* CCEffectStackProtocol.h in Headers */,
@@ -2516,6 +2544,7 @@
 				7A59466119E372EE00F65F90 /* CCEffect.h in Headers */,
 				7A59466319E372EE00F65F90 /* CCEffectStack.h in Headers */,
 				7A59466419E372EE00F65F90 /* CCEffectStack_Private.h in Headers */,
+				9D03A5ED1A02F61B00C651C8 /* CCLightNode_Private.h in Headers */,
 				7A59466619E372EE00F65F90 /* CCEffectBrightness.h in Headers */,
 				7A59466819E372EE00F65F90 /* CCEffectContrast.h in Headers */,
 				7A59466A19E372EE00F65F90 /* CCEffectPixellate.h in Headers */,
@@ -2580,6 +2609,7 @@
 				7A5946CB19E372F500F65F90 /* CCPackageManagerDelegate.h in Headers */,
 				7A5946CC19E372F500F65F90 /* CCPackageTypes.h in Headers */,
 				7A5946CD19E372F500F65F90 /* CCPackageDownload.h in Headers */,
+				9D03A5F61A02F8C200C651C8 /* CCEffectLighting.h in Headers */,
 				7A5946CF19E372F600F65F90 /* CCPackageDownloadDelegate.h in Headers */,
 				7A5946D019E372F600F65F90 /* CCPackageDownloadManager.h in Headers */,
 				7A5946D219E372F600F65F90 /* CCPackageDownloadManagerDelegate.h in Headers */,
@@ -2590,6 +2620,7 @@
 				7A5946DA19E372F700F65F90 /* CCPackageHelper.h in Headers */,
 				7A5946DC19E372F700F65F90 /* CCPackage_private.h in Headers */,
 				7A5946DD19E372F700F65F90 /* CCActionManager_Private.h in Headers */,
+				9D1B4A9B1A02E90300B2DD9B /* CCLightGroups.h in Headers */,
 				7A5946DE19E372F800F65F90 /* CCActionManager.h in Headers */,
 				7A5946E019E372F800F65F90 /* CCAction.h in Headers */,
 				7A5946E219E372F800F65F90 /* CCActionInstant.h in Headers */,
@@ -2716,6 +2747,7 @@
 				D241610A1958F72B003673BD /* CCEffectRenderer.h in Headers */,
 				D2FEB62F194F6C9E00FC0574 /* cocos2d.h in Headers */,
 				D2FEB630194F6C9E00FC0574 /* CCDirectorAndroid.h in Headers */,
+				9D1B4A9A1A02E90300B2DD9B /* CCLightGroups.h in Headers */,
 				D2FEB633194F6C9E00FC0574 /* TGAlib.h in Headers */,
 				D2FEB636194F6C9E00FC0574 /* CCActionEase.h in Headers */,
 				D2FEB637194F6C9E00FC0574 /* CCSprite_Private.h in Headers */,
@@ -2725,6 +2757,7 @@
 				D268FE241980791D00ECBCD0 /* CCEffectBloom.h in Headers */,
 				D2FEB63A194F6C9E00FC0574 /* CCSprite.h in Headers */,
 				D24161131958F738003673BD /* CCAnimationManager_Private.h in Headers */,
+				9D9205D31A0173D600FF2D6D /* CCLightCollection.h in Headers */,
 				D2FEB63B194F6C9E00FC0574 /* CCFileUtils.h in Headers */,
 				D2FEB63E194F6C9E00FC0574 /* CGPointExtension.h in Headers */,
 				D2FEB63F194F6C9E00FC0574 /* CCParticleSystem.h in Headers */,
@@ -2735,6 +2768,7 @@
 				D2FEB641194F6C9E00FC0574 /* CCTexture_Private.h in Headers */,
 				D2FEB644194F6C9E00FC0574 /* CCLayoutBox.h in Headers */,
 				D2FEB645194F6C9E00FC0574 /* CCTouchIOS.h in Headers */,
+				9D03A5EC1A02F61A00C651C8 /* CCLightNode_Private.h in Headers */,
 				D2FEB646194F6C9E00FC0574 /* CCEffect.h in Headers */,
 				D27451C719B111A9006DA0A1 /* CCEffectDFOutline.h in Headers */,
 				D24161141958F738003673BD /* CCAnimationManager.h in Headers */,
@@ -2813,6 +2847,7 @@
 				D2DDB09419805E8400233D80 /* CCMathUtilsAndroid.h in Headers */,
 				D2FEB694194F6C9E00FC0574 /* CCLayout.h in Headers */,
 				D299CE7B19C2910B00519CBB /* CCEffectDFInnerGlow.h in Headers */,
+				9D03A5F31A02F8C100C651C8 /* CCEffectLighting.h in Headers */,
 				D2FEB695194F6C9E00FC0574 /* NSThread+performBlock.h in Headers */,
 				D2FEB696194F6C9E00FC0574 /* CCTiledMapLayer_Private.h in Headers */,
 				D2FEB69A194F6C9E00FC0574 /* CCTransition.h in Headers */,
@@ -3209,6 +3244,7 @@
 				D23C5CB5194BC108007CA669 /* CCTouchIOS.m in Sources */,
 				A6A0734B17C78EF3004343C8 /* CCResponder.m in Sources */,
 				B78AE46317E7AF1C0028BE0B /* CCButton.m in Sources */,
+				9D9205D51A0173D600FF2D6D /* CCLightCollection.m in Sources */,
 				B78AE46517E7AF1C0028BE0B /* CCControl.m in Sources */,
 				B78AE46717E7AF1C0028BE0B /* CCControlTextureFactory.m in Sources */,
 				D38058211889CE7700822437 /* CCCache.m in Sources */,
@@ -3289,6 +3325,7 @@
 				7A59480019E375A300F65F90 /* CCPhysicsNode.m in Sources */,
 				7A59480319E375A300F65F90 /* CCEffectNode.m in Sources */,
 				7A59480519E375A300F65F90 /* CCNodeColor.m in Sources */,
+				9D9205D71A0173D600FF2D6D /* CCLightCollection.m in Sources */,
 				7A59480719E375A400F65F90 /* CCClippingNode.m in Sources */,
 				7A59480919E375A400F65F90 /* CCMotionStreak.m in Sources */,
 				7A59480B19E375A400F65F90 /* CCProgressNode.m in Sources */,
@@ -3361,6 +3398,7 @@
 				7A5948BB19E375BA00F65F90 /* CCBLocalizationManager.m in Sources */,
 				7A5948BD19E375BB00F65F90 /* CCBReader.m in Sources */,
 				7A5948BF19E375BB00F65F90 /* CCBsequence.m in Sources */,
+				9D03A5F81A02F8C600C651C8 /* CCEffectLighting.m in Sources */,
 				7A5948C119E375BB00F65F90 /* CCBSequenceProperty.m in Sources */,
 				7A5948C319E375BC00F65F90 /* CCBReader_Private.h in Sources */,
 				7A5948C719E375BC00F65F90 /* CCControl.m in Sources */,
@@ -3430,6 +3468,7 @@
 				D3903B17199528DF003AA81A /* CCRenderDispatch.m in Sources */,
 				D2FEB6E7194F6C9E00FC0574 /* ZipUtils.m in Sources */,
 				D2FEB6EA194F6C9E00FC0574 /* CCEffectStack.m in Sources */,
+				9D9205D61A0173D600FF2D6D /* CCLightCollection.m in Sources */,
 				D2FEB6EC194F6C9E00FC0574 /* CCRenderTexture.m in Sources */,
 				D28B2E7A19CBA89A00DC6E08 /* CCEffectColorChannelOffset.m in Sources */,
 				D2FEB6ED194F6C9E00FC0574 /* CCMotionStreak.m in Sources */,
@@ -3502,6 +3541,7 @@
 				5BC3CB5A19626FA000C4F0D0 /* CCGestureListener.m in Sources */,
 				BC9F4E8F19DB632B00B25F01 /* CCPackageManager.m in Sources */,
 				D2FEB735194F6C9E00FC0574 /* CCTouchIOS.m in Sources */,
+				9D03A5F71A02F8C500C651C8 /* CCEffectLighting.m in Sources */,
 				D2FEB736194F6C9E00FC0574 /* CCResponder.m in Sources */,
 				D2FEB737194F6C9E00FC0574 /* CCButton.m in Sources */,
 				D2FEB738194F6C9E00FC0574 /* CCControl.m in Sources */,

--- a/cocos2d/CCEffectLighting.h
+++ b/cocos2d/CCEffectLighting.h
@@ -7,7 +7,6 @@
 //
 
 #import "CCEffect.h"
-#import "CCLightNode.h"
 
 #if CC_EFFECTS_EXPERIMENTAL
 
@@ -20,6 +19,14 @@
 /// -----------------------------------------------------------------------
 /// @name Accessing Effect Attributes
 /// -----------------------------------------------------------------------
+
+
+/** The groups that this effect belongs to. Instances of CCLightNode also
+ *  belong to groups. The intersection of a light effect's groups and a light
+ *  node's groups determine whether or not a light node contributes to a light
+ *  effect.
+ */
+@property (nonatomic, copy) NSArray *groups;
 
 /**
  *  The specular color of the affected node. This color is combined with the light's
@@ -40,7 +47,7 @@
 /// -----------------------------------------------------------------------
 
 /**
- *  Initializes a CCEffectLighting object with no lights.
+ *  Initializes a CCEffectLighting object.
  *
  *  @return The CCEffectLighting object.
  */
@@ -49,11 +56,13 @@
 /**
  *  Initializes a CCEffectLighting object with the supplied parameters.
  *
- *  @param environment The array of lights that will light the affected node.
+ *  @param groups         The light groups this effect belongs to.
+ *  @param specularColor  The specular color of this effect.
+ *  @param shininess      The overall shininess of the effect.
  *
  *  @return The CCEffectLighting object.
  */
--(id)initWithLights:(NSArray *)lights;
+-(id)initWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess;
 
 
 /// -----------------------------------------------------------------------
@@ -61,38 +70,15 @@
 /// -----------------------------------------------------------------------
 
 /**
- *  Creates a CCEffectLighting object with the supplied parameters.
+ *  Creates and initializes a CCEffectLighting object with the supplied parameters.
  *
- *  @param environment The array of lights that will light the affected node.
+ *  @param groups         The light groups this effect belongs to.
+ *  @param specularColor  The specular color of this effect.
+ *  @param shininess      The overall shininess of the effect.
  *
  *  @return The CCEffectLighting object.
  */
-+(id)effectWithLights:(NSArray *)lights;
-
-
-/// -----------------------------------------------------------------------
-/// @name Adding and removing lights
-/// -----------------------------------------------------------------------
-
-/**
- *  Adds a light to the effect.
- *
- *  @param light CCLightNode to add.
- */
--(void) addLight:(CCLightNode *)light;
-
-/**
- *  Removes a light from the effect.
- *
- *  @param light The light node to remove.
- */
--(void) removeLight:(CCLightNode *)light;
-
-/**
- *  Removes all lights from the effect.
- */
--(void) removeAllLights;
-
++(id)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess;
 
 @end
 

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -379,7 +379,7 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
                 [fragUniforms addObject:[CCEffectUniform uniform:@"vec4" name:[NSString stringWithFormat:@"u_lightFalloff%lu", (unsigned long)lightIndex] value:[NSValue valueWithGLKVector4:GLKVector4Make(-1.0f, 1.0f, -1.0f, 1.0f)]]];
             }
             
-            [varyings addObject:[CCEffectVarying varying:@"vec3" name:[NSString stringWithFormat:@"v_worldSpaceLightDir%lu", (unsigned long)lightIndex]]];
+            [varyings addObject:[CCEffectVarying varying:@"highp vec3" name:[NSString stringWithFormat:@"v_worldSpaceLightDir%lu", (unsigned long)lightIndex]]];
         }
         
         if (self.needsSpecular)

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -12,7 +12,11 @@
 
 #import "CCDirector.h"
 #import "CCEffectUtils.h"
+#import "CCLightCollection.h"
+#import "CCLightGroups.h"
+#import "CCLightNode.h"
 #import "CCRenderer.h"
+#import "CCScene.h"
 #import "CCSpriteFrame.h"
 #import "CCTexture.h"
 
@@ -26,6 +30,8 @@ typedef struct _CCLightKey
 
 } CCLightKey;
 
+static const NSUInteger CCEffectLightingMaxLightCount = 8;
+
 static CCLightKey CCLightKeyMake(NSArray *lights);
 static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
 
@@ -33,7 +39,9 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
 
 @interface CCEffectLighting ()
 
-@property (nonatomic, strong) NSMutableArray *lights;
+@property (nonatomic, assign) CCLightGroupMask groupMask;
+@property (nonatomic, assign) BOOL groupMaskDirty;
+@property (nonatomic, copy) NSArray *closestLights;
 @property (nonatomic, assign) CCLightKey lightKey;
 @property (nonatomic, readonly) BOOL needsSpecular;
 @property (nonatomic, assign) BOOL shaderHasSpecular;
@@ -46,55 +54,34 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
 
 -(id)init
 {
-    return [self initWithLights:nil];
+    return [self initWithGroups:nil specularColor:[CCColor whiteColor] shininess:5.0f];
 }
 
--(id)initWithLights:(NSArray *)lights
+-(id)initWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess
 {
     if((self = [super init]))
     {
         self.debugName = @"CCEffectLighting";
         
-        if (lights)
-        {
-            _lights = [lights mutableCopy];
-        }
-        else
-        {
-            _lights = [[NSMutableArray alloc] init];
-        }
+        _groups = [groups copy];
+        _groupMask = CCLightCollectionAllGroups;
+        _groupMaskDirty = YES;
+        _closestLights = nil;
         
-        _specularColor = [CCColor whiteColor];
-        _shininess = 5.0f;
+        _specularColor = specularColor;
+        _shininess = shininess;
         
-        _lightKey = CCLightKeyMake(lights);
+        _lightKey = CCLightKeyMake(nil);
         _shaderHasSpecular = NO;
         _shaderHasNormalMap = NO;
     }
     return self;
 }
 
-+(id)effectWithLights:(NSArray *)lights
-{
-    return [[self alloc] initWithLights:lights];
-}
 
--(void)addLight:(CCLightNode *)light
++(id)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess
 {
-    NSAssert(_lights.count < 16, @"CCEffectLighting only supports 16 lights.");
-    NSAssert(![_lights containsObject:light], @"Adding a light to effect that is already here.");
-    [_lights addObject:light];
-}
-
--(void)removeLight:(CCLightNode *)light
-{
-    NSAssert([_lights containsObject:light], @"Removing a light from effect that is not here.");
-    [_lights removeObject:light];
-}
-
--(void)removeAllLights
-{
-    [_lights removeAllObjects];
+    return [[self alloc] initWithGroups:groups specularColor:specularColor shininess:shininess];
 }
 
 
@@ -246,9 +233,9 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_ndcToWorld"]] = [NSValue valueWithGLKMatrix4:ndcToWorld];
 
         GLKVector4 globalAmbientColor = GLKVector4Make(0.0f, 0.0f, 0.0f, 1.0f);
-        for (NSUInteger lightIndex = 0; lightIndex < weakSelf.lights.count; lightIndex++)
+        for (NSUInteger lightIndex = 0; lightIndex < weakSelf.closestLights.count; lightIndex++)
         {
-            CCLightNode *light = weakSelf.lights[lightIndex];
+            CCLightNode *light = weakSelf.closestLights[lightIndex];
             
             // Add this light's ambient contribution to the global ambient light color.
             globalAmbientColor = GLKVector4Add(globalAmbientColor, GLKVector4MultiplyScalar(light.ambientColor.glkVector4, light.ambientIntensity));
@@ -343,7 +330,19 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
 
     BOOL needsNormalMap = (sprite.normalMapSpriteFrame != nil);
     
-    CCLightKey newLightKey = CCLightKeyMake(_lights);
+    CGAffineTransform spriteTransform = sprite.nodeToWorldTransform;
+    CGPoint spritePosition = CGPointMake(spriteTransform.tx, spriteTransform.ty);
+    
+    CCLightCollection *lightCollection = sprite.scene.lights;
+    if (self.groupMaskDirty)
+    {
+        self.groupMask = [lightCollection maskForGroups:self.groups];
+        self.groupMaskDirty = NO;
+    }
+    
+    self.closestLights = [lightCollection findClosestKLights:CCEffectLightingMaxLightCount toPoint:spritePosition withMask:self.groupMask];
+    CCLightKey newLightKey = CCLightKeyMake(self.closestLights);
+    
     if (!self.shader ||
         !CCLightKeyCompare(newLightKey, _lightKey) ||
         (_shaderHasSpecular != self.needsSpecular) ||
@@ -363,9 +362,9 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
                                                                                ]];
         NSMutableArray *varyings = [[NSMutableArray alloc] init];
         
-        for (NSUInteger lightIndex = 0; lightIndex < _lights.count; lightIndex++)
+        for (NSUInteger lightIndex = 0; lightIndex < self.closestLights.count; lightIndex++)
         {
-            CCLightNode *light = _lights[lightIndex];
+            CCLightNode *light = self.closestLights[lightIndex];
             
             [vertUniforms addObject:[CCEffectUniform uniform:@"vec3" name:[NSString stringWithFormat:@"u_lightVector%lu", (unsigned long)lightIndex] value:[NSValue valueWithGLKVector3:GLKVector3Make(0.0f, 0.0f, 0.0f)]]];
             [fragUniforms addObject:[CCEffectUniform uniform:@"vec4" name:[NSString stringWithFormat:@"u_lightColor%lu", (unsigned long)lightIndex] value:[NSValue valueWithGLKVector4:GLKVector4Make(1.0f, 1.0f, 1.0f, 1.0f)]]];
@@ -388,8 +387,8 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
             [fragUniforms addObject:[CCEffectUniform uniform:@"vec4" name:@"u_specularColor" value:[NSValue valueWithGLKVector4:GLKVector4Make(1.0f, 1.0f, 1.0f, 1.0f)]]];
         }
         
-        NSMutableArray *fragFunctions = [CCEffectLighting buildFragmentFunctionsWithLights:_lights normalMap:needsNormalMap specular:self.needsSpecular];
-        NSMutableArray *vertFunctions = [CCEffectLighting buildVertexFunctionsWithLights:_lights];
+        NSMutableArray *fragFunctions = [CCEffectLighting buildFragmentFunctionsWithLights:self.closestLights normalMap:needsNormalMap specular:self.needsSpecular];
+        NSMutableArray *vertFunctions = [CCEffectLighting buildVertexFunctionsWithLights:self.closestLights];
         
         [self buildEffectWithFragmentFunction:fragFunctions vertexFunctions:vertFunctions fragmentUniforms:fragUniforms vertexUniforms:vertUniforms varyings:varyings firstInStack:YES];
 
@@ -401,6 +400,12 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
 - (BOOL)needsSpecular
 {
     return (!ccc4FEqual(_specularColor.ccColor4f, ccc4f(0.0f, 0.0f, 0.0f, 0.0f)) && (_shininess > 0.0f));
+}
+
+-(void)setGroups:(NSArray *)groups
+{
+    _groups = [groups copy];
+    _groupMaskDirty = YES;
 }
 
 @end

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -331,7 +331,7 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
     BOOL needsNormalMap = (sprite.normalMapSpriteFrame != nil);
     
     CGAffineTransform spriteTransform = sprite.nodeToWorldTransform;
-    CGPoint spritePosition = CGPointMake(spriteTransform.tx, spriteTransform.ty);
+    CGPoint spritePosition = CGPointApplyAffineTransform(sprite.anchorPointInPoints, sprite.nodeToWorldTransform);
     
     CCLightCollection *lightCollection = sprite.scene.lights;
     if (self.groupMaskDirty)

--- a/cocos2d/CCLightCollection.h
+++ b/cocos2d/CCLightCollection.h
@@ -1,0 +1,110 @@
+/*
+ * cocos2d swift: http://www.cocos2d-swift.org
+ *
+ * Copyright (c) 2014 Cocos2D Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "ccTypes.h"
+
+#import "CCLightGroups.h"
+
+
+#if CC_EFFECTS_EXPERIMENTAL
+
+extern const CCLightGroupMask CCLightCollectionAllGroups;
+
+@class CCLightNode;
+
+/**
+ * CCLightCollection is a container for light nodes within the scene.  It allows
+ * CCEffectLighting to find the most influential N lights given the relative positions
+ * of a node and the contained lights.
+ */
+
+@interface CCLightCollection : NSObject
+
+/// -----------------------------------------------------------------------
+/// @name Initializing a CCLightCollection object
+/// -----------------------------------------------------------------------
+
+/**
+ *  Initializes an empty CCLightCollection object.
+ *
+ *  @return The CCLightCollection object.
+ */
+- (id)init;
+
+
+/// -----------------------------------------------------------------------
+/// @name Adding and Removing Lights
+/// -----------------------------------------------------------------------
+
+/**
+ *  Adds a light to the collection.
+ *
+ *  @param light CCLightNode to add.
+ */
+- (void)addLight:(CCLightNode *)light;
+
+/**
+ *  Removes a light from the collection.
+ *
+ *  @param light The light node to remove.
+ */
+- (void)removeLight:(CCLightNode *)light;
+
+/**
+ *  Removes all lights from the collection.
+ */
+- (void)removeAllLights;
+
+
+
+/// -----------------------------------------------------------------------
+/// @name Querying for a Subset of Lights
+/// -----------------------------------------------------------------------
+
+/**
+ *  Finds the closest lights to the supplied point.
+ *
+ *  @param count The number of lights to return.
+ *  @param point The reference point.
+ */
+- (NSArray*)findClosestKLights:(NSUInteger)count toPoint:(CGPoint)point withMask:(CCLightGroupMask)mask;
+
+
+/// -----------------------------------------------------------------------
+/// @name Light groups
+/// -----------------------------------------------------------------------
+
+/**
+ *  Convert an array of light group identifiers into a group bitmask.
+ *  The categories are retained and assigned indexes.
+ *
+ *  @param categories Array of categories.
+ *
+ *  @return Bitmask.
+ */
+- (CCLightGroupMask)maskForGroups:(NSArray *)groups;
+
+@end
+
+#endif

--- a/cocos2d/CCLightCollection.m
+++ b/cocos2d/CCLightCollection.m
@@ -1,0 +1,135 @@
+/*
+ * cocos2d swift: http://www.cocos2d-swift.org
+ *
+ * Copyright (c) 2014 Cocos2D Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import "CCLightCollection.h"
+#import "CCLightGroups.h"
+#import "CCLightNode.h"
+
+#import "CCLightNode_Private.h"
+
+
+#if CC_EFFECTS_EXPERIMENTAL
+
+
+const CCLightGroupMask CCLightCollectionAllGroups = ~((CCLightGroupMask)0);
+static const NSUInteger CCLightCollectionMaxGroupCount = sizeof(NSUInteger) * 8;
+
+
+@interface CCLightCollection ()
+
+@property (nonatomic, strong) NSMutableArray *groupNames;
+@property (nonatomic, strong) NSMutableArray *lights;
+
+@end
+
+
+@implementation CCLightCollection
+
+- (id)init
+{
+    if ((self = [super init]))
+    {
+        _groupNames = [[NSMutableArray alloc] init];
+        _lights = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
+#pragma mark - Adding and removing lights
+
+- (void)addLight:(CCLightNode *)light
+{
+    [self.lights addObject:light];
+}
+
+- (void)removeLight:(CCLightNode *)light
+{
+    [self.lights removeObject:light];
+}
+
+- (void)removeAllLights
+{
+    [self.lights removeAllObjects];
+}
+
+
+#pragma mark - Queries
+
+- (NSArray*)findClosestKLights:(NSUInteger)count toPoint:(CGPoint)point withMask:(CCLightGroupMask)mask
+{
+    __block NSUInteger matchCount = 0;
+    NSPredicate *groupsMatch = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+        CCLightNode *light = (CCLightNode*)evaluatedObject;
+        
+        BOOL match = ((light.groupMask & mask) != 0);
+        if (match)
+        {
+            matchCount++;
+        }
+        
+        return match && (matchCount <= count);
+    }];
+    NSArray *results = [self.lights filteredArrayUsingPredicate:groupsMatch];
+    return results;
+}
+
+
+#pragma mark - Group management
+
+- (CCLightGroupMask)maskForGroups:(NSArray *)groups
+{
+    if (groups)
+    {
+        CCLightGroupMask bitmask = 0;
+        for(NSString *group in groups)
+        {
+            bitmask |= (1 << [self indexForGroupName:group]);
+        }
+        return bitmask;
+    }
+    else
+    {
+        // nil (the default value) is equivalent to all groups.
+        return CCLightCollectionAllGroups;
+    }
+}
+
+
+#pragma mark - Private helpers
+
+- (NSUInteger)indexForGroupName:(NSString *)groupName
+{
+    // Add the group name if it doesn't exist yet.
+    if(![_groupNames containsObject:groupName])
+    {
+        NSAssert(_groupNames.count < CCLightCollectionMaxGroupCount, @"A collection can only track up to %lu groups.", (unsigned long)CCLightCollectionMaxGroupCount);
+        [_groupNames addObject:groupName];
+    }
+    
+    return [_groupNames indexOfObject:groupName];
+}
+
+@end
+
+#endif

--- a/cocos2d/CCLightCollection.m
+++ b/cocos2d/CCLightCollection.m
@@ -180,14 +180,14 @@ static const NSUInteger CCLightCollectionMaxGroupCount = sizeof(NSUInteger) * 8;
 
 + (NSUInteger)partitionArray:(NSMutableArray *)array forPoint:(CGPoint)refPoint withLeftIndex:(NSUInteger)leftIndex rightIndex:(NSUInteger)rightIndex pivotIndex:(NSUInteger)pivotIndex
 {
-    float pivotValue = [CCLightCollection distanceFromLight:(CCLightNode *)array[pivotIndex] toPoint:refPoint];
+    float pivotValue = [CCLightCollection distanceSquaredFromLight:(CCLightNode *)array[pivotIndex] toPoint:refPoint];
     [array exchangeObjectAtIndex:pivotIndex withObjectAtIndex:rightIndex];
     
     NSUInteger storeIndex = leftIndex;
     for (NSUInteger i = leftIndex; i < rightIndex; i++)
     {
         CCLightNode *light = (CCLightNode*)array[i];
-        float currentValue = [CCLightCollection distanceFromLight:light toPoint:refPoint];
+        float currentValue = [CCLightCollection distanceSquaredFromLight:light toPoint:refPoint];
         if (currentValue < pivotValue)
         {
             [array exchangeObjectAtIndex:storeIndex withObjectAtIndex:i];
@@ -198,7 +198,7 @@ static const NSUInteger CCLightCollectionMaxGroupCount = sizeof(NSUInteger) * 8;
     return storeIndex;
 }
 
-+ (float)distanceFromLight:(CCLightNode*)light toPoint:(CGPoint)refPoint
++ (float)distanceSquaredFromLight:(CCLightNode*)light toPoint:(CGPoint)refPoint
 {
     CGPoint lightPosition = CGPointApplyAffineTransform(light.anchorPointInPoints, light.nodeToWorldTransform);
     CGPoint delta = CGPointMake(lightPosition.x - refPoint.x, lightPosition.y - refPoint.y);
@@ -212,8 +212,8 @@ static const NSUInteger CCLightCollectionMaxGroupCount = sizeof(NSUInteger) * 8;
     BOOL groupsIntersect = ((light.groupMask & groupMask) != 0);
     BOOL distanceMatters = (light.cutoffRadius > 0.0f);
 
-    float distance = [CCLightCollection distanceFromLight:light toPoint:point];
-    BOOL inRange = (distance < light.cutoffRadius);
+    float dSquared = [CCLightCollection distanceSquaredFromLight:light toPoint:point];
+    BOOL inRange = (dSquared < (light.cutoffRadius * light.cutoffRadius));
     
     return groupsIntersect && (!distanceMatters || inRange);
 }

--- a/cocos2d/CCLightGroups.h
+++ b/cocos2d/CCLightGroups.h
@@ -1,9 +1,7 @@
 /*
- * cocos2d for iPhone: http://www.cocos2d-iphone.org
+ * cocos2d swift: http://www.cocos2d-swift.org
  *
- * Copyright (c) 2008-2010 Ricardo Quesada
- * Copyright (c) 2011 Zynga Inc.
- * Copyright (c) 2013-2014 Cocos2D Authors
+ * Copyright (c) 2014 Cocos2D Authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,32 +20,11 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- *
  */
 
-#import "CCNode.h"
-
-@class CCLightCollection;
-
-/** CCScene is a subclass of CCNode and must be the parent of all your nodes. 
- 
- - In previous versions of Cocos2D, CCLayer was used to group nodes placed in a CCScene.
- - In V3, this is changed, so that a simple CCNode is used in stead.
- - Touch handling is now pr. node, so no touch setup is needed. Just set userInteractionEnabled.
- - To reduce the footprint of a scene, when not active, resources can be loaded in onEnter, and released in onExit.
- 
- */
-@interface CCScene : CCNode
 
 #if CC_EFFECTS_EXPERIMENTAL
-@property (nonatomic, readonly, strong) CCLightCollection *lights;
+
+typedef NSUInteger CCLightGroupMask;
+
 #endif
-
-/// -----------------------------------------------------------------------
-/// @name Initializing a CCScene Object
-/// -----------------------------------------------------------------------
-
-/** Initialize the node. */
-- (id)init;
-
-@end

--- a/cocos2d/CCLightNode.h
+++ b/cocos2d/CCLightNode.h
@@ -39,6 +39,13 @@ typedef NS_ENUM(NSUInteger, CCLightType)
  */
 @property (nonatomic, assign) CCLightType type;
 
+/** The groups that this light belongs to. Instances of CCEffectLighting also
+ *  belong to groups. The intersection of a light effect's groups and a light
+ *  node's groups determine whether or not a light node contributes to a light
+ *  effect.
+ */
+@property (nonatomic, copy) NSArray *groups;
+
 /** The primary color of the light. As described below, the color is modulated by the
  *  intensity value to determine the contribution of the light to the lighting
  *  effect. This color is used when computing the light's position and orientation
@@ -123,17 +130,19 @@ typedef NS_ENUM(NSUInteger, CCLightType)
  *  Initializes a CCLightNode object with the specified parameters.
  *
  *  @param type              The type of the light.
+ *  @param groups            The groups this light belongs to.
  *  @param color             The primary color of the light.
  *  @param intensity         The brightness of the light's primary color.
  *
  *  @return The CCLighttNode object.
  */
--(id)initWithType:(CCLightType)type color:(CCColor *)color intensity:(float)intensity;
+-(id)initWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity;
 
 /**
  *  Initializes a CCLightNode object with the specified parameters.
  *
  *  @param type              The type of the light.
+ *  @param groups            The groups this light belongs to.
  *  @param color             The primary color of the light.
  *  @param intensity         The brightness of the light's primary color.
  *  @param specularColor     The specular color of the light.
@@ -143,7 +152,7 @@ typedef NS_ENUM(NSUInteger, CCLightType)
  *
  *  @return The CCLighttNode object.
  */
--(id)initWithType:(CCLightType)type color:(CCColor *)color intensity:(float)intensity specularColor:(CCColor *)specularColor specularIntensity:(float)specularIntensity ambientColor:(CCColor *)ambientColor ambientIntensity:(float)ambientIntensity;
+-(id)initWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity specularColor:(CCColor *)specularColor specularIntensity:(float)specularIntensity ambientColor:(CCColor *)ambientColor ambientIntensity:(float)ambientIntensity;
 
 
 /// -----------------------------------------------------------------------
@@ -154,17 +163,19 @@ typedef NS_ENUM(NSUInteger, CCLightType)
  *  Creates a CCLightNode object with the specified parameters.
  *
  *  @param type              The type of the light.
+ *  @param groups            The groups this light belongs to.
  *  @param color             The primary color of the light.
  *  @param intensity         The brightness of the light's primary color.
  *
  *  @return An initialized CCLightNode object.
  */
-+(id)lightWithType:(CCLightType)type color:(CCColor *)color intensity:(float)intensity;
++(id)lightWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity;
 
 /**
  *  Creates a CCLightNode object with the specified parameters.
  *
  *  @param type              The type of the light.
+ *  @param groups            The groups this light belongs to.
  *  @param color             The primary color of the light.
  *  @param intensity         The brightness of the light's primary color.
  *  @param specularColor     The specular color of the light.
@@ -174,7 +185,7 @@ typedef NS_ENUM(NSUInteger, CCLightType)
  *
  *  @return An initialized CCLightNode object.
  */
-+(id)lightWithType:(CCLightType)type color:(CCColor *)color intensity:(float)intensity specularColor:(CCColor *)specularColor specularIntensity:(float)specularIntensity ambientColor:(CCColor *)ambientColor ambientIntensity:(float)ambientIntensity;
++(id)lightWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity specularColor:(CCColor *)specularColor specularIntensity:(float)specularIntensity ambientColor:(CCColor *)ambientColor ambientIntensity:(float)ambientIntensity;
 
 
 @end

--- a/cocos2d/CCLightNode_Private.h
+++ b/cocos2d/CCLightNode_Private.h
@@ -1,8 +1,6 @@
 /*
  * cocos2d for iPhone: http://www.cocos2d-iphone.org
  *
- * Copyright (c) 2008-2010 Ricardo Quesada
- * Copyright (c) 2011 Zynga Inc.
  * Copyright (c) 2013-2014 Cocos2D Authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,32 +20,18 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- *
  */
 
-#import "CCNode.h"
+#import "CCLightNode.h"
+#import "CCLightGroups.h"
 
-@class CCLightCollection;
-
-/** CCScene is a subclass of CCNode and must be the parent of all your nodes. 
- 
- - In previous versions of Cocos2D, CCLayer was used to group nodes placed in a CCScene.
- - In V3, this is changed, so that a simple CCNode is used in stead.
- - Touch handling is now pr. node, so no touch setup is needed. Just set userInteractionEnabled.
- - To reduce the footprint of a scene, when not active, resources can be loaded in onEnter, and released in onExit.
- 
- */
-@interface CCScene : CCNode
 
 #if CC_EFFECTS_EXPERIMENTAL
-@property (nonatomic, readonly, strong) CCLightCollection *lights;
-#endif
 
-/// -----------------------------------------------------------------------
-/// @name Initializing a CCScene Object
-/// -----------------------------------------------------------------------
+@interface CCLightNode ()
 
-/** Initialize the node. */
-- (id)init;
+@property (nonatomic, assign) CCLightGroupMask groupMask;
 
 @end
+
+#endif

--- a/cocos2d/CCScene.m
+++ b/cocos2d/CCScene.m
@@ -31,6 +31,7 @@
 #import "Support/CGPointExtension.h"
 #import "CCDirector.h"
 #import "CCDirector_Private.h"
+#import "CCLightCollection.h"
 
 // -----------------------------------------------------------------
 
@@ -50,6 +51,10 @@
 		[self setContentSize:s];
 		
 		self.colorRGBA = [CCColor blackColor];
+        
+#if CC_EFFECTS_EXPERIMENTAL
+        _lights = [[CCLightCollection alloc] init];
+#endif
 	}
 	
 	return( self );


### PR DESCRIPTION
Automatically determine which lights effect which nodes Instead of forcing the user to manually manage this.
- Light effects and light nodes can be arranged into groups via arrays of strings that are converted into bit masks.
- If there is an intersection between the groups of a light effect and a light node then the light node influences the effect.
- The scene owns a light collection which tracks all lights. Light nodes add themselves to the collection upon entry to the scene and remove themselves on exit.
- When a node is rendered with a lighting effect, the light collection is queried to determine the nearest lights.
