### PR TITLE
Swift fixes for v3.4 (actions: sequence, spawn / physics: joint, shape)

### DIFF
--- a/cocos2d/CCActionInterval.h
+++ b/cocos2d/CCActionInterval.h
@@ -211,6 +211,7 @@
  *  @return New action sequence.
  */
 + (id)actionWithArray: (NSArray*) arrayOfActions;
+- (id)initWithArray:(NSArray*)arrayOfActions;
 
 // purposefully undocumented: no point in having this documented if you can just create a list/array with 2 actions
 + (id)actionOne:(CCActionFiniteTime*)actionOne two:(CCActionFiniteTime*)actionTwo;
@@ -326,6 +327,7 @@
  *  @see CCActionSequence
  */
 + (id)actionWithArray:(NSArray*)arrayOfActions;
+- (id)actionWithArray:(NSArray*)arrayOfActions;
 
 // purposefully undocumented: no point in having this documented if you can just create a list/array with 2 actions
 + (id)actionOne:(CCActionFiniteTime*)one two:(CCActionFiniteTime*)two;

--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -155,6 +155,11 @@
 	
 	return prev;
 }
+-(id) initWithArray:(NSArray *)actions
+{
+    // this is backwards because it's "safer" as a quick Swift fix for v3.4
+    return [CCActionSequence actionWithArray:actions];
+}
 
 +(id) actionOne: (CCActionFiniteTime*) one two: (CCActionFiniteTime*) two
 {
@@ -417,6 +422,11 @@
 		prev = [self actionOne:prev two:[actions objectAtIndex:i]];
 
 	return prev;
+}
+-(id) initWithArray: (NSArray*) actions
+{
+    // this is backwards because it's "safer" as a quick Swift fix for v3.4
+    return [CCActionSpawn actionWithArray:actions];
 }
 
 +(id) actionOne: (CCActionFiniteTime*) one two: (CCActionFiniteTime*) two

--- a/cocos2d/CCPhysicsJoint.h
+++ b/cocos2d/CCPhysicsJoint.h
@@ -54,6 +54,10 @@ A CCPhysicsJoint connects two CCPhysicsBody objects together, like a joint betwe
 +(CCPhysicsJoint *)connectedPivotJointWithBodyA:(CCPhysicsBody *)bodyA
                                           bodyB:(CCPhysicsBody *)bodyB
                                         anchorA:(CGPoint)anchorA;
+// needed for Swift
+-(CCPhysicsJoint *)initWithPivotJointWithBodyA:(CCPhysicsBody *)bodyA
+                                         bodyB:(CCPhysicsBody *)bodyB
+                                       anchorA:(CGPoint)anchorA;
 
 /// -----------------------------------------------------------------------
 /// @name Creating Distance Joints
@@ -76,6 +80,11 @@ A CCPhysicsJoint connects two CCPhysicsBody objects together, like a joint betwe
                                              bodyB:(CCPhysicsBody *)bodyB
                                            anchorA:(CGPoint)anchorA
                                            anchorB:(CGPoint)anchorB;
+// needed for Swift
+-(CCPhysicsJoint *)initWithDistanceJointWithBodyA:(CCPhysicsBody *)bodyA
+                                            bodyB:(CCPhysicsBody *)bodyB
+                                          anchorA:(CGPoint)anchorA
+                                          anchorB:(CGPoint)anchorB;
 
 /**
  *  Creates and returns a pivot joint between the two bodies and keeps the distance of the two anchor points within the range.
@@ -97,6 +106,13 @@ A CCPhysicsJoint connects two CCPhysicsBody objects together, like a joint betwe
                                            anchorB:(CGPoint)anchorB
                                        minDistance:(CGFloat)min
                                        maxDistance:(CGFloat)max;
+// needed for Swift
+-(CCPhysicsJoint *)initWithDistanceJointWithBodyA:(CCPhysicsBody *)bodyA
+                                            bodyB:(CCPhysicsBody *)bodyB
+                                          anchorA:(CGPoint)anchorA
+                                          anchorB:(CGPoint)anchorB
+                                      minDistance:(CGFloat)min
+                                      maxDistance:(CGFloat)max;
 
 /// -----------------------------------------------------------------------
 /// @name Creating Spring Joints
@@ -124,6 +140,14 @@ A CCPhysicsJoint connects two CCPhysicsBody objects together, like a joint betwe
                                       restLength:(CGFloat)restLength
                                        stiffness:(CGFloat)stiffness
                                          damping:(CGFloat)damping;
+// needed for Swift
+-(CCPhysicsJoint *)initWithSpringJointWithBodyA:(CCPhysicsBody *)bodyA
+                                          bodyB:(CCPhysicsBody *)bodyB
+                                        anchorA:(CGPoint)anchorA
+                                        anchorB:(CGPoint)anchorB
+                                     restLength:(CGFloat)restLength
+                                      stiffness:(CGFloat)stiffness
+                                        damping:(CGFloat)damping;
 
 /**
  *  Creates and returns a rotary spring joint between the two bodies. 
@@ -143,6 +167,12 @@ A CCPhysicsJoint connects two CCPhysicsBody objects together, like a joint betwe
                                              restAngle:(CGFloat)restAngle
                                              stiffness:(CGFloat)stiffness
                                                damping:(CGFloat)damping;
+// needed for Swift
+-(CCPhysicsJoint *)initWithRotarySpringJointWithBodyA:(CCPhysicsBody *)bodyA
+                                                bodyB:(CCPhysicsBody *)bodyB
+                                            restAngle:(CGFloat)restAngle
+                                            stiffness:(CGFloat)stiffness
+                                              damping:(CGFloat)damping;
 
 
 // This method was misspelled. Please change "stifness" to "stiffness".
@@ -167,6 +197,10 @@ A CCPhysicsJoint connects two CCPhysicsBody objects together, like a joint betwe
 +(CCPhysicsJoint *)connectedMotorJointWithBodyA:(CCPhysicsBody *)bodyA
                                           bodyB:(CCPhysicsBody *)bodyB
                                            rate:(CGFloat)rate;
+// needed for Swift
+-(CCPhysicsJoint *)initWithMotorJointWithBodyA:(CCPhysicsBody *)bodyA
+                                         bodyB:(CCPhysicsBody *)bodyB
+                                          rate:(CGFloat)rate;
 
 
 /// -----------------------------------------------------------------------
@@ -189,6 +223,11 @@ A CCPhysicsJoint connects two CCPhysicsBody objects together, like a joint betwe
                                                 bodyB:(CCPhysicsBody *)bodyB
                                                   min:(CGFloat)min
                                                   max:(CGFloat)max;
+// needed for Swift
+-(CCPhysicsJoint *)initWithRotaryLimitJointWithBodyA:(CCPhysicsBody *)bodyA
+                                               bodyB:(CCPhysicsBody *)bodyB
+                                                 min:(CGFloat)min
+                                                 max:(CGFloat)max;
 
 
 /// -----------------------------------------------------------------------
@@ -212,6 +251,11 @@ A CCPhysicsJoint connects two CCPhysicsBody objects together, like a joint betwe
                                             bodyB:(CCPhysicsBody *)bodyB
                                             phase:(CGFloat)phase
                                           ratchet:(CGFloat)ratchet;
+// needed for Swift
+-(CCPhysicsJoint *)initWithRatchetJointWithBodyA:(CCPhysicsBody *)bodyA
+                                           bodyB:(CCPhysicsBody *)bodyB
+                                           phase:(CGFloat)phase
+                                         ratchet:(CGFloat)ratchet;
 
 /// -----------------------------------------------------------------------
 /// @name Removing a Physics Joint

--- a/cocos2d/CCPhysicsJoint.m
+++ b/cocos2d/CCPhysicsJoint.m
@@ -99,6 +99,10 @@
 	
 	return joint;
 }
+-(CCPhysicsJoint *)initWithPivotJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB anchorA:(CGPoint)anchorA
+{
+    return [CCPhysicsJoint connectedPivotJointWithBodyA:bodyA bodyB:bodyB anchorA:anchorA];
+}
 
 +(CCPhysicsJoint *)connectedDistanceJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
 										   anchorA:(CGPoint)anchorA anchorB:(CGPoint)anchorB
@@ -110,6 +114,11 @@
 	[joint addToPhysicsNode:bodyA.physicsNode];
 	
 	return joint;
+}
+-(CCPhysicsJoint *)initWithDistanceJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
+                                           anchorA:(CGPoint)anchorA anchorB:(CGPoint)anchorB
+{
+    return [CCPhysicsJoint connectedDistanceJointWithBodyA:bodyA bodyB:bodyB anchorA:anchorA anchorB:anchorB];
 }
 
 +(CCPhysicsJoint *)connectedDistanceJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
@@ -124,6 +133,12 @@
 	
 	return joint;
 }
+-(CCPhysicsJoint *)initWithDistanceJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
+                                          anchorA:(CGPoint)anchorA anchorB:(CGPoint)anchorB
+                                      minDistance:(CGFloat)min maxDistance:(CGFloat)max
+{
+    return [CCPhysicsJoint connectedDistanceJointWithBodyA:bodyA bodyB:bodyB anchorA:anchorA anchorB:anchorB minDistance:min maxDistance:max];
+}
 
 +(CCPhysicsJoint *)connectedSpringJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
 										 anchorA:(CGPoint)anchorA anchorB:(CGPoint)anchorB
@@ -137,6 +152,12 @@
 	
 	
 	return joint;
+}
+-(CCPhysicsJoint *)initWithSpringJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
+                                        anchorA:(CGPoint)anchorA anchorB:(CGPoint)anchorB
+                                     restLength:(CGFloat)restLength stiffness:(CGFloat)stiffness damping:(CGFloat)damping
+{
+    return [CCPhysicsJoint connectedSpringJointWithBodyA:bodyA bodyB:bodyB anchorA:anchorA anchorB:anchorB restLength:restLength stiffness:stiffness damping:damping];
 }
 
 
@@ -161,6 +182,13 @@
     [joint addToPhysicsNode:bodyA.physicsNode];
     return joint;
 }
+-(CCPhysicsJoint *)initWithRotarySpringJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
+                                            restAngle:(CGFloat)restAngle
+                                            stiffness:(CGFloat)stiffness
+                                              damping:(CGFloat)damping
+{
+    return [CCPhysicsJoint connectedRotarySpringJointWithBodyA:bodyA bodyB:bodyB restAngle:restAngle stiffness:stiffness damping:damping];
+}
 
 
 +(CCPhysicsJoint *)connectedMotorJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
@@ -172,6 +200,10 @@
 	[bodyB addJoint:joint];
     [joint addToPhysicsNode:bodyA.physicsNode];
     return joint;
+}
+-(CCPhysicsJoint *)initWithMotorJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB rate:(CGFloat)rate
+{
+    return [CCPhysicsJoint connectedMotorJointWithBodyA:bodyA bodyB:bodyB rate:rate];
 }
 
 
@@ -187,6 +219,10 @@
     [joint addToPhysicsNode:bodyA.physicsNode];
     return joint;
 }
+-(CCPhysicsJoint *)initWithRotaryLimitJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB min:(cpFloat)min max:(cpFloat)max
+{
+    return [CCPhysicsJoint connectedRotaryLimitJointWithBodyA:bodyA bodyB:bodyB min:min max:max];
+}
 
 
 +(CCPhysicsJoint *)connectedRatchetJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
@@ -199,6 +235,12 @@
 	[bodyB addJoint:joint];
     [joint addToPhysicsNode:bodyA.physicsNode];
     return joint;
+}
+-(CCPhysicsJoint *)initWithRatchetJointWithBodyA:(CCPhysicsBody *)bodyA bodyB:(CCPhysicsBody *)bodyB
+                                           phase:(cpFloat)phase
+                                         ratchet:(cpFloat)ratchet
+{
+    return [CCPhysicsJoint connectedRatchetJointWithBodyA:bodyA bodyB:bodyB phase:phase ratchet:ratchet];
 }
 
 

--- a/cocos2d/CCPhysicsShape.h
+++ b/cocos2d/CCPhysicsShape.h
@@ -50,6 +50,8 @@ Using simple shapes instead of composite ones can make collision handling code s
 *  @return The CCPhysicsShape Object.
 */
 +(CCPhysicsShape *)circleShapeWithRadius:(CGFloat)radius center:(CGPoint)center;
+// needed for Swift
+-(CCPhysicsShape *)initWithCircleShapeWithRadius:(CGFloat)radius center:(CGPoint)center;
 
 /**
  *  Creates and returns a physics box shape with rounded corners.
@@ -60,6 +62,8 @@ Using simple shapes instead of composite ones can make collision handling code s
  *  @return The CCPhysicsShape Object.
  */
 +(CCPhysicsShape *)rectShape:(CGRect)rect cornerRadius:(CGFloat)cornerRadius;
+// needed for Swift
+-(CCPhysicsShape *)initWithRectShape:(CGRect)rect cornerRadius:(CGFloat)cornerRadius;
 
 /**
  *  Creates and returns a pill shaped physics shape with rounded corners that stretches from 'start' to 'end'.
@@ -71,6 +75,8 @@ Using simple shapes instead of composite ones can make collision handling code s
  *  @return The CCPhysicsShape Object.
  */
 +(CCPhysicsShape *)pillShapeFrom:(CGPoint)from to:(CGPoint)to cornerRadius:(CGFloat)cornerRadius;
+// needed for Swift
+-(CCPhysicsShape *)initWithPillShapeFrom:(CGPoint)from to:(CGPoint)to cornerRadius:(CGFloat)cornerRadius;
 
 /**
  *  Creates and returns a convex polygon physics shape with rounded corners. 
@@ -89,6 +95,8 @@ Using simple shapes instead of composite ones can make collision handling code s
  *  @see [Definition: Convex vs Concave](http://en.wikipedia.org/wiki/Convex_and_concave_polygons)
  */
 +(CCPhysicsShape *)polygonShapeWithPoints:(CGPoint *)points count:(NSUInteger)count cornerRadius:(CGFloat)cornerRadius;
+// needed for Swift
+-(CCPhysicsShape *)initWithPolygonShapeWithPoints:(CGPoint *)points count:(NSUInteger)count cornerRadius:(CGFloat)cornerRadius;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCPhysicsShape.m
+++ b/cocos2d/CCPhysicsShape.m
@@ -65,20 +65,36 @@
 {
 	return [[CCPhysicsCircleShape alloc] initWithRadius:radius center:center];
 }
+-(CCPhysicsShape *)initWithCircleShapeWithRadius:(CGFloat)radius center:(CGPoint)center
+{
+    return [[CCPhysicsCircleShape alloc] initWithRadius:radius center:center];
+}
 
 +(CCPhysicsShape *)rectShape:(CGRect)rect cornerRadius:(CGFloat)cornerRadius
 {
 	return [[CCPhysicsPolyShape alloc] initWithRect:rect cornerRadius:cornerRadius];
+}
+-(CCPhysicsShape *)initWithRectShape:(CGRect)rect cornerRadius:(CGFloat)cornerRadius
+{
+    return [[CCPhysicsPolyShape alloc] initWithRect:rect cornerRadius:cornerRadius];
 }
 
 +(CCPhysicsShape *)pillShapeFrom:(CGPoint)from to:(CGPoint)to cornerRadius:(CGFloat)cornerRadius
 {
 	return [[CCPhysicsSegmentShape alloc] initFrom:from to:to cornerRadius:cornerRadius];
 }
+-(CCPhysicsShape *)initWithPillShapeFrom:(CGPoint)from to:(CGPoint)to cornerRadius:(CGFloat)cornerRadius
+{
+    return [[CCPhysicsSegmentShape alloc] initFrom:from to:to cornerRadius:cornerRadius];
+}
 
 +(CCPhysicsShape *)polygonShapeWithPoints:(CGPoint *)points count:(NSUInteger)count cornerRadius:(CGFloat)cornerRadius
 {
 	return [[CCPhysicsPolyShape alloc] initWithPolygonFromPoints:points count:count cornerRadius:cornerRadius];
+}
+-(CCPhysicsShape *)initWithPolygonShapeWithPoints:(CGPoint *)points count:(NSUInteger)count cornerRadius:(CGFloat)cornerRadius
+{
+    return [[CCPhysicsPolyShape alloc] initWithPolygonFromPoints:points count:count cornerRadius:cornerRadius];
 }
 
 -(cpTransform)shapeTransform

--- a/cocos2d/cocos2d.h
+++ b/cocos2d/cocos2d.h
@@ -130,7 +130,7 @@
 #import "OALSimpleAudio.h"
 
 // Retiring
-//#import "CCAnimation.h"
+#import "CCAnimation.h" // put this back for v3.4 because it's still in use, and would otherwise be unavailable to Swift
 //#import "CCAnimationCache.h"
 //#import "CCActionManager.h"
 //#import "ccFPSImages.h"


### PR DESCRIPTION
Mainly exposing "initWith" in the header files so Swift bridging picks them up where the +(id) initializer isn't properly named.
