### PR TITLE
Scrolling fix on Android (handle only events inside CCScrollView)

### DIFF
--- a/cocos2d-ui/CCScrollView.m
+++ b/cocos2d-ui/CCScrollView.m
@@ -847,11 +847,23 @@
     return phase;
 }
 
+- (BOOL)isEventInNode:(AndroidMotionEvent *)event
+{
+	float scaleFactor = [[CCDirector sharedDirector] view].contentScaleFactor;
+	CGPoint location = ccp(event.x/scaleFactor, event.y/scaleFactor);
+	location = [[CCDirector sharedDirector] convertToGL:location];
+	location = [self convertToNodeSpace:location];
+	return CGRectContainsPoint(self.boundingBox, location) ? YES : NO;
+}
+
 - (BOOL)onScroll:(AndroidMotionEvent *)start end:(AndroidMotionEvent *)end distanceX:(float)dx distanceY:(float)dy
 {
     _isPanning = YES;
     _velocity = CGPointZero;
-    
+	
+	if (![self isEventInNode:start])
+		return NO;
+	
     // Note about start and end events: We will get a CCTouchPhaseBegan for the start event, followed by CCTouchPhaseMoved in the end event
     CCTouchPhase phase = [self handleGestureEvent:start end:end];
     
@@ -922,7 +934,10 @@
 - (BOOL)onFling:(AndroidMotionEvent *)start end:(AndroidMotionEvent *)end velocityX:(float)vx velocityY:(float)vy
 {
     static CGPoint rawTranslationFling;
-
+	
+	if (![self isEventInNode:start])
+		return NO;
+	
     CCTouchPhase phase = [self handleGestureEvent:start end:end];
     
     if(phase == CCTouchPhaseCancelled || phase == CCTouchPhaseEnded)

--- a/cocos2d/Platforms/Android/CCGLView.m
+++ b/cocos2d/Platforms/Android/CCGLView.m
@@ -463,13 +463,13 @@ static inline void logConfig(EGLDisplay display, EGLConfig conf) {
     
     _eglConfiguration = configs[0];
     
-    logConfig(_eglDisplay, _eglConfiguration);
-
     if(!eglChooseConfig(_eglDisplay, configAttribs, &_eglConfiguration, 1, &numConfigs))
     {
         NSLog(@"eglChooseConfig() returned error %d", eglGetError());
         return NO;
     }
+
+    logConfig(_eglDisplay, _eglConfiguration);
 
     if(eglGetError() != EGL_SUCCESS) { NSLog(@"EGL ERROR: %i", eglGetError()); };
     


### PR DESCRIPTION
I found a problem with CCScrollView on Android devices: it is scrolling even if I tap&move outside of scrollview bounds. I'm not an Android professional (just trying to build and run my project on Android), so maybe my solution isn't the best. In my case it solves this situation.

Also there's a small change in Platforms/Android/CCGLView.m where I moved logConfig() after eglChooseConfig(). The problem was, that it first logged EGL values, than changed them (especially EGL_DEPTH_SIZE and EGL_STENCIL_SIZE). The logs were misleading.
