### PR TITLE
Fixed incorrectly capitalized references to ccMacros.h.

### DIFF
--- a/cocos2d-ui/Platform/Mac/CCPlatformTextFieldMac.h
+++ b/cocos2d-ui/Platform/Mac/CCPlatformTextFieldMac.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import "CCMacros.h"
+#import "ccMacros.h"
 
 #if __CC_PLATFORM_MAC
 

--- a/cocos2d/CCResponder.h
+++ b/cocos2d/CCResponder.h
@@ -29,7 +29,7 @@
 
 #import <Foundation/Foundation.h>
 #import "CCResponderManager.h"
-#import "CCMacros.h"
+#import "ccMacros.h"
 
 /**
   CCResponder is the base class for all nodes.

--- a/cocos2d/Platforms/Android/CCActivity.h
+++ b/cocos2d/Platforms/Android/CCActivity.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Apportable. All rights reserved.
 //
 
-#import "CCMacros.h"
+#import "ccMacros.h"
 #if __CC_PLATFORM_ANDROID
 
 #import <GLActivityKit/GLActivity.h>

--- a/cocos2d/Platforms/Android/CCGestureListener.h
+++ b/cocos2d/Platforms/Android/CCGestureListener.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import "CCMacros.h"
+#import "ccMacros.h"
 #if __CC_PLATFORM_ANDROID
 
 #import <GLActivityKit/GLGestureListener.h>


### PR DESCRIPTION
# import "CCMacros.h" was causing build errors on case-sensitive file systems -- changed to ccMacros.h so that  the compiler can find the file.
