### PR TITLE
Fix package manager tests

### DIFF
--- a/UnitTests/CCActionTest.m
+++ b/UnitTests/CCActionTest.m
@@ -10,9 +10,9 @@
 #import "cocos2d.h"
 #import "CCAction.h"
 
-@interface CCActionBaseTest : XCTestCase @end
+@interface CCActionTestBase : XCTestCase @end
 
-@implementation CCActionBaseTest
+@implementation CCActionTestBase
 
 const float accuracy = 1e-4;
 
@@ -43,7 +43,7 @@ CCNode *node;
 
 @end
 
-@interface CCActionGeneralTest : CCActionBaseTest  @end
+@interface CCActionGeneralTest : CCActionTestBase  @end
 
 @implementation CCActionGeneralTest
 
@@ -176,7 +176,7 @@ CCNode *node;
 @end
 
 
-@interface CCActionReuseTest : CCActionBaseTest @end
+@interface CCActionReuseTest : CCActionTestBase @end
 
 @implementation CCActionReuseTest
 
@@ -345,7 +345,7 @@ CCNode *node;
 
 @end
 
-@interface CCActionInstantTest : CCActionBaseTest @end
+@interface CCActionInstantTest : CCActionTestBase @end
 
 @implementation CCActionInstantTest
 

--- a/UnitTests/CCMemoryTests.m
+++ b/UnitTests/CCMemoryTests.m
@@ -48,13 +48,13 @@
 - (void)testPhysicsBodyRetainCycle1
 {
 	CCNode *node = [[CCNode alloc] init];
-	XCTAssert(node.retainCount == 1, @"");
+	XCTAssertEqual(1, node.retainCount, @"");
 	
 	node.physicsBody = [CCPhysicsBody bodyWithCircleOfRadius:1 andCenter:CGPointZero];
-	XCTAssert(node.retainCount == 1, @"");
+	XCTAssertEqual(1, node.retainCount, @"");
 	
 	node.physicsBody = nil;
-	XCTAssert(node.retainCount == 1, @"");
+	XCTAssertEqual(1, node.retainCount, @"");
 	
 	[node release];
 }
@@ -65,10 +65,10 @@
 	CCPhysicsNode *physics;
 	@autoreleasepool {
 		node = [[CCMemoryNode alloc] init];
-		XCTAssert(node.retainCount == 1, @"");
+		XCTAssertEqual(1, node.retainCount, @"");
 		
 		node.physicsBody = [CCPhysicsBody bodyWithCircleOfRadius:1 andCenter:CGPointZero];
-		XCTAssert(node.retainCount == 1, @"");
+		XCTAssertEqual(1, node.retainCount, @"");
 		
 		physics = [CCPhysicsNode node];
 		[physics onEnter];
@@ -77,9 +77,12 @@
 		XCTAssert(node.retainCount > 1, @"");
 		
 		[physics removeChild:node];
+
+#warning Explicitly calling cleanup wasn't necessary in develop. Currently required to unschedule the physics node, which is causing an extra retain.
+        [physics cleanup];
 	}
-	XCTAssert(node.retainCount == 1, @"");
-	XCTAssert(physics.retainCount == 1, @"");
+	XCTAssertEqual(1, node.retainCount, @"");
+	XCTAssertEqual(1, physics.retainCount, @"");
 	
 	[physics release];
 	[node release];

--- a/UnitTests/CCPackageDownloadManagerTests.m
+++ b/UnitTests/CCPackageDownloadManagerTests.m
@@ -70,9 +70,8 @@
     [super setUp];
 
     [(AppController *)[UIApplication sharedApplication].delegate configureCocos2d];
+    // Stop the normal cocos2d main loop from happening during the tests. We will step it manually.
     [[CCDirector sharedDirector] stopAnimation];
-    // Spin the runloop a bit otherwise nondeterministic exceptions are thrown in the CCScheduler.
-    [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeInterval:0.2 sinceDate:[NSDate date]]];
 
     [NSURLProtocol registerClass:[CCPackageDownloadManagerTestURLProtocol class]];
 

--- a/UnitTests/CCPackageDownloadTests.m
+++ b/UnitTests/CCPackageDownloadTests.m
@@ -133,10 +133,9 @@ static BOOL __support_range_request = YES;
     [super setUp];
 
     [(AppController *)[UIApplication sharedApplication].delegate configureCocos2d];
+    // Stop the normal cocos2d main loop from happening during the tests. We will step it manually.
     [[CCDirector sharedDirector] stopAnimation];
-    // Spin the runloop a bit otherwise nondeterministic exceptions are thrown in the CCScheduler.
-    [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeInterval:0.2 sinceDate:[NSDate date]]];
-
+    
     [NSURLProtocol registerClass:[CCPackageDownloadTestURLProtocol class]];
 
     self.downloadPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"Downloads"];

--- a/UnitTests/CCPackageManagerTests.m
+++ b/UnitTests/CCPackageManagerTests.m
@@ -95,8 +95,9 @@ static NSString *const PACKAGE_BASE_URL = @"http://manager.test";
     [super setUp];
 
     [(AppController *)[UIApplication sharedApplication].delegate configureCocos2d];
+    // Stop the normal cocos2d main loop from happening during the tests. We will step it manually.
     [[CCDirector sharedDirector] stopAnimation];
-
+    
     self.packageManager = [[CCPackageManager alloc] init];
     _packageManager.delegate = self;
 

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -144,8 +144,8 @@
 	
 	[self pushScene:scene];
 
-	NSThread *thread = [self runningThread];
-	[self performSelector:@selector(drawScene) onThread:thread withObject:nil waitUntilDone:YES];
+    [self drawScene];
+    [self startAnimation];
 }
 
 -(void) reshapeProjection:(CGSize)newViewSize
@@ -223,7 +223,7 @@
 {
 	[super viewWillAppear:animated];
 
-    // This line was presumably added to deadl with apps entering and leaving the background.
+    // This line was presumably added to deal with apps entering and leaving the background.
     // ViewWillAppear is called many times on application launch (7 times for the unit tests) and it's also called
     // by the OS outside of normal control, so it's very hard to actually call stopAnimation and expect it to work.
 //    [self startAnimationIfPossible];

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -223,7 +223,10 @@
 {
 	[super viewWillAppear:animated];
 
-    [self startAnimationIfPossible];
+    // This line was presumably added to deadl with apps entering and leaving the background.
+    // ViewWillAppear is called many times on application launch (7 times for the unit tests) and it's also called
+    // by the OS outside of normal control, so it's very hard to actually call stopAnimation and expect it to work.
+//    [self startAnimationIfPossible];
 }
 
 -(void) viewDidAppear:(BOOL)animated
@@ -306,6 +309,9 @@
 
 -(void) mainLoop:(id)sender
 {
+    if(!_animating)
+        return;
+    
 	[self drawScene];
 }
 


### PR DESCRIPTION
These commits include some general cleanup and fixes to a few tests, but most notably for the PackageManager tests.

These tests rely on waiting for stuff scheduled on the cocos2d game loop, such as downloading packages. Unfortunately, waiting on the main loop causes the xcode unit tests to try to do their normal drawing code. This happens without a properly set up gl context.

There was already code that was attempting to call `stopAnimation`, which stops the normal draw loop, but it wasn't working on my system due to the xcode unit testing system making repeated calls to `viewWillAppear`, which keeps restarting the animation loop. CCDirectorIOS has been modified to prevent that behavior, and starts the main loop in a better place. While this could have detrimental side effects in weird situations, it does seem to work well for unit tests, actual normal app runs, and suspending and resuming the app. Furthermore, the V4 director code is scheduled for a rewrite, so this is a good time for a temporary fix.
