### PR TITLE
Bugfixes for packages

### DIFF
--- a/cocos2d.xcodeproj/project.pbxproj
+++ b/cocos2d.xcodeproj/project.pbxproj
@@ -461,6 +461,7 @@
 		83E1A88719C8ACDC000A3BCA /* CCPackageCocos2dEnabler.m in Sources */ = {isa = PBXBuildFile; fileRef = 83E1A87F19C8ACDC000A3BCA /* CCPackageCocos2dEnabler.m */; };
 		83E1A88A19C8ACDC000A3BCA /* CCPackageInstaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 83E1A88219C8ACDC000A3BCA /* CCPackageInstaller.h */; };
 		83E1A88B19C8ACDC000A3BCA /* CCPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 83E1A88319C8ACDC000A3BCA /* CCPackageInstaller.m */; };
+		83E21C001A121EB5000D1695 /* CCPackageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 83E1A85F19C8ACA0000A3BCA /* CCPackageManager.m */; };
 		9D03A5EB1A02F61700C651C8 /* CCLightNode_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D1B4A941A02D51600B2DD9B /* CCLightNode_Private.h */; };
 		9D03A5EC1A02F61A00C651C8 /* CCLightNode_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D1B4A941A02D51600B2DD9B /* CCLightNode_Private.h */; };
 		9D03A5ED1A02F61B00C651C8 /* CCLightNode_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D1B4A941A02D51600B2DD9B /* CCLightNode_Private.h */; };
@@ -3272,6 +3273,7 @@
 				7A59479319E3759800F65F90 /* CCEffectDFOutline.m in Sources */,
 				839CE58B19FFB146003369F0 /* CCEffectInvert.m in Sources */,
 				7A59479519E3759800F65F90 /* CCEffectDFInnerGlow.m in Sources */,
+				83E21C001A121EB5000D1695 /* CCPackageManager.m in Sources */,
 				7A59479719E3759800F65F90 /* CCEffectColorChannelOffset.m in Sources */,
 				7A59479919E3759900F65F90 /* CCEffectBlur.m in Sources */,
 				7A59479B19E3759900F65F90 /* CCEffectRefraction.m in Sources */,

--- a/cocos2d/CCPackageManager.m
+++ b/cocos2d/CCPackageManager.m
@@ -45,8 +45,14 @@
         self.packages = [NSMutableArray array];
         self.unzipTasks = [NSMutableArray array];
 
+        #if __CC_PLATFORM_MAC
+        NSString *applicationSupportPath = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) lastObject];
+        NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+        self.installedPackagesPath = [[applicationSupportPath stringByAppendingPathComponent:bundleIdentifier] stringByAppendingPathComponent:@"Packages"];
+        #else
         NSString *cachesPath = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
         self.installedPackagesPath = [cachesPath stringByAppendingPathComponent:@"Packages"];
+        #endif
 
         self.downloadManager = [[CCPackageDownloadManager alloc] init];
         _downloadManager.delegate = self;

--- a/cocos2d/CCPackageManager.m
+++ b/cocos2d/CCPackageManager.m
@@ -402,7 +402,7 @@
     if ([fileManager fileExistsAtPath:package.unzipURL.path])
     {
         NSError *error;
-        CCLOGINFO(@"[PACKAGE/UNZIP][INFO] Removing incomplete unzipped archive: %@", installData.unzipURL.path);
+        CCLOGINFO(@"[PACKAGE/UNZIP][INFO] Removing incomplete unzipped archive: %@", package.unzipURL.path);
         if ([fileManager removeItemAtURL:package.unzipURL error:&error])
         {
             CCLOG(@"[PACKAGE/UNZIP][ERROR] Removing incomplete unzipped archive: %@", error);
@@ -438,7 +438,7 @@
 
 - (void)removeUnzippedPackage:(CCPackage *)package
 {
-    NSAssert(package.unzipURL, @"installData.unzipURL must not be nil");
+    NSAssert(package.unzipURL, @"package.unzipURL must not be nil");
 
     NSError *error;
     if (![[NSFileManager defaultManager] removeItemAtURL:package.unzipURL error:&error])
@@ -475,7 +475,7 @@
         [packageCocos2dEnabler enablePackages:@[package]];
     }
 
-    CCLOGINFO(@"[PACKAGE/INSTALL][INFO] Installation of package successful! Package enabled: %d", [package installData].enableOnDownload);
+    CCLOGINFO(@"[PACKAGE/INSTALL][INFO] Installation of package successful! Package enabled: %d", package.enableOnDownload);
 
     [_delegate packageInstallationFinished:package];
     return YES;
@@ -483,7 +483,7 @@
 
 - (BOOL)determinePackageFolderNameInUnzippedFile:(CCPackage *)package error:(NSError **)error
 {
-    NSAssert(package.unzipURL, @"installData.unzipURL must not be nil");
+    NSAssert(package.unzipURL, @"package.unzipURL must not be nil");
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSArray *files = [fileManager contentsOfDirectoryAtURL:package.unzipURL
@@ -527,7 +527,7 @@
 
 - (void)setPackageEmptyError:(NSError **)error package:(CCPackage *)package
 {
-    NSAssert(package.unzipURL, @"installData.unzipURL must not be nil");
+    NSAssert(package.unzipURL, @"package.unzipURL must not be nil");
 
     if (error)
     {
@@ -541,7 +541,7 @@
 
 - (BOOL)askDelegateForCustomFolderName:(CCPackage *)package files:(NSArray *)files
 {
-    NSAssert(package.unzipURL, @"installData.unzipURL must not be nil");
+    NSAssert(package.unzipURL, @"package.unzipURL must not be nil");
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if ([_delegate respondsToSelector:@selector(customFolderName:packageContents:)])

--- a/cocos2d/Platforms/Android/CCActivity.m
+++ b/cocos2d/Platforms/Android/CCActivity.m
@@ -177,6 +177,7 @@ static void handler(NSException *e)
 - (void)handlePause
 {
     [[CCDirector sharedDirector] pause];
+    [[CCPackageManager sharedManager] savePackages];
 }
 
 
@@ -200,6 +201,7 @@ static void handler(NSException *e)
 - (void)handleLowMemory
 {
     [[CCDirector sharedDirector] purgeCachedData];
+    [[CCPackageManager sharedManager] savePackages];
 }
 
 - (void)reshape:(NSValue *)value
@@ -262,7 +264,8 @@ static void handler(NSException *e)
             director.designSize = fixed;
             [director setProjection:CCDirectorProjectionCustom];
         }
-        
+
+        [[CCPackageManager sharedManager] loadPackages];
 
         [director runWithScene:[self startScene]];
         [director setAnimationInterval:1.0/60.0];

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -259,13 +259,13 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	
 	// set the Navigation Controller as the root view controller
 	[window_ setRootViewController:navController_];
-	
+
+	[[CCPackageManager sharedManager] loadPackages];
+
 	// make main window visible
 	[window_ makeKeyAndVisible];
     
     [self forceOrientation];
-
-	[[CCPackageManager sharedManager] loadPackages];
 }
 
 // iOS8 hack around orientation bug
@@ -309,6 +309,7 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	if([CCDirector sharedDirector].animating) {
 		[[CCDirector sharedDirector] stopAnimation];
 	}
+	[[CCPackageManager sharedManager] savePackages];
 }
 
 -(void) applicationWillEnterForeground:(UIApplication*)application
@@ -316,7 +317,6 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	if([CCDirector sharedDirector].animating == NO) {
 		[[CCDirector sharedDirector] startAnimation];
 	}
-	[[CCPackageManager sharedManager] savePackages];
 }
 
 // application will be killed


### PR DESCRIPTION
- Loading packages did not take effect before startScene was called on iOS.
- Saving packages on iOS was triggerd in the wrong place. Packages now saved when app enter background.
- Packages default insallation folder now working for mac targets.
