### PR TITLE
Annotate designated initializers for improved Swift Support

### DIFF
--- a/cocos2d/CCActionCatmullRom.h
+++ b/cocos2d/CCActionCatmullRom.h
@@ -104,7 +104,7 @@ extern "C" {
  *  @return New point array.
  *  @see arrayWithCapacity:
  */
-- (id)initWithCapacity:(NSUInteger)capacity;
+- (id)initWithCapacity:(NSUInteger)capacity NS_DESIGNATED_INITIALIZER;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCLabelBMFont.h
+++ b/cocos2d/CCLabelBMFont.h
@@ -100,7 +100,7 @@
  *  @return The CCLabelBMFont Object.
  *  @see CCTextAlignment
  */
-+(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment imageOffset:(CGPoint)offset;
++(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment imageOffset:(CGPoint)offset NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Initializes and returns a label object using the specified text and font file values.

--- a/cocos2d/CCNodeColor.h
+++ b/cocos2d/CCNodeColor.h
@@ -77,7 +77,7 @@
  *  @return An initialized CCNodeColor Object.
  *  @see CCColor
  */
--(id) initWithColor:(CCColor*)color width:(GLfloat)w height:(GLfloat)h;
+-(id) initWithColor:(CCColor*)color width:(GLfloat)w height:(GLfloat)h NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Creates a node with color. Width and height are the window size.

--- a/cocos2d/CCProgressNode.h
+++ b/cocos2d/CCProgressNode.h
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSUInteger, CCProgressNodeType) {
  *  @return An initialized CCProgressNode Object.
  *  @see CCSprite
  */
--(id)initWithSprite:(CCSprite*) sprite;
+-(id)initWithSprite:(CCSprite*) sprite NS_DESIGNATED_INITIALIZER;
 
 /// -----------------------------------------------------------------------
 /// @name Changing Progress Behavior

--- a/cocos2d/CCSprite.h
+++ b/cocos2d/CCSprite.h
@@ -166,7 +166,7 @@ typedef struct CCSpriteTexCoordSet {
  *  @return A newly initialized CCSprite object.
  *  @see CCTexture
  */
-- (id)initWithTexture:(CCTexture *)texture rect:(CGRect)rect rotated:(BOOL)rotated;
+- (id)initWithTexture:(CCTexture *)texture rect:(CGRect)rect rotated:(BOOL)rotated NS_DESIGNATED_INITIALIZER;
 
 /// -----------------------------------------------------------------------
 /// @name Creating a Sprite with a CGImage

--- a/cocos2d/CCSpriteBatchNode.h
+++ b/cocos2d/CCSpriteBatchNode.h
@@ -79,7 +79,7 @@ __attribute__((deprecated))
  *  @return An initialized CCSpriteBatchNode Object.
  *  @see CCTexture
  */
--(id)initWithTexture:(CCTexture *)tex capacity:(NSUInteger)capacity;
+-(id)initWithTexture:(CCTexture *)tex capacity:(NSUInteger)capacity NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Creates and returns a batch node with the specified texture and capacity values.


### PR DESCRIPTION
Swift requires subclasses to call a designated initializer of the superclass. Calls to convenience initializers within the superclass will be sent to the subclass; if the subclass does not implement all initializers of the superclass an exception will be thrown (more info here: http://www.codeproject.com/Articles/783584/Subclassing-Objective-C-classes-in-Swift-and-the-p)

Marking the designated initializers will emit a compiler error if a subclass does not call the designated initializer of the superclass; this is preferable to a runtime exception.

I have annotated all initializers that were documented as designated initializers.
