### PR TITLE
CCEffectLighting - Light collection bug fixes

### DIFF
--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -7,6 +7,7 @@
 
 #import "CCEffect_Private.h"
 #import "CCEffectStack_Private.h"
+#import "CCLightCollection.h"
 
 @interface CCEffectsTest : TestBase @end
 @implementation CCEffectsTest {
@@ -257,6 +258,8 @@
 {
     self.subTitle = @"Simple Lighting Test";
     
+    [self.contentNode.scene.lights flushGroupNames];
+    
     NSString *normalMapImage = @"Images/ShinyTorusNormals.png";
     NSString *diffuseImage = @"Images/ShinyTorusColor.png";
     
@@ -321,6 +324,8 @@
 {
     self.subTitle = @"Varying Light Parameter Test";
     
+    [self.contentNode.scene.lights flushGroupNames];
+
     NSString *normalMapImage = @"Images/ShinyTorusNormals.png";
     NSString *diffuseImage = @"Images/ShinyTorusColor.png";
     
@@ -575,6 +580,8 @@
 {
     self.subTitle = @"Lighting Collection Test";
     
+    [self.contentNode.scene.lights flushGroupNames];
+    
     NSString *normalMapImage = @"Images/ShinyTorusNormals.png";
     NSString *diffuseImage = @"Images/ShinyTorusColor.png";
     
@@ -635,6 +642,8 @@
 -(void)setupLightingPerformanceTest
 {
     self.subTitle = @"Lighting Performance Test";
+    
+    [self.contentNode.scene.lights flushGroupNames];
     
     NSString *normalMapImage = @"Images/ShinyTorusNormals.png";
     NSString *diffuseImage = @"Images/ShinyTorusColor.png";

--- a/cocos2d.xcodeproj/project.pbxproj
+++ b/cocos2d.xcodeproj/project.pbxproj
@@ -489,6 +489,10 @@
 		9D9205D71A0173D600FF2D6D /* CCLightCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D9205D11A0173D600FF2D6D /* CCLightCollection.m */; };
 		9DBCA31419B68BE400EFE96D /* CCEffectColorChannelOffset.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DBCA31219B68BE400EFE96D /* CCEffectColorChannelOffset.h */; };
 		9DBCA31519B68BE400EFE96D /* CCEffectColorChannelOffset.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DBCA31319B68BE400EFE96D /* CCEffectColorChannelOffset.m */; };
+		9DC780B71A1175F000DD5A4B /* CCLightNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D69E6D419DF604800C2749C /* CCLightNode.h */; };
+		9DC780BA1A1175F100DD5A4B /* CCLightNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D69E6D419DF604800C2749C /* CCLightNode.h */; };
+		9DC780BB1A11760A00DD5A4B /* CCLightNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D69E6D519DF604800C2749C /* CCLightNode.m */; };
+		9DC780BC1A11760B00DD5A4B /* CCLightNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D69E6D519DF604800C2749C /* CCLightNode.m */; };
 		9DDD047E19DE154400687820 /* CCEffectLighting.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DDD047C19DE154400687820 /* CCEffectLighting.h */; };
 		9DDD047F19DE154400687820 /* CCEffectLighting.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DDD047D19DE154400687820 /* CCEffectLighting.m */; };
 		9DF37621191C594A00C6D27A /* CCEffectPixellate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF3761F191C594A00C6D27A /* CCEffectPixellate.h */; };
@@ -2692,6 +2696,7 @@
 				7A59476019E3731400F65F90 /* CCPlatformTextField.h in Headers */,
 				7A59476219E3731400F65F90 /* CCPlatformTextFieldIOS.h in Headers */,
 				7A59476419E3731500F65F90 /* CCPlatformTextFieldMac.h in Headers */,
+				9DC780BA1A1175F100DD5A4B /* CCLightNode.h in Headers */,
 				7A59476619E3731600F65F90 /* CCAnimationManager_Private.h in Headers */,
 				7A59476719E3731600F65F90 /* CCAnimationManager.h in Headers */,
 				7A59476919E3731700F65F90 /* CCAnimationManager+FrameAnimation.h in Headers */,
@@ -2844,6 +2849,7 @@
 				D2FEB691194F6C9E00FC0574 /* CCGLView.h in Headers */,
 				D2FEB692194F6C9E00FC0574 /* CCWindow.h in Headers */,
 				D2FEB693194F6C9E00FC0574 /* CCProgressNode.h in Headers */,
+				9DC780B71A1175F000DD5A4B /* CCLightNode.h in Headers */,
 				D2DDB09419805E8400233D80 /* CCMathUtilsAndroid.h in Headers */,
 				D2FEB694194F6C9E00FC0574 /* CCLayout.h in Headers */,
 				D299CE7B19C2910B00519CBB /* CCEffectDFInnerGlow.h in Headers */,
@@ -3347,6 +3353,7 @@
 				7A59483619E375A900F65F90 /* CCActionProgressTimer.m in Sources */,
 				7A59483819E375A900F65F90 /* CCActionTween.m in Sources */,
 				7A59483A19E375A900F65F90 /* CCTexturePVR.m in Sources */,
+				9DC780BC1A11760B00DD5A4B /* CCLightNode.m in Sources */,
 				7A59483C19E375A900F65F90 /* CCTexture.m in Sources */,
 				7A59483F19E375AA00F65F90 /* CCTextureCache.m in Sources */,
 				7A59484219E375AA00F65F90 /* TGAlib.m in Sources */,
@@ -3490,6 +3497,7 @@
 				D2FEB6F9194F6C9E00FC0574 /* CCSpriteBatchNode.m in Sources */,
 				D2FEB6FA194F6C9E00FC0574 /* ccUtils.c in Sources */,
 				D2FEB6FB194F6C9E00FC0574 /* CCTouchAndroid.m in Sources */,
+				9DC780BB1A11760A00DD5A4B /* CCLightNode.m in Sources */,
 				BC9F4E9119DB633500B25F01 /* CCPackageDownload.m in Sources */,
 				D3903B16199528DB003AA81A /* CCNoARC.m in Sources */,
 				D268FE1C1980791400ECBCD0 /* CCEffectRefraction.m in Sources */,

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -232,14 +232,10 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
         // to node local coordinates.
         pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_ndcToWorld"]] = [NSValue valueWithGLKMatrix4:ndcToWorld];
 
-        GLKVector4 globalAmbientColor = GLKVector4Make(0.0f, 0.0f, 0.0f, 1.0f);
         for (NSUInteger lightIndex = 0; lightIndex < weakSelf.closestLights.count; lightIndex++)
         {
             CCLightNode *light = weakSelf.closestLights[lightIndex];
             
-            // Add this light's ambient contribution to the global ambient light color.
-            globalAmbientColor = GLKVector4Add(globalAmbientColor, GLKVector4MultiplyScalar(light.ambientColor.glkVector4, light.ambientIntensity));
-
             // Get the transform from the light's coordinate space to the effect's coordinate space.
             GLKMatrix4 lightNodeToWorld = CCEffectUtilsMat4FromAffineTransform(light.nodeToWorldTransform);
             
@@ -311,7 +307,8 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
             }
         }
 
-        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_globalAmbientColor"]] = [NSValue valueWithGLKVector4:globalAmbientColor];
+        CCColor *ambientColor = [pass.node.scene.lights findAmbientSumForLightsWithMask:self.groupMask];
+        pass.shaderUniforms[weakSelf.uniformTranslationTable[@"u_globalAmbientColor"]] = [NSValue valueWithGLKVector4:ambientColor.glkVector4];
         
         if (self.needsSpecular)
         {

--- a/cocos2d/CCLightCollection.h
+++ b/cocos2d/CCLightCollection.h
@@ -23,7 +23,7 @@
  */
 
 #import "ccTypes.h"
-
+#import "CCColor.h"
 #import "CCLightGroups.h"
 
 
@@ -85,10 +85,19 @@ extern const CCLightGroupMask CCLightCollectionAllGroups;
 /**
  *  Finds the closest lights to the supplied point.
  *
- *  @param count The number of lights to return.
- *  @param point The reference point.
+ *  @param count   The number of lights to return.
+ *  @param point   The query point.
+ *  @param mask    The light group mask to match.
  */
 - (NSArray*)findClosestKLights:(NSUInteger)count toPoint:(CGPoint)point withMask:(CCLightGroupMask)mask;
+
+/**
+ *  Return the sum of ambient colors for all lights matching the
+ *  supplied mask.
+ *
+ *  @param mask    The light group mask to match.
+ */
+- (CCColor*)findAmbientSumForLightsWithMask:(CCLightGroupMask)mask;
 
 
 /// -----------------------------------------------------------------------
@@ -104,6 +113,12 @@ extern const CCLightGroupMask CCLightCollectionAllGroups;
  *  @return Bitmask.
  */
 - (CCLightGroupMask)maskForGroups:(NSArray *)groups;
+
+/**
+ *  Reset the group name to group mask mapping. This invalidates any outstanding
+ *  group masks.
+ */
+- (void)flushGroupNames;
 
 @end
 

--- a/cocos2d/CCLightCollection.m
+++ b/cocos2d/CCLightCollection.m
@@ -98,6 +98,19 @@ static const NSUInteger CCLightCollectionMaxGroupCount = sizeof(NSUInteger) * 8;
     }
 }
 
+- (CCColor*)findAmbientSumForLightsWithMask:(CCLightGroupMask)mask
+{
+    GLKVector4 sum = GLKVector4Make(0.0f, 0.0f, 0.0f, 0.0f);
+    for (CCLightNode* light in self.lights)
+    {
+        if (light.groupMask & mask)
+        {
+            sum = GLKVector4Add(sum, GLKVector4MultiplyScalar(light.ambientColor.glkVector4, light.ambientIntensity));
+        }
+    }
+    return [CCColor colorWithGLKVector4:sum];
+}
+
 
 #pragma mark - Group management
 
@@ -119,6 +132,10 @@ static const NSUInteger CCLightCollectionMaxGroupCount = sizeof(NSUInteger) * 8;
     }
 }
 
+- (void)flushGroupNames
+{
+    [self.groupNames removeAllObjects];
+}
 
 #pragma mark - Private helpers
 
@@ -210,12 +227,7 @@ static const NSUInteger CCLightCollectionMaxGroupCount = sizeof(NSUInteger) * 8;
 + (BOOL)light:(CCLightNode *)light hasEffectOnGroups:(CCLightGroupMask)groupMask atPoint:(CGPoint)point
 {
     BOOL groupsIntersect = ((light.groupMask & groupMask) != 0);
-    BOOL distanceMatters = (light.cutoffRadius > 0.0f);
-
-    float dSquared = [CCLightCollection distanceSquaredFromLight:light toPoint:point];
-    BOOL inRange = (dSquared < (light.cutoffRadius * light.cutoffRadius));
-    
-    return groupsIntersect && (!distanceMatters || inRange);
+    return groupsIntersect;
 }
 
 @end


### PR DESCRIPTION
- Don't filter the light list based on distance. I tried this optimization but its causing some problems so I'm removing it for now. 
- Provide an interface for clearing the light collection's group name list. This is mostly just used for the tests since I want to be able to reset the group names / masks with each test.
- Add a method to CCLightCollection that returns the ambient color sum of all lights matching a supplied group mask. This is necessary since we want lights to contribute their ambient color even if they are not in the set of closest K lights that is used by the shader.
- Fix the Mac and Android builds by adding CCLightNode to these targets.
