### PR TITLE
Stop excluding audio from android.

### DIFF
--- a/cocos2d/CCActionInstant.m
+++ b/cocos2d/CCActionInstant.m
@@ -386,9 +386,7 @@
 
 - (void)update:(CCTime)time
 {
-#if __CC_PLATFORM_IOS || __CC_PLATFORM_MAC
     [[OALSimpleAudio sharedInstance] playEffect:_soundFile volume:_gain pitch:_pitch pan:_pan loop:NO];
-#endif
 }
 
 - (id)copyWithZone:(NSZone*)zone


### PR DESCRIPTION
This PR is designed to resolve https://github.com/spritebuilder/SpriteBuilder/issues/988 

Currently this method is conditionally compiled for mac and iOS only - this method has been tested to work on Android also with the latest ObjectAL submodules in cocos2d. With this method enabled, it is possible to queue and activate sound effects from within spritebuilder.
