### PR TITLE
Fixed and Flexible layouts for Android.

### DIFF
--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -393,6 +393,8 @@ static CCDirector *_sharedDirector = nil;
 		_winSizeInPixels = CGSizeMake(size.width*scale, size.height*scale);
 		_winSizeInPoints = size;
 		__ccContentScaleFactor = scale;
+        CCLOG(@"set scale factor %f", scale);
+
 
 		// it could be nil
 		if( view ) {
@@ -418,7 +420,8 @@ static CCDirector *_sharedDirector = nil;
 	NSAssert(scaleFactor > 0.0, @"scaleFactor must be positive.");
 	
 	if( scaleFactor != __ccContentScaleFactor ) {
-		__ccContentScaleFactor = scaleFactor;
+        CCLOG(@"set scale factor %f", scaleFactor);
+        __ccContentScaleFactor = scaleFactor;
 		_winSizeInPoints = CGSizeMake( _winSizeInPixels.width / scaleFactor, _winSizeInPixels.height / scaleFactor );
 
 		// update projection
@@ -502,9 +505,12 @@ static CCDirector *_sharedDirector = nil;
 {
 	_winSizeInPixels = newViewSize;
 	_winSizeInPoints = CGSizeMake( _winSizeInPixels.width / __ccContentScaleFactor, _winSizeInPixels.height / __ccContentScaleFactor );
-	
+
 	[self setProjection:_projection];
-	
+
+    CCLOG(@"resize to pixels %dx%d", (int)_winSizeInPixels.width, (int)_winSizeInPixels.height);
+    CCLOG(@"resize to points %dx%d", (int)_winSizeInPoints.width, (int)_winSizeInPoints.height);
+
 	[_runningScene viewDidResizeTo: newViewSize];
 }
 

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -393,8 +393,6 @@ static CCDirector *_sharedDirector = nil;
 		_winSizeInPixels = CGSizeMake(size.width*scale, size.height*scale);
 		_winSizeInPoints = size;
 		__ccContentScaleFactor = scale;
-        CCLOG(@"set scale factor %f", scale);
-
 
 		// it could be nil
 		if( view ) {
@@ -420,8 +418,7 @@ static CCDirector *_sharedDirector = nil;
 	NSAssert(scaleFactor > 0.0, @"scaleFactor must be positive.");
 	
 	if( scaleFactor != __ccContentScaleFactor ) {
-        CCLOG(@"set scale factor %f", scaleFactor);
-        __ccContentScaleFactor = scaleFactor;
+		__ccContentScaleFactor = scaleFactor;
 		_winSizeInPoints = CGSizeMake( _winSizeInPixels.width / scaleFactor, _winSizeInPixels.height / scaleFactor );
 
 		// update projection
@@ -505,13 +502,10 @@ static CCDirector *_sharedDirector = nil;
 {
 	_winSizeInPixels = newViewSize;
 	_winSizeInPoints = CGSizeMake( _winSizeInPixels.width / __ccContentScaleFactor, _winSizeInPixels.height / __ccContentScaleFactor );
-
+	
 	[self setProjection:_projection];
-
-    CCLOG(@"resize to pixels %dx%d", (int)_winSizeInPixels.width, (int)_winSizeInPixels.height);
-    CCLOG(@"resize to points %dx%d", (int)_winSizeInPoints.width, (int)_winSizeInPoints.height);
-
-	[_runningScene viewDidResizeTo: newViewSize];
+	
+	[_runningScene viewDidResizeTo: _winSizeInPoints];
 }
 
 #pragma mark Director Scene Management

--- a/cocos2d/Platforms/Android/CCActivity.m
+++ b/cocos2d/Platforms/Android/CCActivity.m
@@ -12,13 +12,13 @@
 
 #import <android/native_window.h>
 #import <bridge/runtime.h>
+#import <bridge/jni.h>
 
 #import "cocos2d.h"
 #import "CCBReader.h"
 #import "CCGLView.h"
 #import "CCScene.h"
 #import <android/looper.h>
-#import "CCPackageManager.h"
 
 #define USE_MAIN_THREAD 0 // enable to run on OpenGL/Cocos2D on the android main thread
 
@@ -228,7 +228,7 @@ static void handler(NSException *e)
 
 - (void)setupView:(JavaObject<AndroidSurfaceHolder> *)holder
 {
-    ANativeWindow* window = holder.surface.window;
+    ANativeWindow* window = ANativeWindow_fromSurface(jni_getEnv(), bridge_getJava(holder.surface, NULL));
     [_glView setupView:window];
 }
 

--- a/cocos2d/Platforms/Android/CCActivity.m
+++ b/cocos2d/Platforms/Android/CCActivity.m
@@ -12,7 +12,6 @@
 
 #import <android/native_window.h>
 #import <bridge/runtime.h>
-#import <bridge/jni.h>
 
 #import "cocos2d.h"
 #import "CCBReader.h"
@@ -83,17 +82,7 @@ static void handler(NSException *e)
     NSLog(@"Unhandled exception %@", e);
 }
 
-static CGFloat
-FindPOTScale(CGFloat size, CGFloat fixedSize)
-{
-	int scale = 1;
-	while(fixedSize*scale < size) scale *= 2;
-
-	return scale;
-}
-
-static CGFloat
-FindLinearScale(CGFloat size, CGFloat fixedSize)
+static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
 {
 	int scale = 1;
 	while(fixedSize*scale < size) scale++;
@@ -248,7 +237,7 @@ FindLinearScale(CGFloat size, CGFloat fixedSize)
 
 - (void)setupView:(JavaObject<AndroidSurfaceHolder> *)holder
 {
-    ANativeWindow* window = ANativeWindow_fromSurface(jni_getEnv(), bridge_getJava(holder.surface, NULL));
+    ANativeWindow* window = holder.surface.window;
     [_glView setupView:window];
 }
 
@@ -462,9 +451,6 @@ FindLinearScale(CGFloat size, CGFloat fixedSize)
 {
 	CGSize sizePoint = [CCDirector sharedDirector].viewSize;
 	CGSize fixed = [CCDirector sharedDirector].designSize;
-
-	CCLOG(@"view size %dx%d", (int)sizePoint.width, (int)sizePoint.height);
-    CCLOG(@"fixed %dx%d", (int)fixed.width, (int)fixed.height);
 
 	// Half of the extra size that will be cut off
 	CGPoint offset = ccpMult(ccp(fixed.width - sizePoint.width, fixed.height - sizePoint.height), 0.5);

--- a/cocos2d/Platforms/Android/CCActivity.m
+++ b/cocos2d/Platforms/Android/CCActivity.m
@@ -19,6 +19,7 @@
 #import "CCGLView.h"
 #import "CCScene.h"
 #import <android/looper.h>
+#import "CCPackageManager.h"
 
 #define USE_MAIN_THREAD 0 // enable to run on OpenGL/Cocos2D on the android main thread
 
@@ -277,8 +278,14 @@ FindLinearScale(CGFloat size, CGFloat fixedSize)
         {
             [self setupFixedScreenMode];
         }
+        else
+        {
+            [self setupFlexibleScreenMode];
+        }
         
         [[CCPackageManager sharedManager] loadPackages];
+
+
 
         [director runWithScene:[self startScene]];
         [director setAnimationInterval:1.0/60.0];
@@ -287,6 +294,27 @@ FindLinearScale(CGFloat size, CGFloat fixedSize)
         [_gameLoop runUntilDate:[NSDate distantFuture]];
 #endif
     }
+}
+
+- (void)setupFlexibleScreenMode
+{
+    CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector sharedDirector];
+    
+    NSInteger device = [[CCConfiguration sharedConfiguration] runningDevice];
+    BOOL tablet = device == CCDeviceiPad || device == CCDeviceiPadRetinaDisplay;
+
+    if(tablet && [_cocos2dSetupConfig[CCSetupTabletScale2X] boolValue])
+    {    
+        // Set the UI scale factor to show things at "native" size.
+        director.UIScaleFactor = 0.5;
+
+        // Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
+        [[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
+    }
+    
+    director.contentScaleFactor *= 1.83;
+
+    [director setProjection:CCDirectorProjection2D];
 }
 
 - (void)setupFixedScreenMode

--- a/cocos2d/Platforms/Android/CCDirectorAndroid.m
+++ b/cocos2d/Platforms/Android/CCDirectorAndroid.m
@@ -75,9 +75,13 @@
                                                    GLKMatrix4MakePerspective(CC_DEGREES_TO_RADIANS(60), (float)sizePoint.width/sizePoint.height, 0.1f, zeye*2),
                                                    GLKMatrix4MakeTranslation(-sizePoint.width/2.0, -sizePoint.height/2, -zeye)
                                                    );
+            break;
+        }
             
+        case CCDirectorProjectionCustom:
+			if( [_delegate respondsToSelector:@selector(updateProjection)] )
+				_projectionMatrix = [_delegate updateProjection];
 			break;
-		}
             
 		default:
 			CCLOG(@"cocos2d: Director: unrecognized projection");
@@ -98,17 +102,6 @@
     
 	NSThread *thread = [self runningThread];
 	[self performSelector:@selector(drawScene) onThread:thread withObject:nil waitUntilDone:YES];
-}
-
-// overriden, don't call super
--(void) reshapeProjection:(CGSize)size
-{
-	_winSizeInPixels = size;
-	_winSizeInPoints = CGSizeMake(size.width/__ccContentScaleFactor, size.height/__ccContentScaleFactor);
-	
-	[self setProjection:_projection];
-    
-    [self.runningScene viewDidResizeTo: _winSizeInPoints];
 }
 
 -(void)end

--- a/cocos2d/Platforms/Android/CCGLView.m
+++ b/cocos2d/Platforms/Android/CCGLView.m
@@ -20,7 +20,7 @@
 #import "CCTouchAndroid.h"
 #import <CoreGraphics/CGGeometry.h>
 
-#define IPHONE3G_WIDTH 320.0f
+//const CGSize FIXED_SIZE = {568, 384};
 
 static NSMutableDictionary *touches = nil;
 static CCTouchEvent *currentEvent = nil;
@@ -517,7 +517,9 @@ static inline void logConfig(EGLDisplay display, EGLConfig conf) {
         NSLog(@"eglQuerySurface() returned error %d", eglGetError());
         return NO;
     }
-    
+
+	CCLOG(@"cocos2d: surface size: %dx%d", (int)width, (int)height);
+
     switch (_screenMode)
     {
         case CCNativeScreenMode:
@@ -533,7 +535,7 @@ static inline void logConfig(EGLDisplay display, EGLConfig conf) {
             if (width > height)
                 size = CGSizeMake(height, width);
             
-            _contentScaleFactor = size.width / IPHONE3G_WIDTH;
+            _contentScaleFactor = size.width / 586;
             
             width /= _contentScaleFactor;
             height /= _contentScaleFactor;

--- a/cocos2d/Platforms/Android/CCGLView.m
+++ b/cocos2d/Platforms/Android/CCGLView.m
@@ -20,7 +20,7 @@
 #import "CCTouchAndroid.h"
 #import <CoreGraphics/CGGeometry.h>
 
-//const CGSize FIXED_SIZE = {568, 384};
+static const CGSize FIXED_SIZE = {586, 384};
 
 static NSMutableDictionary *touches = nil;
 static CCTouchEvent *currentEvent = nil;
@@ -535,7 +535,7 @@ static inline void logConfig(EGLDisplay display, EGLConfig conf) {
             if (width > height)
                 size = CGSizeMake(height, width);
             
-            _contentScaleFactor = size.width / 586;
+            _contentScaleFactor = size.width / FIXED_SIZE.width;
             
             width /= _contentScaleFactor;
             height /= _contentScaleFactor;
@@ -549,11 +549,6 @@ static inline void logConfig(EGLDisplay display, EGLConfig conf) {
             
     }
     
-//    ANativeWindow_setBuffersGeometry(window, width, height, format);
-    
-    if(eglGetError() != EGL_SUCCESS) { NSLog(@"EGL ERROR: %i", eglGetError()); };
-    
-//    eglSwapInterval(_eglDisplay, 0.016667);
     
     if(eglGetError() != EGL_SUCCESS) { NSLog(@"EGL ERROR: %i", eglGetError()); };
     

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -99,7 +99,10 @@ const CGSize FIXED_SIZE = {568, 384};
 {
 	CGSize sizePoint = [CCDirector sharedDirector].viewSize;
 	CGSize fixed = [CCDirector sharedDirector].designSize;
-	
+
+    CCLOG(@"view size %dx%d", (int)sizePoint.width, (int)sizePoint.height);
+    CCLOG(@"fixed %dx%d", (int)fixed.width, (int)fixed.height);
+
 	// Half of the extra size that will be cut off
 	CGPoint offset = ccpMult(ccp(fixed.width - sizePoint.width, fixed.height - sizePoint.height), 0.5);
 	
@@ -203,42 +206,10 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	[director setView:ccview];
 	
 	if([config[CCSetupScreenMode] isEqual:CCScreenModeFixed]){
-		CGSize size = [CCDirector sharedDirector].viewSizeInPixels;
-		CGSize fixed = FIXED_SIZE;
-		
-		if([config[CCSetupScreenOrientation] isEqualToString:CCScreenOrientationPortrait]){
-			CC_SWAP(fixed.width, fixed.height);
-		}
-		
-		// Find the minimal power-of-two scale that covers both the width and height.
-		CGFloat scaleFactor = MIN(FindPOTScale(size.width, fixed.width), FindPOTScale(size.height, fixed.height));
-		
-		director.contentScaleFactor = scaleFactor;
-		director.UIScaleFactor = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 1.0 : 0.5);
-		
-		// Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
-		[[CCFileUtils sharedFileUtils] setiPadContentScaleFactor: 2.0];
-		
-		director.designSize = fixed;
-		[director setProjection:CCDirectorProjectionCustom];
-	} else {
-		// Setup tablet scaling if it was requested.
-		if(
-			UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
-			[config[CCSetupTabletScale2X] boolValue]
-		){
-			// Set the director to use 2 points per pixel.
-			director.contentScaleFactor *= 2.0;
-			
-			// Set the UI scale factor to show things at "native" size.
-			director.UIScaleFactor = 0.5;
-			
-			// Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
-			[[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
-		}
-		
-		[director setProjection:CCDirectorProjection2D];
-	}
+        [self setupFixedScreenMode:config director:director];
+    } else {
+        [self setupFlexibleScreenMode:config director:director];
+    }
 	
 	// Default texture format for PNG/BMP/TIFF/JPEG/GIF images
 	// It can be RGBA8888, RGBA4444, RGB5_A1, RGB565
@@ -259,13 +230,55 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	
 	// set the Navigation Controller as the root view controller
 	[window_ setRootViewController:navController_];
-
-	[[CCPackageManager sharedManager] loadPackages];
-
+	
 	// make main window visible
 	[window_ makeKeyAndVisible];
     
     [self forceOrientation];
+
+	[[CCPackageManager sharedManager] loadPackages];
+}
+
+- (void)setupFlexibleScreenMode:(NSDictionary *)config director:(CCDirectorIOS *)director
+{
+// Setup tablet scaling if it was requested.
+    if(
+			UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+			[config[CCSetupTabletScale2X] boolValue]
+		){
+			// Set the director to use 2 points per pixel.
+			director.contentScaleFactor *= 2.0;
+
+			// Set the UI scale factor to show things at "native" size.
+			director.UIScaleFactor = 0.5;
+
+			// Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
+			[[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
+		}
+
+    [director setProjection:CCDirectorProjection2D];
+}
+
+- (void)setupFixedScreenMode:(NSDictionary *)config director:(CCDirectorIOS *)director
+{
+    CGSize size = [CCDirector sharedDirector].viewSizeInPixels;
+    CGSize fixed = FIXED_SIZE;
+
+    if([config[CCSetupScreenOrientation] isEqualToString:CCScreenOrientationPortrait]){
+			CC_SWAP(fixed.width, fixed.height);
+		}
+
+    // Find the minimal power-of-two scale that covers both the width and height.
+    CGFloat scaleFactor = MIN(FindPOTScale(size.width, fixed.width), FindPOTScale(size.height, fixed.height));
+
+    director.contentScaleFactor = scaleFactor;
+    director.UIScaleFactor = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 1.0 : 0.5);
+
+    // Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
+    [[CCFileUtils sharedFileUtils] setiPadContentScaleFactor: 2.0];
+
+    director.designSize = fixed;
+    [director setProjection:CCDirectorProjectionCustom];
 }
 
 // iOS8 hack around orientation bug
@@ -309,7 +322,6 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	if([CCDirector sharedDirector].animating) {
 		[[CCDirector sharedDirector] stopAnimation];
 	}
-	[[CCPackageManager sharedManager] savePackages];
 }
 
 -(void) applicationWillEnterForeground:(UIApplication*)application
@@ -317,6 +329,7 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	if([CCDirector sharedDirector].animating == NO) {
 		[[CCDirector sharedDirector] startAnimation];
 	}
+	[[CCPackageManager sharedManager] savePackages];
 }
 
 // application will be killed

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -100,9 +100,6 @@ const CGSize FIXED_SIZE = {568, 384};
 	CGSize sizePoint = [CCDirector sharedDirector].viewSize;
 	CGSize fixed = [CCDirector sharedDirector].designSize;
 
-    CCLOG(@"view size %dx%d", (int)sizePoint.width, (int)sizePoint.height);
-    CCLOG(@"fixed %dx%d", (int)fixed.width, (int)fixed.height);
-
 	// Half of the extra size that will be cut off
 	CGPoint offset = ccpMult(ccp(fixed.width - sizePoint.width, fixed.height - sizePoint.height), 0.5);
 	
@@ -230,31 +227,29 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	
 	// set the Navigation Controller as the root view controller
 	[window_ setRootViewController:navController_];
+    
+    [[CCPackageManager sharedManager] loadPackages];
 	
 	// make main window visible
 	[window_ makeKeyAndVisible];
     
     [self forceOrientation];
-
-	[[CCPackageManager sharedManager] loadPackages];
 }
 
 - (void)setupFlexibleScreenMode:(NSDictionary *)config director:(CCDirectorIOS *)director
 {
-// Setup tablet scaling if it was requested.
-    if(
-			UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
-			[config[CCSetupTabletScale2X] boolValue]
-		){
-			// Set the director to use 2 points per pixel.
-			director.contentScaleFactor *= 2.0;
+    // Setup tablet scaling if it was requested.
+    if(	UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&	[config[CCSetupTabletScale2X] boolValue] )
+    {
+        // Set the director to use 2 points per pixel.
+        director.contentScaleFactor *= 2.0;
 
-			// Set the UI scale factor to show things at "native" size.
-			director.UIScaleFactor = 0.5;
+        // Set the UI scale factor to show things at "native" size.
+        director.UIScaleFactor = 0.5;
 
-			// Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
-			[[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
-		}
+        // Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
+        [[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
+    }
 
     [director setProjection:CCDirectorProjection2D];
 }
@@ -322,6 +317,7 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	if([CCDirector sharedDirector].animating) {
 		[[CCDirector sharedDirector] stopAnimation];
 	}
+	[[CCPackageManager sharedManager] savePackages];
 }
 
 -(void) applicationWillEnterForeground:(UIApplication*)application
@@ -329,7 +325,6 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
 	if([CCDirector sharedDirector].animating == NO) {
 		[[CCDirector sharedDirector] startAnimation];
 	}
-	[[CCPackageManager sharedManager] savePackages];
 }
 
 // application will be killed

--- a/cocos2d/Support/CCFileUtils.h
+++ b/cocos2d/Support/CCFileUtils.h
@@ -163,7 +163,7 @@ typedef NS_ENUM(NSUInteger, CCFileUtilsSearchMode) {
  */
 @property (nonatomic, readwrite, copy) NSMutableDictionary *filenameLookup;
 
-#if __CC_PLATFORM_IOS
+#if __CC_PLATFORM_IOS || __CC_PLATFORM_ANDROID
 /** 
  *  The iPhone RetinaDisplay suffixes to load resources.
  *  By default it is "-hd" and "" in that order.

--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -394,7 +394,7 @@ static CCFileUtils *fileUtils = nil;
 	// XXX XXX Super Slow
 	for( NSString *key in dictionary) {
 		NSString *value = [dictionary objectForKey:key];
-		if( [value isEqualToString:k]) {
+		if( [value isEqualToString:k] ) {
 			
 #if __CC_PLATFORM_IOS || __CC_PLATFORM_ANDROID
 			// XXX Add this in a Dictionary

--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -213,7 +213,6 @@ static CCFileUtils *fileUtils = nil;
 - (void) buildSearchResolutionsOrder
 {
 	NSInteger device = [[CCConfiguration sharedConfiguration] runningDevice];
-    
 	[_searchResolutionsOrder removeAllObjects];
 	
 #if __CC_PLATFORM_IOS || __CC_PLATFORM_ANDROID
@@ -395,7 +394,7 @@ static CCFileUtils *fileUtils = nil;
 	// XXX XXX Super Slow
 	for( NSString *key in dictionary) {
 		NSString *value = [dictionary objectForKey:key];
-		if( [value isEqualToString:k] ) {
+		if( [value isEqualToString:k]) {
 			
 #if __CC_PLATFORM_IOS || __CC_PLATFORM_ANDROID
 			// XXX Add this in a Dictionary
@@ -681,7 +680,7 @@ static CCFileUtils *fileUtils = nil;
 	}
 }
 
-#if __CC_PLATFORM_IOS
+#if __CC_PLATFORM_IOS || __CC_PLATFORM_ANDROID
 
 -(void) setiPadRetinaDisplaySuffix:(NSString *)suffix
 {


### PR DESCRIPTION
This review adds the same functionality as exists on iOS for sprite builder's fixed and flexible layouts on android platform.

Note: I'm not happy with the magic `1.83` in CCActivity#setupFlexibleScreenMode - it's mentioned in the Device Resolution document and is the best fit after some experimentation. Ideally there would be a programatically derived scaling solution, but i'm unsure what to scale against.

Devices Tested
- Galaxy S4 GT-I9505G
- Tab 4 SM-T900
- Galaxy Note GT-N5110
- Galaxy S2 SGH-T989
- Kindle Fire HDX 8.9
