### PR TITLE
Only enable Metal support on 64-bit devices.

### DIFF
--- a/cocos2d/ccMacros.h
+++ b/cocos2d/ccMacros.h
@@ -56,7 +56,8 @@
 #endif
 
 // Metal is only supported on iOS devices (currently does not include the simulator) and on iOS 8 and greater.
-#if __CC_PLATFORM_IOS && defined(__IPHONE_8_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0
+// Metal is only supported on 64-bit devices.
+#if __CC_PLATFORM_IOS && defined(__IPHONE_8_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0 && defined(__LP64__)
 #define __CC_METAL_SUPPORTED_AND_ENABLED (CC_ENABLE_METAL_RENDERING && !TARGET_IPHONE_SIMULATOR)
 #else
 #define __CC_METAL_SUPPORTED_AND_ENABLED 0


### PR DESCRIPTION
Prior to this commit, Cocos2D will still be built and run with Metal support if CC_ENABLE_METAL_RENDERING is 1 and we are building with the iOS 8 SDK, even if we are running on a device that doesn't support Metal but supports iOS 8 such as the iPhone 5. When this happens, Cocos2D crashes.

What really should happen is that if creating the Metal view fails then Cocos2D should fall back to OpenGL, but this will have to do for now.
