### PR TITLE
support for Mac OS X Retina displays

### DIFF
--- a/cocos2d/CCConfiguration.m
+++ b/cocos2d/CCConfiguration.m
@@ -233,9 +233,8 @@ static char * glExtensions;
 	}
 	
 #elif __CC_PLATFORM_MAC
-	
-	// XXX: Add here support for Mac Retina Display
-	return CCDeviceMac;
+    CCDirectorMac *dir = (CCDirectorMac *)[CCDirectorMac sharedDirector];
+    return dir.deviceContentScaleFactor == 1.0 ? CCDeviceMac : CCDeviceMacRetinaDisplay;
 	
 #endif // __CC_PLATFORM_MAC
 	

--- a/cocos2d/Platforms/Mac/CCDirectorMac.h
+++ b/cocos2d/Platforms/Mac/CCDirectorMac.h
@@ -71,6 +71,10 @@ enum  {
 
 @property (nonatomic, readwrite) CGSize originalWinSizeInPoints;
 
+/** returns the real device content scale factor
+ */
+@property (nonatomic, readonly) CGFloat deviceContentScaleFactor;
+
 /* Sets the view in fullscreen or window mode */
 - (void) setFullScreen:(BOOL)fullscreen;
 

--- a/cocos2d/Platforms/Mac/CCDirectorMac.m
+++ b/cocos2d/Platforms/Mac/CCDirectorMac.m
@@ -206,6 +206,16 @@
 		}
 }
 
+- (CGFloat)deviceContentScaleFactor {
+    if (self.view) {
+        NSRect backingBounds = [self.view convertRectToBacking:[self.view bounds]];
+        
+        return backingBounds.size.width / self.view.bounds.size.width;
+    }
+    
+    return 1.0;
+}
+
 -(int) resizeMode
 {
 	return _resizeMode;

--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -41,6 +41,7 @@ NSString * const CCFileUtilsSuffixiPhone5 = @"iphone5";
 NSString * const CCFileUtilsSuffixiPhone5HD = @"iphone5hd";
 NSString * const CCFileUtilsSuffixMac = @"mac";
 NSString * const CCFileUtilsSuffixMacHD = @"machd";
+NSString * const CCFileUtilsSuffix2x = @"2x";
 
 NSString * const kCCFileUtilsDefaultSearchPath = @"";
 
@@ -179,6 +180,7 @@ static CCFileUtils *fileUtils = nil;
 		_suffixesDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
 						 @"", CCFileUtilsSuffixMac,
 						 @"-machd", CCFileUtilsSuffixMacHD,
+						 @"@2x", CCFileUtilsSuffix2x,
 						 @"", CCFileUtilsSuffixDefault,
 						 nil];
 		
@@ -272,6 +274,7 @@ static CCFileUtils *fileUtils = nil;
 #elif __CC_PLATFORM_MAC
 	if (device == CCDeviceMacRetinaDisplay)
 	{
+		[_searchResolutionsOrder addObject:CCFileUtilsSuffix2x];
 		[_searchResolutionsOrder addObject:CCFileUtilsSuffixMacHD];
 		[_searchResolutionsOrder addObject:CCFileUtilsSuffixMac];
 	}
@@ -418,8 +421,10 @@ static CCFileUtils *fileUtils = nil;
 				return 1.0*_macContentScaleFactor;
 			if( [key isEqualToString:CCFileUtilsSuffixMacHD] )
 				return 2.0*_macContentScaleFactor;
+			if( [key isEqualToString:CCFileUtilsSuffix2x] )
+				return 2.0*_macContentScaleFactor;
 			if( [key isEqualToString:CCFileUtilsSuffixDefault] )
-				return 1.0;
+				return 1.0*_macContentScaleFactor;
 #endif // __CC_PLATFORM_MAC
 		}
 	}


### PR DESCRIPTION
Add retina support for Mac OS X. This is needed in order to merge in [SpriteBuilder #705](https://github.com/spritebuilder/SpriteBuilder/issues/705)
