### PR TITLE
Replace CGAffineTransform with GLKMatrix4x4

### DIFF
--- a/UnitTests/CCNodeTests.m
+++ b/UnitTests/CCNodeTests.m
@@ -485,13 +485,13 @@
 	
 	[scene addChild:first z:0];
 	
-	CGAffineTransform nodeToWorld = [first nodeToWorldTransform];
-	XCTAssertEqualWithAccuracy(nodeToWorld.a, 2.0, 0.001, @""); // Node Scale *does* change the transform scale.
-	XCTAssertEqualWithAccuracy(nodeToWorld.b, 0.0, 0.001, @"");
-	XCTAssertEqualWithAccuracy(nodeToWorld.c, 0.0, 0.001, @"");
-	XCTAssertEqualWithAccuracy(nodeToWorld.d, 2.0, 0.001, @"");
-	XCTAssertEqualWithAccuracy(nodeToWorld.tx, 10.0, 0.001, @"");
-	XCTAssertEqualWithAccuracy(nodeToWorld.ty, 15.0, 0.001, @"");
+	GLKMatrix4 nodeToWorld = [first nodeToWorldTransform];
+	XCTAssertEqualWithAccuracy(nodeToWorld.m[ 0],  2.0, 0.001, @""); // Node Scale *does* change the transform scale.
+	XCTAssertEqualWithAccuracy(nodeToWorld.m[ 1],  0.0, 0.001, @"");
+	XCTAssertEqualWithAccuracy(nodeToWorld.m[ 4],  0.0, 0.001, @"");
+	XCTAssertEqualWithAccuracy(nodeToWorld.m[ 5],  2.0, 0.001, @"");
+	XCTAssertEqualWithAccuracy(nodeToWorld.m[12], 10.0, 0.001, @"");
+	XCTAssertEqualWithAccuracy(nodeToWorld.m[13], 15.0, 0.001, @"");
 	
 	// Changing node transform scale does not change the content size, which is local to the node.
 	XCTAssertEqualWithAccuracy(first.contentSize.width, 1.0, 0.001, @"");

--- a/cocos2d/CCEffectGlass.m
+++ b/cocos2d/CCEffectGlass.m
@@ -249,7 +249,7 @@ static const float CCEffectGlassDefaultFresnelPower = 2.0f;
         // Concatenate the node to environment transform with the environment node to environment texture transform.
         // The result takes us from the affected node's coordinates to the environment's texture coordinates. We need
         // this when computing the tangent and normal vectors below.
-        GLKMatrix4 effectNodeToRefractEnvTexture = GLKMatrix4Multiply(CCEffectUtilsMat4FromAffineTransform(weakSelf.refractionEnvironment.nodeToTextureTransform), effectNodeToRefractEnvNode);
+        GLKMatrix4 effectNodeToRefractEnvTexture = GLKMatrix4Multiply(weakSelf.refractionEnvironment.nodeToTextureTransform, effectNodeToRefractEnvNode);
         
         // Concatenate the node to environment texture transform together with the transform from NDC to local node
         // coordinates. (NDC == normalized device coordinates == render target coordinates that are normalized to the
@@ -272,7 +272,7 @@ static const float CCEffectGlassDefaultFresnelPower = 2.0f;
         // Concatenate the node to environment transform with the environment node to environment texture transform.
         // The result takes us from the affected node's coordinates to the environment's texture coordinates. We need
         // this when computing the tangent and normal vectors below.
-        GLKMatrix4 effectNodeToReflectEnvTexture = GLKMatrix4Multiply(CCEffectUtilsMat4FromAffineTransform(weakSelf.reflectionEnvironment.nodeToTextureTransform), effectNodeToReflectEnvNode);
+        GLKMatrix4 effectNodeToReflectEnvTexture = GLKMatrix4Multiply(weakSelf.reflectionEnvironment.nodeToTextureTransform, effectNodeToReflectEnvNode);
         
         // Concatenate the node to environment texture transform together with the transform from NDC to local node
         // coordinates. (NDC == normalized device coordinates == render target coordinates that are normalized to the

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -330,8 +330,8 @@ static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
 
     BOOL needsNormalMap = (sprite.normalMapSpriteFrame != nil);
     
-    CGAffineTransform spriteTransform = sprite.nodeToWorldTransform;
-    CGPoint spritePosition = CGPointApplyAffineTransform(sprite.anchorPointInPoints, sprite.nodeToWorldTransform);
+    GLKMatrix4 spriteTransform = sprite.nodeToWorldTransform;
+    CGPoint spritePosition = CGPointApplyGLKMatrix4(sprite.anchorPointInPoints, sprite.nodeToWorldTransform);
     
     CCLightCollection *lightCollection = sprite.scene.lights;
     if (self.groupMaskDirty)

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -215,7 +215,7 @@
         // Concatenate the node to environment transform with the environment node to environment texture transform.
         // The result takes us from the affected node's coordinates to the environment's texture coordinates. We need
         // this when computing the tangent and normal vectors below.
-        GLKMatrix4 effectNodeToReflectEnvTexture = GLKMatrix4Multiply(CCEffectUtilsMat4FromAffineTransform(weakSelf.environment.nodeToTextureTransform), effectNodeToReflectEnvNode);
+        GLKMatrix4 effectNodeToReflectEnvTexture = GLKMatrix4Multiply(weakSelf.environment.nodeToTextureTransform, effectNodeToReflectEnvNode);
         
         // Concatenate the node to environment texture transform together with the transform from NDC to local node
         // coordinates. (NDC == normalized device coordinates == render target coordinates that are normalized to the

--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -167,7 +167,7 @@
         // Concatenate the node to environment transform with the environment node to environment texture transform.
         // The result takes us from the affected node's coordinates to the environment's texture coordinates. We need
         // this when computing the tangent and normal vectors below.
-        GLKMatrix4 effectNodeToRefractEnvTexture = GLKMatrix4Multiply(CCEffectUtilsMat4FromAffineTransform(weakSelf.environment.nodeToTextureTransform), effectNodeToRefractEnvNode);
+        GLKMatrix4 effectNodeToRefractEnvTexture = GLKMatrix4Multiply(weakSelf.environment.nodeToTextureTransform, effectNodeToRefractEnvNode);
 
         // Concatenate the node to environment texture transform together with the transform from NDC to local node
         // coordinates. (NDC == normalized device coordinates == render target coordinates that are normalized to the

--- a/cocos2d/CCEffectUtils.m
+++ b/cocos2d/CCEffectUtils.m
@@ -54,12 +54,12 @@ GLKMatrix4 CCEffectUtilsTransformFromNodeToAncestor(CCNode *descendant, CCNode *
     NSCAssert(CCEffectUtilsNodeIsDescendantOfNode(descendant, ancestor), @"The supplied nodes are not related to each other.");
                                                   
     // Compute the transform from this node to the common ancestor
-    CGAffineTransform t = [descendant nodeToParentTransform];
+    GLKMatrix4 t = [descendant nodeToParentTransform];
     for (CCNode *p = CCEffectUtilsGetNodeParent(descendant); p != CCEffectUtilsGetNodeParent(ancestor); p = CCEffectUtilsGetNodeParent(p))
     {
-        t = CGAffineTransformConcat(t, [p nodeToParentTransform]);
+		    t = GLKMatrix4Multiply([p nodeToParentTransform], t);
     }
-    return CCEffectUtilsMat4FromAffineTransform(t);
+    return t;
 }
 
 GLKMatrix4 CCEffectUtilsTransformFromNodeToNode(CCNode *first, CCNode *second, BOOL *success)

--- a/cocos2d/CCNoARC.m
+++ b/cocos2d/CCNoARC.m
@@ -14,16 +14,8 @@
 static inline GLKMatrix4
 CCNodeTransform(CCNode *node, GLKMatrix4 parentTransform)
 {
-	CGAffineTransform t = [node nodeToParentTransform];
-	float z = node->_vertexZ;
-	
-	// Convert to 4x4 column major GLK matrix.
-	return GLKMatrix4Multiply(parentTransform, GLKMatrix4Make(
-		 t.a,  t.b, 0.0f, 0.0f,
-		 t.c,  t.d, 0.0f, 0.0f,
-		0.0f, 0.0f, 1.0f, 0.0f,
-		t.tx, t.ty,    z, 1.0f
-	));
+	GLKMatrix4 t = [node nodeToParentTransform];
+	return GLKMatrix4Multiply(parentTransform, t);
 }
 
 -(GLKMatrix4)transform:(const GLKMatrix4 *)parentTransform

--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -97,7 +97,7 @@ A common user pattern in building a Cocos2d game is to subclass CCNode, add it t
 	CGSize	_contentSize;
 
 	// Transform.
-	CGAffineTransform _transform, _inverse;
+	GLKMatrix4 _transform, _inverse;
 
 	BOOL _isTransformDirty;
 	BOOL _isInverseDirty;
@@ -568,7 +568,7 @@ A common user pattern in building a Cocos2d game is to subclass CCNode, add it t
 /** Returns the matrix that transform the node's (local) space coordinates into the parent's space coordinates.
  The matrix is in Pixels.
  */
-- (CGAffineTransform)nodeToParentTransform;
+- (GLKMatrix4)nodeToParentTransform;
 
 - (CGPoint) convertPositionToPoints:(CGPoint)position type:(CCPositionType)type;
 - (CGPoint) convertPositionFromPoints:(CGPoint)positionInPoints type:(CCPositionType) type;
@@ -577,13 +577,13 @@ A common user pattern in building a Cocos2d game is to subclass CCNode, add it t
 - (CGSize) convertContentSizeFromPoints:(CGSize)pointSize type:(CCSizeType) type;
 
 /** Returns the matrix that transform parent's space coordinates to the node's (local) space coordinates. The matrix is in Pixels. */
-- (CGAffineTransform)parentToNodeTransform;
+- (GLKMatrix4)parentToNodeTransform;
 
 /** Returns the world affine transform matrix. The matrix is in Pixels. */
-- (CGAffineTransform)nodeToWorldTransform;
+- (GLKMatrix4)nodeToWorldTransform;
 
 /** Returns the inverse world affine transform matrix. The matrix is in Pixels. */
-- (CGAffineTransform)worldToNodeTransform;
+- (GLKMatrix4)worldToNodeTransform;
 
 /**
  *  Converts a Point to node (local) space coordinates. The result is in Points.

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -74,12 +74,12 @@ GetBodyIfRunning(CCNode *node)
 	return (node->_isInActiveScene ? node->_physicsBody : nil);
 }
 
-CGAffineTransform
+GLKMatrix4
 NodeToPhysicsTransform(CCNode *node)
 {
-	CGAffineTransform transform = CGAffineTransformIdentity;
+	GLKMatrix4 transform = GLKMatrix4Identity;
 	for(CCNode *n = node; n && !n.isPhysicsNode; n = n.parent){
-		transform = CGAffineTransformConcat(transform, n.nodeToParentTransform);
+	transform = GLKMatrix4Multiply(n.nodeToParentTransform, transform);
 	}
 	
 	return transform;
@@ -109,10 +109,10 @@ NodeToPhysicsScale(CCNode * node)
 	
 }
 
-inline CGAffineTransform
+inline GLKMatrix4
 RigidBodyToParentTransform(CCNode *node, CCPhysicsBody *body)
 {
-	return CGAffineTransformConcat(body.absoluteTransform, CGAffineTransformInvert(NodeToPhysicsTransform(node.parent)));
+	return GLKMatrix4Multiply(GLKMatrix4Invert(NodeToPhysicsTransform(node.parent), NULL), body.absoluteTransform);
 }
 
 // XXX: Yes, nodes might have a sort problem once every 15 days if the game runs at 60 FPS and each frame sprites are reordered.
@@ -313,7 +313,7 @@ static NSUInteger globalOrderOfArrival = 1;
 inline CGPoint
 GetPositionFromBody(CCNode *node, CCPhysicsBody *body)
 {
-	return CGPointApplyAffineTransform(node->_anchorPointInPoints, [node nodeToParentTransform]);
+	return CGPointApplyGLKMatrix4(node->_anchorPointInPoints, [node nodeToParentTransform]);
 }
 
 -(CGPoint)position
@@ -328,9 +328,10 @@ GetPositionFromBody(CCNode *node, CCPhysicsBody *body)
 
 // Urg. CGPoint types. -_-
 inline CGPoint
-TransformPointAsVector(CGPoint p, CGAffineTransform t)
+TransformPointAsVector(CGPoint p, GLKMatrix4 t)
 {
-  return (CGPoint){t.a*p.x + t.c*p.y, t.b*p.x + t.d*p.y};
+	GLKVector4 v = GLKMatrix4MultiplyVector4(t, GLKVector4Make(p.x, p.y, 0.0f, 0.0f));
+	return CGPointMake(v.x, v.y);
 }
 
 -(void) setPosition: (CGPoint)newPosition
@@ -585,7 +586,8 @@ TransformPointAsVector(CGPoint p, CGAffineTransform t)
 {
     CGSize contentSize = self.contentSizeInPoints;
     CGRect rect = CGRectMake(0, 0, contentSize.width, contentSize.height);
-    return CGRectApplyAffineTransform(rect, [self nodeToParentTransform]);
+    GLKMatrix4 t = [self nodeToParentTransform];
+    return CGRectApplyAffineTransform(rect, CGAffineTransformMake(t.m[0], t.m[1], t.m[4], t.m[5], t.m[12], t.m[13]));
 }
 
 -(void) setVertexZ:(float)vertexZ
@@ -916,28 +918,33 @@ RecursivelyIncrementPausedAncestors(CCNode *node, int increment)
 
 #pragma mark CCPhysics support.
 
-inline CGAffineTransform
-CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
+inline GLKMatrix4
+GLKMatrix4MakeRigid(CGPoint pos, CGFloat radians)
 {
 	CGPoint rot = ccpForAngle(radians);
-	return CGAffineTransformMake(rot.x, rot.y, -rot.y, rot.x, translate.x, translate.y);
+	return GLKMatrix4Make(
+		 rot.x, rot.y, 0.0f, 0.0f,
+		-rot.y, rot.x, 0.0f, 0.0f,
+		  0.0f,  0.0f, 1.0f, 0.0f,
+		 pos.x, pos.y, 0.0f, 1.0f
+	);
 }
 
 // Private method used to extract the non-rigid part of the node's transform relative to a CCPhysicsNode.
 // This method can only be called in very specific circumstances.
--(CGAffineTransform)nonRigidTransform
+-(GLKMatrix4)nonRigidTransform
 {
-	CGAffineTransform toPhysics = NodeToPhysicsTransform(self);
+	GLKMatrix4 toPhysics = NodeToPhysicsTransform(self);
 	
 	CCPhysicsBody *body = GetBodyIfRunning(self);
 	if(body){
-		return CGAffineTransformConcat(toPhysics, CGAffineTransformInvert(body.absoluteTransform));
+		return GLKMatrix4Multiply(GLKMatrix4Invert(body.absoluteTransform, NULL), toPhysics);
 	} else {
 		// Body is not active yet, so this is more of a mess. :-\
 		// Need to guess the rigid part of the transform.
 		float radians = CC_DEGREES_TO_RADIANS(NodeToPhysicsRotation(self));
-		CGAffineTransform absolute = CGAffineTransformMakeRigid(ccp(toPhysics.tx, toPhysics.ty), radians);
-		return CGAffineTransformConcat(toPhysics, CGAffineTransformInvert(absolute));
+		GLKMatrix4 absolute = GLKMatrix4MakeRigid(ccp(toPhysics.m[12], toPhysics.m[13]), radians);
+		return GLKMatrix4Multiply(GLKMatrix4Invert(absolute, NULL), toPhysics);
 	}
 }
 
@@ -962,14 +969,14 @@ CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
 		physicsBody.absoluteRadians = CC_DEGREES_TO_RADIANS(NodeToPhysicsRotation(self));
 		
 		// Grab the origin position of the node from it's transform.
-		CGAffineTransform transform = NodeToPhysicsTransform(self);
-		physicsBody.absolutePosition = ccp(transform.tx, transform.ty);
+		GLKMatrix4 transform = NodeToPhysicsTransform(self);
+		physicsBody.absolutePosition = ccp(transform.m[12], transform.m[13]);
         
         physicsBody.relativePosition = self.positionInPoints;
 		physicsBody.relativeRotation = self.rotation;
         
-		CGAffineTransform nonRigid = self.nonRigidTransform;
-		[_physicsBody willAddToPhysicsNode:physics nonRigidTransform:CGAFFINETRANSFORM_TO_CPTRANSFORM(nonRigid)];
+		GLKMatrix4 nonRigid = self.nonRigidTransform;
+		[_physicsBody willAddToPhysicsNode:physics nonRigidTransform:nonRigid];
 		[physics.space smartAdd:physicsBody];
 		[_physicsBody didAddToPhysicsNode:physics];
 		
@@ -1418,30 +1425,30 @@ CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
 	self.position = [self convertPositionFromPoints:positionInPoints type:self.positionType];
 }
 
-- (CGAffineTransform)nodeToParentTransform
+- (GLKMatrix4)nodeToParentTransform
 {
 	// The body ivar cannot be changed while this method is running and it's ARC retain/release is 70% of the profile samples for this method.
 	__unsafe_unretained CCPhysicsBody *physicsBody = GetBodyIfRunning(self);
 	if(physicsBody){
         
-		CGAffineTransform rigidTransform;
+		GLKMatrix4 rigidTransform;
 		
 		if(physicsBody.type == CCPhysicsBodyTypeKinematic)
 		{
 			CGPoint anchorPointInPointsScaled = ccpCompMult(_anchorPointInPoints,
 															ccp(_scaleX, _scaleY));
 			CGPoint rot = ccpRotateByAngle(anchorPointInPointsScaled, CGPointZero, -CC_DEGREES_TO_RADIANS(physicsBody.relativeRotation));
-			rigidTransform = CGAffineTransformMakeRigid(ccpSub(physicsBody.relativePosition , rot ), -CC_DEGREES_TO_RADIANS(physicsBody.relativeRotation));
+			rigidTransform = GLKMatrix4MakeRigid(ccpSub(physicsBody.relativePosition , rot ), -CC_DEGREES_TO_RADIANS(physicsBody.relativeRotation));
 		}
 		else
 		{
 			CGPoint scaleToParent = NodeToPhysicsScale(self.parent);
-			CGAffineTransform nodeToPhysics = NodeToPhysicsTransform(self.parent);
-			rigidTransform = CGAffineTransformConcat(physicsBody.absoluteTransform, CGAffineTransformInvert(nodeToPhysics));
-			rigidTransform = CGAffineTransformConcat(CGAffineTransformMakeScale(scaleToParent.x, scaleToParent.y), rigidTransform);
+			GLKMatrix4 nodeToPhysics = NodeToPhysicsTransform(self.parent);
+			rigidTransform = GLKMatrix4Multiply(GLKMatrix4Invert(nodeToPhysics, NULL), physicsBody.absoluteTransform);
+			rigidTransform = GLKMatrix4Multiply(rigidTransform, GLKMatrix4MakeScale(scaleToParent.x, scaleToParent.y, 1.0f));
 		}
-
-		_transform = CGAffineTransformConcat(CGAffineTransformMakeScale(_scaleX , _scaleY), rigidTransform);
+		
+		_transform = GLKMatrix4Multiply(rigidTransform, GLKMatrix4MakeScale(_scaleX, _scaleY, 1.0));
 	} else if ( _isTransformDirty ) {
         
         // Get content size
@@ -1504,21 +1511,23 @@ CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
 
 		// Build Transform Matrix
 		// Adjusted transfor m calculation for rotational skew
-		_transform = CGAffineTransformMake( cy * _scaleX * scaleFactor, sy * _scaleX * scaleFactor,
-										   -sx * _scaleY * scaleFactor, cx * _scaleY * scaleFactor,
-										   x, y );
+		_transform = GLKMatrix4Make( cy * _scaleX * scaleFactor, sy * _scaleX * scaleFactor, 0.0f, 0.0f,
+										   -sx * _scaleY * scaleFactor, cx * _scaleY * scaleFactor, 0.0f, 0.0f,
+											 0.0f, 0.0f, 1.0f, 0.0f,
+										   x, y, _vertexZ, 1.0f);
 
 		// XXX: Try to inline skew
 		// If skew is needed, apply skew and then anchor point
 		if( needsSkewMatrix ) {
-			CGAffineTransform skewMatrix = CGAffineTransformMake(1.0f, tanf(CC_DEGREES_TO_RADIANS(_skewY)),
-																 tanf(CC_DEGREES_TO_RADIANS(_skewX)), 1.0f,
-																 0.0f, 0.0f );
-			_transform = CGAffineTransformConcat(skewMatrix, _transform);
+			GLKMatrix4 skewMatrix = GLKMatrix4Make(1.0f, tanf(CC_DEGREES_TO_RADIANS(_skewY)), 0.0f, 0.0f,
+																 tanf(CC_DEGREES_TO_RADIANS(_skewX)), 1.0f, 0.0f, 0.0f,
+											 0.0f, 0.0f, 1.0f, 0.0f,
+																 0.0f, 0.0f, 0.0f, 1.0f);
+			_transform = GLKMatrix4Multiply(_transform, skewMatrix);
 
 			// adjust anchor point
 			if( ! CGPointEqualToPoint(_anchorPointInPoints, CGPointZero) )
-				_transform = CGAffineTransformTranslate(_transform, -_anchorPointInPoints.x, -_anchorPointInPoints.y);
+				_transform = GLKMatrix4Translate(_transform, -_anchorPointInPoints.x, -_anchorPointInPoints.y, 0.0f);
 		}
 
 		_isTransformDirty = NO;
@@ -1527,42 +1536,40 @@ CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
 	return _transform;
 }
 
-- (CGAffineTransform)parentToNodeTransform
+- (GLKMatrix4)parentToNodeTransform
 {
 	// TODO Need to find a better way to mark physics transforms as dirty
 	if ( _isInverseDirty || GetBodyIfRunning(self) ) {
-		_inverse = CGAffineTransformInvert([self nodeToParentTransform]);
+		_inverse = GLKMatrix4Invert([self nodeToParentTransform], NULL);
 		_isInverseDirty = NO;
 	}
 
 	return _inverse;
 }
 
-- (CGAffineTransform)nodeToWorldTransform
+- (GLKMatrix4)nodeToWorldTransform
 {
-	CGAffineTransform t = [self nodeToParentTransform];
+	GLKMatrix4 t = [self nodeToParentTransform];
 
 	for (CCNode *p = _parent; p != nil; p = p.parent)
-		t = CGAffineTransformConcat(t, [p nodeToParentTransform]);
+		t = GLKMatrix4Multiply([p nodeToParentTransform], t);
 
 	return t;
 }
 
-- (CGAffineTransform)worldToNodeTransform
+- (GLKMatrix4)worldToNodeTransform
 {
-	return CGAffineTransformInvert([self nodeToWorldTransform]);
+	return GLKMatrix4Invert([self nodeToWorldTransform], NULL);
 }
 
 - (CGPoint)convertToNodeSpace:(CGPoint)worldPoint
 {
-	CGPoint ret = CGPointApplyAffineTransform(worldPoint, [self worldToNodeTransform]);
-	return ret;
+	return CGPointApplyGLKMatrix4(worldPoint, [self worldToNodeTransform]);
 }
 
 - (CGPoint)convertToWorldSpace:(CGPoint)nodePoint
 {
-	CGPoint ret = CGPointApplyAffineTransform(nodePoint, [self nodeToWorldTransform]);
-	return ret;
+	return CGPointApplyGLKMatrix4(nodePoint, [self nodeToWorldTransform]);
 }
 
 - (CGPoint)convertToNodeSpaceAR:(CGPoint)worldPoint

--- a/cocos2d/CCNode_Private.h
+++ b/cocos2d/CCNode_Private.h
@@ -26,11 +26,19 @@
 
 CGPoint NodeToPhysicsScale(CCNode * node);
 float NodeToPhysicsRotation(CCNode *node);
-CGAffineTransform NodeToPhysicsTransform(CCNode *node);
-CGAffineTransform RigidBodyToParentTransform(CCNode *node, CCPhysicsBody *body);
+GLKMatrix4 NodeToPhysicsTransform(CCNode *node);
+GLKMatrix4 RigidBodyToParentTransform(CCNode *node, CCPhysicsBody *body);
 CGPoint GetPositionFromBody(CCNode *node, CCPhysicsBody *body);
-CGPoint TransformPointAsVector(CGPoint p, CGAffineTransform t);
-CGAffineTransform CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians);
+CGPoint TransformPointAsVector(CGPoint p, GLKMatrix4 t);
+GLKMatrix4 GLKMatrix4MakeRigid(CGPoint translate, CGFloat radians);
+
+// TODO Doesn't really belong here, but the header includes are such a sphagetti mess it's hard to find anywhere else.
+/// Transform and project a CGPoint by a 4x4 matrix. Throw away the resulting z value.
+static inline CGPoint
+CGPointApplyGLKMatrix4(CGPoint p, GLKMatrix4 m){
+	GLKVector3 v = GLKMatrix4MultiplyAndProjectVector3(m, GLKVector3Make(p.x, p.y, 0.0));
+	return CGPointMake(v.x, v.y);
+}
 
 @interface CCNode()<CCShaderProtocol, CCBlendProtocol, CCTextureProtocol> {
 	@protected

--- a/cocos2d/CCPhysics+ObjectiveChipmunk.h
+++ b/cocos2d/CCPhysics+ObjectiveChipmunk.h
@@ -86,7 +86,7 @@ static inline cpTransform CGAFFINETRANSFORM_TO_CPTRANSFORM(CGAffineTransform t){
 @property(nonatomic, assign) CGFloat relativeRotation;
 
 /** The transform of the body relative to the space. */
-@property(nonatomic, readonly) CGAffineTransform absoluteTransform;
+@property(nonatomic, readonly) GLKMatrix4 absoluteTransform;
 
 /** Chipmunk Body. */
 @property(nonatomic, readonly) ChipmunkBody *body;
@@ -118,7 +118,7 @@ static inline cpTransform CGAFFINETRANSFORM_TO_CPTRANSFORM(CGAffineTransform t){
  *  @param physics Physics node.
  *  @param transform Transform to use.
  */
--(void)willAddToPhysicsNode:(CCPhysicsNode *)physics nonRigidTransform:(cpTransform)transform;
+-(void)willAddToPhysicsNode:(CCPhysicsNode *)physics nonRigidTransform:(GLKMatrix4)transform;
 
 /**
  *  Used for deferring collision type setup until there is access to the physics node.
@@ -160,7 +160,7 @@ static inline cpTransform CGAFFINETRANSFORM_TO_CPTRANSFORM(CGAffineTransform t){
  *  @param physics Physics node.
  *  @param transform Transform to use.
  */
--(void)willAddToPhysicsNode:(CCPhysicsNode *)physics nonRigidTransform:(cpTransform)transform;
+-(void)willAddToPhysicsNode:(CCPhysicsNode *)physics nonRigidTransform:(GLKMatrix4)transform;
 
 /**
  *  Used for deferring collision type setup until there is access to the physics node.

--- a/cocos2d/CCPhysicsBody.m
+++ b/cocos2d/CCPhysicsBody.m
@@ -31,7 +31,7 @@
 
 
 @interface CCNode(Private)
--(CGAffineTransform)nonRigidTransform;
+-(GLKMatrix4)nonRigidTransform;
 @end
 
 //Function Prototype
@@ -56,7 +56,7 @@ CCPhysicsBodyUpdatePosition(cpBody *body, cpFloat dt);
 	BOOL _trackingPerformed;
     BOOL _isKinematicTransformDirty;
     
-    CGAffineTransform _lastTransform;
+    cpTransform _lastTransform;
     
     CGPoint           _relativePosition;
     float             _relativeRotation;
@@ -430,8 +430,14 @@ CCPhysicsBodyUpdatePosition(cpBody *body, cpFloat dt)
 }
 
 
--(CGAffineTransform)absoluteTransform {
-	return CPTRANSFORM_TO_CGAFFINETRANSFORM(_body.transform);
+-(GLKMatrix4)absoluteTransform {
+	cpTransform t = _body.transform;
+	return GLKMatrix4Make(
+		 t.a,  t.b, 0.0f, 0.0f,
+		 t.c,  t.d, 0.0f, 0.0f,
+		0.0f, 0.0f, 1.0f, 0.0f,
+		t.tx, t.ty, 0.0f, 1.0f
+	);
 }
 
 
@@ -456,7 +462,8 @@ CCPhysicsBodyUpdatePosition(cpBody *body, cpFloat dt)
         
         /////// Update absolute position
         
-		CGAffineTransform phyicsTransform = NodeToPhysicsTransform(self.node.parent);
+		GLKMatrix4 t = NodeToPhysicsTransform(self.node.parent);
+		cpTransform phyicsTransform = cpTransformNew(t.m[0], t.m[1], t.m[4], t.m[5], t.m[12], t.m[13]);
 		
 		CGPoint anchorPointInPointsScaled = ccpCompMult(self.node.anchorPointInPoints,
 												   ccp(self.node.scaleX, self.node.scaleY));
@@ -480,7 +487,8 @@ CCPhysicsBodyUpdatePosition(cpBody *body, cpFloat dt)
         CGPoint velocity = ccpMult(ccpSub(self.absolutePosition, lastPos), 1.0/deltaTime);
 		
         // Change in transform since last frame.
-        cpTransform deltaTransform = cpTransformMult(cpTransformInverse(_lastTransform), self.absoluteTransform);
+        cpTransform currentTransform = _body.transform;
+        cpTransform deltaTransform = cpTransformMult(cpTransformInverse(_lastTransform), currentTransform);
 
         // Change in rotation since the last frame.
         cpFloat deltaRadians = cpfatan2(deltaTransform.b, deltaTransform.a);
@@ -490,7 +498,7 @@ CCPhysicsBodyUpdatePosition(cpBody *body, cpFloat dt)
 		_body.angularVelocity = angularVelocity;
         self.velocity = velocity;
        
-        _lastTransform = self.absoluteTransform;
+        _lastTransform = currentTransform;
        
     }
     
@@ -511,10 +519,11 @@ CCPhysicsBodyUpdatePosition(cpBody *body, cpFloat dt)
 	[_joints removeObject:joint];
 }
 
--(void)willAddToPhysicsNode:(CCPhysicsNode *)physics nonRigidTransform:(cpTransform)transform
+-(void)willAddToPhysicsNode:(CCPhysicsNode *)physics nonRigidTransform:(GLKMatrix4)transform
 {
-    _lastTransform = NodeToPhysicsTransform(self.node);
-	FOREACH_SHAPE(self, shape) [shape willAddToPhysicsNode:physics nonRigidTransform:transform];
+    GLKMatrix4 t = NodeToPhysicsTransform(self.node.parent);
+    _lastTransform = cpTransformNew(t.m[0], t.m[1], t.m[4], t.m[5], t.m[12], t.m[13]);
+    FOREACH_SHAPE(self, shape) [shape willAddToPhysicsNode:physics nonRigidTransform:transform];
 
     if(self.type == CCPhysicsBodyTypeStatic)
 		[self trackParentTransformations:physics];

--- a/cocos2d/CCPhysicsJoint.m
+++ b/cocos2d/CCPhysicsJoint.m
@@ -27,7 +27,7 @@
 #import "CCNode_Private.h"
 
 @interface CCNode(Private)
--(CGAffineTransform)nonRigidTransform;
+-(GLKMatrix4)nonRigidTransform;
 @end
 
 
@@ -280,7 +280,7 @@ BreakConstraint(cpConstraint *constraint, cpSpace *space)
 {
 	
 	CCPhysicsBody *bodyA = self.bodyA;
-	CGPoint anchor = CGPointApplyAffineTransform(_anchor, bodyA.node.nonRigidTransform);
+	CGPoint anchor = CGPointApplyGLKMatrix4(_anchor, bodyA.node.nonRigidTransform);
 	
 	_constraint.anchorA = CCP_TO_CPV(anchor);
 	_constraint.anchorB = [_constraint.bodyB worldToLocal:[_constraint.bodyA localToWorld:CCP_TO_CPV(anchor)]];
@@ -345,8 +345,8 @@ BreakConstraint(cpConstraint *constraint, cpSpace *space)
 -(void)willAddToPhysicsNode:(CCPhysicsNode *)physics
 {
 	CCPhysicsBody *bodyA = self.bodyA, *bodyB = self.bodyB;
-	CGPoint anchorA = CGPointApplyAffineTransform(_anchorA, bodyA.node.nonRigidTransform);
-	CGPoint anchorB = CGPointApplyAffineTransform(_anchorB, bodyB.node.nonRigidTransform);
+	CGPoint anchorA = CGPointApplyGLKMatrix4(_anchorA, bodyA.node.nonRigidTransform);
+	CGPoint anchorB = CGPointApplyGLKMatrix4(_anchorB, bodyB.node.nonRigidTransform);
     _constraint.anchorA = CCP_TO_CPV(anchorA);
     _constraint.anchorB = CCP_TO_CPV(anchorB);
 	
@@ -383,8 +383,8 @@ BreakConstraint(cpConstraint *constraint, cpSpace *space)
 -(void)willAddToPhysicsNode:(CCPhysicsNode *)physics
 {
 	CCPhysicsBody *bodyA = self.bodyA, *bodyB = self.bodyB;
-	_constraint.anchorA = CCP_TO_CPV(CGPointApplyAffineTransform(_anchorA, bodyA.node.nonRigidTransform));
-	_constraint.anchorB = CCP_TO_CPV(CGPointApplyAffineTransform(_anchorB, bodyB.node.nonRigidTransform));
+	_constraint.anchorA = CCP_TO_CPV(CGPointApplyGLKMatrix4(_anchorA, bodyA.node.nonRigidTransform));
+	_constraint.anchorB = CCP_TO_CPV(CGPointApplyGLKMatrix4(_anchorB, bodyB.node.nonRigidTransform));
 }
 
 -(void)setScale:(float)_scale
@@ -427,8 +427,8 @@ BreakConstraint(cpConstraint *constraint, cpSpace *space)
 -(void)willAddToPhysicsNode:(CCPhysicsNode *)physics
 {
 	CCPhysicsBody *bodyA = self.bodyA, *bodyB = self.bodyB;
-	_constraint.anchorA = CCP_TO_CPV(CGPointApplyAffineTransform(_anchorA, bodyA.node.nonRigidTransform));
-	_constraint.anchorB = CCP_TO_CPV(CGPointApplyAffineTransform(_anchorB, bodyB.node.nonRigidTransform));
+	_constraint.anchorA = CCP_TO_CPV(CGPointApplyGLKMatrix4(_anchorA, bodyA.node.nonRigidTransform));
+	_constraint.anchorB = CCP_TO_CPV(CGPointApplyGLKMatrix4(_anchorB, bodyB.node.nonRigidTransform));
 	
 }
 

--- a/cocos2d/CCPhysicsShape.m
+++ b/cocos2d/CCPhysicsShape.m
@@ -33,7 +33,7 @@
 
 
 @interface CCNode()
--(CGAffineTransform)nonRigidTransform;
+-(GLKMatrix4)nonRigidTransform;
 @end
 
 
@@ -81,31 +81,26 @@
 	return [[CCPhysicsPolyShape alloc] initWithPolygonFromPoints:points count:count cornerRadius:cornerRadius];
 }
 
--(cpTransform)shapeTransform
+-(CGFloat)shapeTransformDeterminant
 {
 	// TODO Might be better to use the physics relative transform.
 	// That's not available until the scene is set up though... hrm.
 	CCNode *node = self.node;
 	if(node){
-		return CGAFFINETRANSFORM_TO_CPTRANSFORM([node nonRigidTransform]);
+		GLKMatrix4 t = node.nonRigidTransform;
+		return (t.m[0]*t.m[5] - t.m[4]*t.m[1]);
 	} else {
-		return cpTransformIdentity;
+		return 1.0;
 	}
-}
-
-static cpFloat
-Determinant(cpTransform t)
-{
-	return (t.a*t.d - t.c*t.b);
 }
 
 -(CGFloat)mass {return self.shape.mass;}
 -(void)setMass:(CGFloat)mass {self.shape.mass = mass;}
 
--(CGFloat)density {return 1e3*self.shape.density/Determinant(self.shapeTransform);}
--(void)setDensity:(CGFloat)density {self.shape.density = 1e-3*density*Determinant(self.shapeTransform);}
+-(CGFloat)density {return 1e3*self.shape.density/self.shapeTransformDeterminant;}
+-(void)setDensity:(CGFloat)density {self.shape.density = 1e-3*density*self.shapeTransformDeterminant;}
 
--(CGFloat)area {return self.shape.area*Determinant(self.shapeTransform);}
+-(CGFloat)area {return self.shape.area*self.shapeTransformDeterminant;}
 
 -(CGFloat)friction {return self.shape.friction;}
 -(void)setFriction:(CGFloat)friction {self.shape.friction = friction;}
@@ -200,7 +195,7 @@ Determinant(cpTransform t)
 -(void)rescaleShape:(cpTransform)transform {@throw [NSException exceptionWithName:@"AbstractInvocation" reason:@"This method is abstract." userInfo:nil];}
 -(ChipmunkShape *)shape {@throw [NSException exceptionWithName:@"AbstractInvocation" reason:@"This method is abstract." userInfo:nil];}
 
--(void)willAddToPhysicsNode:(CCPhysicsNode *)physics nonRigidTransform:(cpTransform)transform;
+-(void)willAddToPhysicsNode:(CCPhysicsNode *)physics nonRigidTransform:(GLKMatrix4)t;
 {
 	// Intern the collision type to ensure it's not a unique object reference.
 	_collisionType = [physics internString:_collisionType];
@@ -217,8 +212,8 @@ Determinant(cpTransform t)
 	_collisionCategories = nil;
 	_collisionMask = nil;
 	
-	[self rescaleShape:transform];
-    
+	
+	[self rescaleShape:cpTransformNew(t.m[0], t.m[1], t.m[4], t.m[5], t.m[12], t.m[13])];
 }
 
 -(void)didRemoveFromPhysicsNode:(CCPhysicsNode *)physics

--- a/cocos2d/CCRenderTexture.m
+++ b/cocos2d/CCRenderTexture.m
@@ -64,13 +64,13 @@
 	return _renderState;
 }
 
-- (CGAffineTransform)nodeToWorldTransform
+- (GLKMatrix4)nodeToWorldTransform
 {
-	CGAffineTransform t = [self nodeToParentTransform];
+	GLKMatrix4 t = [self nodeToParentTransform];
     
 	for (CCNode *p = _renderTexture; p != nil; p = p.parent)
     {
-		t = CGAffineTransformConcat(t, [p nodeToParentTransform]);
+		t = GLKMatrix4Multiply([p nodeToParentTransform], t);
     }
 	return t;
 }

--- a/cocos2d/CCRenderTexture_Private.h
+++ b/cocos2d/CCRenderTexture_Private.h
@@ -49,7 +49,5 @@
 
 @property (nonatomic, weak) CCRenderTexture *renderTexture;
 
-- (CGAffineTransform)nodeToWorldTransform;
-
 @end
 

--- a/cocos2d/CCSprite.h
+++ b/cocos2d/CCSprite.h
@@ -258,7 +258,7 @@ typedef struct CCSpriteTexCoordSet {
 
 /** Returns the matrix that transforms the sprite's (local) space coordinates into the sprite's texture space coordinates.
  */
-- (CGAffineTransform)nodeToTextureTransform;
+- (GLKMatrix4)nodeToTextureTransform;
 
 
 

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -330,14 +330,19 @@
 	return &_verts;
 }
 
-- (CGAffineTransform)nodeToTextureTransform
+- (GLKMatrix4)nodeToTextureTransform
 {
     CGFloat sx = (_verts.br.texCoord1.s - _verts.bl.texCoord1.s) / (_verts.br.position.x - _verts.bl.position.x);
     CGFloat sy = (_verts.tl.texCoord1.t - _verts.bl.texCoord1.t) / (_verts.tl.position.y - _verts.bl.position.y);
     CGFloat tx = (_verts.bl.texCoord1.s - _verts.bl.position.x * sx);
     CGFloat ty = (_verts.bl.texCoord1.t - _verts.bl.position.y * sy);
     
-	return CGAffineTransformMake(sx, 0.0f, 0.0f, sy, tx, ty);
+	return GLKMatrix4Make(
+		  sx, 0.0f, 0.0f, 0.0f,
+		0.0f,   sy, 0.0f, 0.0f,
+		0.0f, 0.0f, 1.0f, 0.0f,
+		  tx,   ty, 0.0f, 1.0f
+	);
 }
 
 #pragma mark CCSprite - draw


### PR DESCRIPTION
(Note: this is going into the brand new develop-v4 branch, not v3.x)

Replacing CGAffineTransform usage internally. Using 4x4 transforms avoids the 2x3 -> 4x4 conversion step that happens a lot, and prevents a lot of ambiguities between rendering and input coordinates. This also opens the possibility for adding 3D transforms to a category. Performance seems unaffected, but was only lightly tested.

This is a very straightforward, 1:1 conversion of the functions to prepare for the next set of transform related changes. I did not attempt to further simplify the resulting code. I figured that should wait until later since many more transform changes are being discussed.

One question: I changed 4 public methods in CCNode.h to return GLKMatrix4 instead of CGAffineTransform. Is it worth cluttering up the v4 API with backwards compatible methods and make new methods to return the 4x4 matrices? I would guess these methods are rarely used directly by users. It's hard to get a good estimate from a GitHub code search since they are used internally quite heavily.
