### PR TITLE
Use 'instancetype' for factory methods to improve Swift support

### DIFF
--- a/cocos2d/CCAction.m
+++ b/cocos2d/CCAction.m
@@ -41,7 +41,7 @@
 
 @synthesize tag = _tag, target = _target, originalTarget = _originalTarget;
 
-+(id) action
++(instancetype) action
 {
 	return [[self alloc] init];
 }
@@ -121,7 +121,7 @@
 #pragma mark RepeatForever
 @implementation CCActionRepeatForever
 @synthesize innerAction=_innerAction;
-+(id) actionWithAction: (CCActionInterval*) action
++(instancetype) actionWithAction: (CCActionInterval*) action
 {
 	return [[self alloc] initWithAction: action];
 }
@@ -181,7 +181,7 @@
 @synthesize speed=_speed;
 @synthesize innerAction=_innerAction;
 
-+(id) actionWithAction: (CCActionInterval*) action speed:(CGFloat)value
++(instancetype) actionWithAction: (CCActionInterval*) action speed:(CGFloat)value
 {
 	return [[self alloc] initWithAction: action speed:value];
 }
@@ -239,12 +239,12 @@
 
 @synthesize boundarySet = _boundarySet;
 
-+(id) actionWithTarget:(CCNode *) fNode
++(instancetype) actionWithTarget:(CCNode *) fNode
 {
 	return [[self alloc] initWithTarget:fNode];
 }
 
-+(id) actionWithTarget:(CCNode *) fNode worldBoundary:(CGRect)rect
++(instancetype) actionWithTarget:(CCNode *) fNode worldBoundary:(CGRect)rect
 {
 	return [[self alloc] initWithTarget:fNode worldBoundary:rect];
 }

--- a/cocos2d/CCActionCatmullRom.m
+++ b/cocos2d/CCActionCatmullRom.m
@@ -43,7 +43,7 @@
 
 @synthesize controlPoints = _controlPoints;
 
-+(id) arrayWithCapacity:(NSUInteger)capacity
++(instancetype) arrayWithCapacity:(NSUInteger)capacity
 {
 	return [[self alloc] initWithCapacity:capacity];
 }
@@ -186,7 +186,7 @@ inline CGPoint CCCardinalSplineAt( CGPoint p0, CGPoint p1, CGPoint p2, CGPoint p
 
 @synthesize points=_points;
 
-+(id) actionWithDuration:(CCTime)duration points:(CCPointArray *)points tension:(CGFloat)tension
++(instancetype) actionWithDuration:(CCTime)duration points:(CCPointArray *)points tension:(CGFloat)tension
 {
 	return [[self alloc] initWithDuration:duration points:points tension:tension ];
 }
@@ -337,7 +337,7 @@ inline CGPoint CCCardinalSplineAt( CGPoint p0, CGPoint p1, CGPoint p2, CGPoint p
 @end
 
 @implementation CCActionCatmullRomTo
-+(id) actionWithDuration:(CCTime)dt points:(CCPointArray *)points
++(instancetype) actionWithDuration:(CCTime)dt points:(CCPointArray *)points
 {
 	return [[self alloc] initWithDuration:dt points:points];
 }
@@ -353,7 +353,7 @@ inline CGPoint CCCardinalSplineAt( CGPoint p0, CGPoint p1, CGPoint p2, CGPoint p
 @end
 
 @implementation CCActionCatmullRomBy
-+(id) actionWithDuration:(CCTime)dt points:(CCPointArray *)points
++(instancetype) actionWithDuration:(CCTime)dt points:(CCPointArray *)points
 {
 	return [[self alloc] initWithDuration:dt points:points];
 }

--- a/cocos2d/CCActionEase.m
+++ b/cocos2d/CCActionEase.m
@@ -46,7 +46,7 @@
 
 @synthesize inner=_inner;
 
-+(id) actionWithAction: (CCActionInterval*) action
++(instancetype) actionWithAction: (CCActionInterval*) action
 {
 	return [[self alloc] initWithAction: action];
 }
@@ -138,7 +138,7 @@
 
 @implementation CCActionEaseRate
 @synthesize rate=_rate;
-+(id) actionWithAction: (CCActionInterval*) action rate:(float)rate
++(instancetype) actionWithAction: (CCActionInterval*) action rate:(float)rate
 {
 	return [[self alloc] initWithAction: action rate:rate];
 }
@@ -209,12 +209,12 @@
 
 @synthesize period = _period;
 
-+(id) actionWithAction: (CCActionInterval*) action
++(instancetype) actionWithAction: (CCActionInterval*) action
 {
 	return [[self alloc] initWithAction:action period:0.3f];
 }
 
-+(id) actionWithAction: (CCActionInterval*) action period:(float)period
++(instancetype) actionWithAction: (CCActionInterval*) action period:(float)period
 {
 	return [[self alloc] initWithAction:action period:period];
 }

--- a/cocos2d/CCActionInstant.h
+++ b/cocos2d/CCActionInstant.h
@@ -351,7 +351,7 @@
  *  @return The sprite frame action object.
  *  @see CCSpriteFrame
  */
-+(id) actionWithSpriteFrame:(CCSpriteFrame*)spriteFrame;
++(instancetype) actionWithSpriteFrame:(CCSpriteFrame*)spriteFrame;
 
 /**
  *  Initializes the action action with the specified sprite frame.
@@ -391,7 +391,7 @@
  @see OALSimpleAudio
  @see [OALSimpleAudio playEffect:volume:pitch:pan:loop:]
  */
-+(id) actionWithSoundFile:(NSString*)file pitch:(float)pitch pan:(float) pan gain:(float)gain;
++(instancetype) actionWithSoundFile:(NSString*)file pitch:(float)pitch pan:(float) pan gain:(float)gain;
 
 /**
  Creates a sound effect action.

--- a/cocos2d/CCActionInstant.m
+++ b/cocos2d/CCActionInstant.m
@@ -139,7 +139,7 @@
 #pragma mark CCFlipX
 
 @implementation CCActionFlipX
-+(id) actionWithFlipX:(BOOL)x
++(instancetype) actionWithFlipX:(BOOL)x
 {
 	return [[self alloc] initWithFlipX:x];
 }
@@ -175,7 +175,7 @@
 #pragma mark CCFlipY
 
 @implementation CCActionFlipY
-+(id) actionWithFlipY:(BOOL)y
++(instancetype) actionWithFlipY:(BOOL)y
 {
 	return [[self alloc] initWithFlipY:y];
 }
@@ -212,7 +212,7 @@
 #pragma mark CCPlace
 
 @implementation CCActionPlace
-+(id) actionWithPosition: (CGPoint) pos
++(instancetype) actionWithPosition: (CGPoint) pos
 {
 	return [[self alloc]initWithPosition:pos];
 }
@@ -247,7 +247,7 @@
 
 @synthesize targetCallback = _targetCallback;
 
-+(id) actionWithTarget: (id) t selector:(SEL) s
++(instancetype) actionWithTarget: (id) t selector:(SEL) s
 {
 	return [[self alloc] initWithTarget: t selector: s];
 }
@@ -301,7 +301,7 @@
 
 @implementation CCActionCallBlock
 
-+(id) actionWithBlock:(void(^)())block
++(instancetype) actionWithBlock:(void(^)())block
 {
 	return [[self alloc] initWithBlock:block];
 }

--- a/cocos2d/CCActionInterval.h
+++ b/cocos2d/CCActionInterval.h
@@ -1032,7 +1032,7 @@ typedef struct _ccBezierConfig {
   @return New animation action
   @see CCAnimation
 */
-+(id) actionWithAnimation:(CCAnimation*)animation;
++(instancetype) actionWithAnimation:(CCAnimation*)animation;
 
 /**
   Initializes the action with an Animation.

--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -49,7 +49,7 @@
 	return nil;
 }
 
-+(id) actionWithDuration: (CCTime) d
++(instancetype) actionWithDuration: (CCTime) d
 {
 	return [[self alloc] initWithDuration:d ];
 }
@@ -117,7 +117,7 @@
 //
 #pragma mark - CCSequence
 @implementation CCActionSequence
-+(id) actions: (CCActionFiniteTime*) action1, ...
++(instancetype) actions: (CCActionFiniteTime*) action1, ...
 {
 	va_list args;
 	va_start(args, action1);
@@ -129,7 +129,7 @@
 	return  ret;
 }
 
-+(id) actions: (CCActionFiniteTime*) action1 vaList:(va_list)args
++(instancetype) actions: (CCActionFiniteTime*) action1 vaList:(va_list)args
 {
 	CCActionFiniteTime *now;
 	CCActionFiniteTime *prev = action1;
@@ -146,7 +146,7 @@
 }
 
 
-+(id) actionWithArray: (NSArray*) actions
++(instancetype) actionWithArray: (NSArray*) actions
 {
 	CCActionFiniteTime *prev = [actions objectAtIndex:0];
 	
@@ -161,7 +161,7 @@
     return [CCActionSequence actionWithArray:actions];
 }
 
-+(id) actionOne: (CCActionFiniteTime*) one two: (CCActionFiniteTime*) two
++(instancetype) actionOne: (CCActionFiniteTime*) one two: (CCActionFiniteTime*) two
 {
 	return [[self alloc] initOne:one two:two ];
 }
@@ -282,7 +282,7 @@
 @implementation CCActionRepeat
 @synthesize innerAction=_innerAction;
 
-+(id) actionWithAction:(CCActionFiniteTime*)action times:(NSUInteger)times
++(instancetype) actionWithAction:(CCActionFiniteTime*)action times:(NSUInteger)times
 {
 	return [[self alloc] initWithAction:action times:times];
 }
@@ -386,7 +386,7 @@
 #pragma mark - CCSpawn
 
 @implementation CCActionSpawn
-+(id) actions: (CCActionFiniteTime*) action1, ...
++(instancetype) actions: (CCActionFiniteTime*) action1, ...
 {
 	va_list args;
 	va_start(args, action1);
@@ -397,7 +397,7 @@
 	return ret;
 }
 
-+(id) actions: (CCActionFiniteTime*) action1 vaList:(va_list)args
++(instancetype) actions: (CCActionFiniteTime*) action1 vaList:(va_list)args
 {
 	CCActionFiniteTime *now;
 	CCActionFiniteTime *prev = action1;
@@ -414,7 +414,7 @@
 }
 
 
-+(id) actionWithArray: (NSArray*) actions
++(instancetype) actionWithArray: (NSArray*) actions
 {
 	CCActionFiniteTime *prev = [actions objectAtIndex:0];
 
@@ -429,7 +429,7 @@
     return [CCActionSpawn actionWithArray:actions];
 }
 
-+(id) actionOne: (CCActionFiniteTime*) one two: (CCActionFiniteTime*) two
++(instancetype) actionOne: (CCActionFiniteTime*) one two: (CCActionFiniteTime*) two
 {
 	return [[self alloc] initOne:one two:two ];
 }
@@ -499,12 +499,12 @@
 
 @implementation CCActionRotateTo
 
-+(id) actionWithDuration: (CCTime) t angle:(float) a
++(instancetype) actionWithDuration: (CCTime) t angle:(float) a
 {
 	return [[self alloc] initWithDuration:t angle:a simple:NO];
 }
 
-+(id) actionWithDuration: (CCTime) t angle:(float) a simple:(bool)simple
++(instancetype) actionWithDuration: (CCTime) t angle:(float) a simple:(bool)simple
 {
 	return [[self alloc] initWithDuration:t angle:a simple:simple];
 }
@@ -524,7 +524,7 @@
 	return self;
 }
 
-+(id) actionWithDuration: (CCTime) t angleX:(float) aX angleY:(float) aY
++(instancetype) actionWithDuration: (CCTime) t angleX:(float) aX angleY:(float) aY
 {
 	return [[self alloc] initWithDuration:t angleX:aX angleY:aY ];
 }
@@ -540,7 +540,7 @@
 	return self;
 }
 
-+(id) actionWithDuration: (CCTime) t angleX:(float) aX
++(instancetype) actionWithDuration: (CCTime) t angleX:(float) aX
 {
 	return [[self alloc] initWithDuration:t angleX:aX];
 }
@@ -554,7 +554,7 @@
 	return self;
 }
 
-+(id) actionWithDuration: (CCTime) t angleY:(float) aY
++(instancetype) actionWithDuration: (CCTime) t angleY:(float) aY
 {
 	return [[self alloc] initWithDuration:t angleY:aY];
 }
@@ -648,7 +648,7 @@
 #pragma mark - RotateBy
 
 @implementation CCActionRotateBy
-+(id) actionWithDuration: (CCTime) t angle:(float) a
++(instancetype) actionWithDuration: (CCTime) t angle:(float) a
 {
 	return [[self alloc] initWithDuration:t angle:a ];
 }
@@ -661,7 +661,7 @@
 	return self;
 }
 
-+(id) actionWithDuration: (CCTime) t angleX:(float) aX angleY:(float) aY
++(instancetype) actionWithDuration: (CCTime) t angleX:(float) aX angleY:(float) aY
 {
 	return [[self alloc] initWithDuration:t angleX:aX angleY:aY ];
 }
@@ -716,7 +716,7 @@
 #pragma mark - MoveBy
 
 @implementation CCActionMoveBy
-+(id) actionWithDuration: (CCTime) t position: (CGPoint) p
++(instancetype) actionWithDuration: (CCTime) t position: (CGPoint) p
 {
 	return [[self alloc] initWithDuration:t position:p ];
 }
@@ -769,7 +769,7 @@
 #pragma mark MoveTo
 
 @implementation CCActionMoveTo
-+(id) actionWithDuration: (CCTime) t position: (CGPoint) p
++(instancetype) actionWithDuration: (CCTime) t position: (CGPoint) p
 {
 	return [[self alloc] initWithDuration:t position:p ];
 }
@@ -803,7 +803,7 @@
 #pragma mark - CCSkewTo
 
 @implementation CCActionSkewTo
-+(id) actionWithDuration:(CCTime)t skewX:(float)sx skewY:(float)sy
++(instancetype) actionWithDuration:(CCTime)t skewX:(float)sx skewY:(float)sy
 {
 	return [[self alloc] initWithDuration: t skewX:sx skewY:sy];
 }
@@ -906,7 +906,7 @@
 #pragma mark - CCJumpBy
 
 @implementation CCActionJumpBy
-+(id) actionWithDuration: (CCTime) t position: (CGPoint) pos height: (CCTime) h jumps:(NSUInteger)j
++(instancetype) actionWithDuration: (CCTime) t position: (CGPoint) pos height: (CCTime) h jumps:(NSUInteger)j
 {
 	return [[self alloc] initWithDuration: t position: pos height: h jumps:j];
 }
@@ -1001,7 +1001,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 // BezierBy
 //
 @implementation CCActionBezierBy
-+(id) actionWithDuration: (CCTime) t bezier:(ccBezierConfig) c
++(instancetype) actionWithDuration: (CCTime) t bezier:(ccBezierConfig) c
 {
 	return [[self alloc] initWithDuration:t bezier:c ];
 }
@@ -1103,7 +1103,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 //
 #pragma mark - CCScaleTo
 @implementation CCActionScaleTo
-+(id) actionWithDuration: (CCTime) t scale:(float) s
++(instancetype) actionWithDuration: (CCTime) t scale:(float) s
 {
 	return [[self alloc] initWithDuration: t scale:s];
 }
@@ -1117,7 +1117,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 	return self;
 }
 
-+(id) actionWithDuration: (CCTime) t scaleX:(float)sx scaleY:(float)sy
++(instancetype) actionWithDuration: (CCTime) t scaleX:(float)sx scaleY:(float)sy
 {
 	return [[self alloc] initWithDuration: t scaleX:sx scaleY:sy];
 }
@@ -1184,7 +1184,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 //
 #pragma mark - CCBlink
 @implementation CCActionBlink
-+(id) actionWithDuration: (CCTime) t blinks: (NSUInteger) b
++(instancetype) actionWithDuration: (CCTime) t blinks: (NSUInteger) b
 {
 	return [[ self alloc] initWithDuration: t blinks: b];
 }
@@ -1268,7 +1268,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 //
 #pragma mark - CCFadeTo
 @implementation CCActionFadeTo
-+(id) actionWithDuration: (CCTime) t opacity: (CGFloat) o
++(instancetype) actionWithDuration: (CCTime) t opacity: (CGFloat) o
 {
 	return [[ self alloc] initWithDuration: t opacity: o];
 }
@@ -1304,7 +1304,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 //
 #pragma mark - CCTintTo
 @implementation CCActionTintTo
-+(id) actionWithDuration:(CCTime)duration color:(CCColor*)color
++(instancetype) actionWithDuration:(CCTime)duration color:(CCColor*)color
 {
 	return [(CCActionTintTo*)[ self alloc] initWithDuration:duration color:color];
 }
@@ -1347,7 +1347,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 //
 #pragma mark - CCTintBy
 @implementation CCActionTintBy
-+(id) actionWithDuration:(CCTime)t red:(CGFloat)r green:(CGFloat)g blue:(CGFloat)b
++(instancetype) actionWithDuration:(CCTime)t red:(CGFloat)r green:(CGFloat)g blue:(CGFloat)b
 {
 	return [(CCActionTintBy*)[ self alloc] initWithDuration:t red:r green:g blue:b];
 }
@@ -1412,7 +1412,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 //
 #pragma mark - CCReverseTime
 @implementation CCActionReverse
-+(id) actionWithAction: (CCActionFiniteTime*) action
++(instancetype) actionWithAction: (CCActionFiniteTime*) action
 {
 	// casting to prevent warnings
 	CCActionReverse *a = [self alloc];
@@ -1470,7 +1470,7 @@ static inline CGFloat bezierat( float a, float b, float c, float d, CCTime t )
 
 @synthesize animation = _animation;
 
-+(id) actionWithAnimation: (CCAnimation*)anim
++(instancetype) actionWithAnimation: (CCAnimation*)anim
 {
 	return [[self alloc] initWithAnimation:anim];
 }

--- a/cocos2d/CCActionProgressTimer.m
+++ b/cocos2d/CCActionProgressTimer.m
@@ -28,7 +28,7 @@
 #import "CCActionProgressTimer.h"
 
 @implementation CCActionProgressTo
-+(id) actionWithDuration: (CCTime) t percent: (float) v
++(instancetype) actionWithDuration: (CCTime) t percent: (float) v
 {
 	return [[ self alloc] initWithDuration: t percent: v];
 }
@@ -65,7 +65,7 @@
 @end
 
 @implementation CCActionProgressFromTo
-+(id) actionWithDuration: (CCTime) t from:(float)fromPercentage to:(float) toPercentage
++(instancetype) actionWithDuration: (CCTime) t from:(float)fromPercentage to:(float) toPercentage
 {
 	return [[self alloc] initWithDuration: t from: fromPercentage to: toPercentage];
 }

--- a/cocos2d/CCAnimation.h
+++ b/cocos2d/CCAnimation.h
@@ -120,7 +120,7 @@
  *
  *  @return The CCAnimation Object.
  */
-+(id) animation;
++(instancetype) animation;
 
 /**
  *  Creates and returns an animation object using the specified CCSpriteFrame array value.
@@ -130,7 +130,7 @@
  *
  *  @return The CCAnimation Object.
  */
-+(id) animationWithSpriteFrames:(NSArray*)arrayOfSpriteFrameNames;
++(instancetype) animationWithSpriteFrames:(NSArray*)arrayOfSpriteFrameNames;
 
 /**
  *  Creates and returns an animation object using the specified CCSpriteFrame array and per frame dealy values.
@@ -140,7 +140,7 @@
  *
  *  @return The CCAnimation Object.
  */
-+(id) animationWithSpriteFrames:(NSArray*)arrayOfSpriteFrameNames delay:(float)delay;
++(instancetype) animationWithSpriteFrames:(NSArray*)arrayOfSpriteFrameNames delay:(float)delay;
 
 /**
  *  Creates and returns an animation object using the specified CCSpriteFrame array, per frame delay and times to repeat animation values.
@@ -151,7 +151,7 @@
  *
  *  @return The CCAnimation Object.
  */
-+(id) animationWithAnimationFrames:(NSArray*)arrayOfAnimationFrames delayPerUnit:(float)delayPerUnit loops:(NSUInteger)loops;
++(instancetype) animationWithAnimationFrames:(NSArray*)arrayOfAnimationFrames delayPerUnit:(float)delayPerUnit loops:(NSUInteger)loops;
 
 /**
  *  Initializes and returns an animation object.

--- a/cocos2d/CCAnimation.m
+++ b/cocos2d/CCAnimation.m
@@ -72,22 +72,22 @@
 @implementation CCAnimation
 @synthesize frames = _frames, totalDelayUnits=_totalDelayUnits, delayPerUnit=_delayPerUnit, restoreOriginalFrame=_restoreOriginalFrame, loops=_loops;
 
-+(id) animation
++(instancetype) animation
 {
 	return [[self alloc] init];
 }
 
-+(id) animationWithSpriteFrames:(NSArray*)frames
++(instancetype) animationWithSpriteFrames:(NSArray*)frames
 {
 	return [[self alloc] initWithSpriteFrames:frames];
 }
 
-+(id) animationWithSpriteFrames:(NSArray*)frames delay:(float)delay
++(instancetype) animationWithSpriteFrames:(NSArray*)frames delay:(float)delay
 {
 	return [[self alloc] initWithSpriteFrames:frames delay:delay];
 }
 
-+(id) animationWithAnimationFrames:(NSArray*)arrayOfAnimationFrames delayPerUnit:(float)delayPerUnit loops:(NSUInteger)loops
++(instancetype) animationWithAnimationFrames:(NSArray*)arrayOfAnimationFrames delayPerUnit:(float)delayPerUnit loops:(NSUInteger)loops
 {
 	return [[self alloc] initWithAnimationFrames:arrayOfAnimationFrames delayPerUnit:delayPerUnit loops:loops];
 }

--- a/cocos2d/CCClippingNode.h
+++ b/cocos2d/CCClippingNode.h
@@ -60,7 +60,7 @@
  *  @return The new CCClippingNode instance.
  *  @see clippingNodeWithStencil:
  */
-+(id) clippingNode;
++(instancetype) clippingNode;
 
 /**
  *  Creates and returns a clipping node object with the specified stencil node.
@@ -70,7 +70,7 @@
  *  @return The new CCClippingNode instance.
  *  @see clippingNode
  */
-+(id) clippingNodeWithStencil:(CCNode *)stencil;
++(instancetype) clippingNodeWithStencil:(CCNode *)stencil;
 
 // purposefully undocumented: init is inherited from NSObject
 -(id) init;

--- a/cocos2d/CCEffect.m
+++ b/cocos2d/CCEffect.m
@@ -72,7 +72,7 @@ static NSString* vertBase =
     return self;
 }
 
-+(id)functionWithName:(NSString*)name body:(NSString*)body inputs:(NSArray*)inputs returnType:(NSString*)returnType
++(instancetype)functionWithName:(NSString*)name body:(NSString*)body inputs:(NSArray*)inputs returnType:(NSString*)returnType
 {
     return [[self alloc] initWithName:name body:body inputs:inputs returnType:returnType];
 }
@@ -122,7 +122,7 @@ static NSString* vertBase =
     return self;
 }
 
-+(id)inputWithType:(NSString*)type name:(NSString*)name initialSnippet:(NSString*)initialSnippet snippet:(NSString*)snippet
++(instancetype)inputWithType:(NSString*)type name:(NSString*)name initialSnippet:(NSString*)initialSnippet snippet:(NSString*)snippet
 {
     return [[self alloc] initWithType:type name:name initialSnippet:initialSnippet snippet:snippet];
 }
@@ -147,7 +147,7 @@ static NSString* vertBase =
     return self;
 }
 
-+(id)uniform:(NSString*)type name:(NSString*)name value:(NSValue*)value
++(instancetype)uniform:(NSString*)type name:(NSString*)name value:(NSValue*)value
 {
     return [[self alloc] initWithType:type name:name value:value];
 }
@@ -174,7 +174,7 @@ static NSString* vertBase =
     return self;
 }
 
-+(id)varying:(NSString*)type name:(NSString*)name
++(instancetype)varying:(NSString*)type name:(NSString*)name
 {
     return [[self alloc] initWithType:type name:name];
 }
@@ -193,7 +193,7 @@ static NSString* vertBase =
     return self;
 }
 
-+(id)varying:(NSString*)type name:(NSString*)name count:(NSInteger)count
++(instancetype)varying:(NSString*)type name:(NSString*)name count:(NSInteger)count
 {
     return [[self alloc] initWithType:type name:name count:count];
 }

--- a/cocos2d/CCEffectBloom.h
+++ b/cocos2d/CCEffectBloom.h
@@ -36,7 +36,7 @@
  *  @return The CCEffectBloom object.
  *  @since v3.2 and later
  */
-+(id)effectWithBlurRadius:(NSUInteger)blurRadius intensity:(float)intensity luminanceThreshold:(float)luminanceThreshold;
++(instancetype)effectWithBlurRadius:(NSUInteger)blurRadius intensity:(float)intensity luminanceThreshold:(float)luminanceThreshold;
 
 /**
  *  Initializes a CCEffectBloom object with the following default values:

--- a/cocos2d/CCEffectBloom.m
+++ b/cocos2d/CCEffectBloom.m
@@ -380,7 +380,7 @@
     return self;
 }
 
-+(id)effectWithBlurRadius:(NSUInteger)blurRadius intensity:(float)intensity luminanceThreshold:(float)luminanceThreshold
++(instancetype)effectWithBlurRadius:(NSUInteger)blurRadius intensity:(float)intensity luminanceThreshold:(float)luminanceThreshold
 {
     return [[self alloc] initWithPixelBlurRadius:blurRadius intensity:intensity luminanceThreshold:luminanceThreshold];
 }

--- a/cocos2d/CCEffectBlur.h
+++ b/cocos2d/CCEffectBlur.h
@@ -39,7 +39,7 @@
  *  @return The CCEffectBlur object.
  *  @since v3.2 and later
  */
-+(id)effectWithBlurRadius:(NSUInteger)blurRadius;
++(instancetype)effectWithBlurRadius:(NSUInteger)blurRadius;
 
 /**
  *  Initializes a CCEffectBlur object with the following default parameters:

--- a/cocos2d/CCEffectBlur.m
+++ b/cocos2d/CCEffectBlur.m
@@ -308,7 +308,7 @@
     return self;
 }
 
-+(id)effectWithBlurRadius:(NSUInteger)blurRadius
++(instancetype)effectWithBlurRadius:(NSUInteger)blurRadius
 {
     return [[self alloc] initWithPixelBlurRadius:blurRadius];
 }

--- a/cocos2d/CCEffectBrightness.h
+++ b/cocos2d/CCEffectBrightness.h
@@ -30,7 +30,7 @@
 *  @return The CCEffectBrightness object.
 *  @since v3.2 and later
 */
-+(id)effectWithBrightness:(float)brightness;
++(instancetype)effectWithBrightness:(float)brightness;
 
 /**
  *  Initializes a CCEffectBrightness object with a brightness adjustment of 0.

--- a/cocos2d/CCEffectBrightness.m
+++ b/cocos2d/CCEffectBrightness.m
@@ -93,7 +93,7 @@ static float conditionBrightness(float brightness);
     return self;
 }
 
-+(id)effectWithBrightness:(float)brightness
++(instancetype)effectWithBrightness:(float)brightness
 {
     return [[self alloc] initWithBrightness:brightness];
 }

--- a/cocos2d/CCEffectColorChannelOffset.h
+++ b/cocos2d/CCEffectColorChannelOffset.h
@@ -29,7 +29,7 @@
  *  @since v3.2 and later
  *  @deprecated Use CGPoint version instead.
  */
-+(id)effectWithRedOffset:(GLKVector2)redOffset greenOffset:(GLKVector2)greenOffset blueOffset:(GLKVector2)blueOffset __attribute__((deprecated));
++(instancetype)effectWithRedOffset:(GLKVector2)redOffset greenOffset:(GLKVector2)greenOffset blueOffset:(GLKVector2)blueOffset __attribute__((deprecated));
 
 /**
  *  Creates a CCEffectColorChannelOffset object with the supplied color channel offsets.
@@ -41,7 +41,7 @@
  *  @return The CCEffectColorChannelOffset object.
  *  @since v3.4 and later
  */
-+(id)effectWithRedOffsetWithPoint:(CGPoint)redOffset greenOffsetWithPoint:(CGPoint)greenOffset blueOffsetWithPoint:(CGPoint)blueOffset;
++(instancetype)effectWithRedOffsetWithPoint:(CGPoint)redOffset greenOffsetWithPoint:(CGPoint)greenOffset blueOffsetWithPoint:(CGPoint)blueOffset;
 
 /**
  *  Initializes a CCEffectColorChannelOffset object with zero length color channel offsets.

--- a/cocos2d/CCEffectColorChannelOffset.m
+++ b/cocos2d/CCEffectColorChannelOffset.m
@@ -139,12 +139,12 @@
     return self;
 }
 
-+(id)effectWithRedOffset:(GLKVector2)redOffset greenOffset:(GLKVector2)greenOffset blueOffset:(GLKVector2)blueOffset;
++(instancetype)effectWithRedOffset:(GLKVector2)redOffset greenOffset:(GLKVector2)greenOffset blueOffset:(GLKVector2)blueOffset;
 {
     return [[self alloc] initWithRedOffset:redOffset greenOffset:greenOffset blueOffset:blueOffset];
 }
 
-+(id)effectWithRedOffsetWithPoint:(CGPoint)redOffset greenOffsetWithPoint:(CGPoint)greenOffset blueOffsetWithPoint:(CGPoint)blueOffset
++(instancetype)effectWithRedOffsetWithPoint:(CGPoint)redOffset greenOffsetWithPoint:(CGPoint)greenOffset blueOffsetWithPoint:(CGPoint)blueOffset
 {
     return [[self alloc] initWithRedOffsetWithPoint:redOffset greenOffsetWithPoint:greenOffset blueOffsetWithPoint:blueOffset];
 }

--- a/cocos2d/CCEffectContrast.h
+++ b/cocos2d/CCEffectContrast.h
@@ -29,7 +29,7 @@
 *  @return The CCEffectContrast object.
 *  @since v3.2 and later
 */
-+(id)effectWithContrast:(float)contrast;
++(instancetype)effectWithContrast:(float)contrast;
 
 /**
  *  Initializes a CCEffectContrast object with a contrast adjustment of 0.

--- a/cocos2d/CCEffectContrast.m
+++ b/cocos2d/CCEffectContrast.m
@@ -95,7 +95,7 @@ static float conditionContrast(float contrast);
     return self;
 }
 
-+(id)effectWithContrast:(float)contrast
++(instancetype)effectWithContrast:(float)contrast
 {
     return [[self alloc] initWithContrast:contrast];
 }

--- a/cocos2d/CCEffectDFInnerGlow.h
+++ b/cocos2d/CCEffectDFInnerGlow.h
@@ -37,7 +37,7 @@
 *  @see CCColor
 *  @see CCTexture
 */
-+(id)effectWithGlowColor:(CCColor*)glowColor fillColor:(CCColor*)fillColor glowWidth:(int)glowWidth fieldScale:(float)fieldScale distanceField:(CCTexture*)distanceField;
++(instancetype)effectWithGlowColor:(CCColor*)glowColor fillColor:(CCColor*)fillColor glowWidth:(int)glowWidth fieldScale:(float)fieldScale distanceField:(CCTexture*)distanceField;
 
 /**
  *  Initializes a CCEffectDFInnerGlow.

--- a/cocos2d/CCEffectDFInnerGlow.m
+++ b/cocos2d/CCEffectDFInnerGlow.m
@@ -185,7 +185,7 @@
     return self;
 }
 
-+(id)effectWithGlowColor:(CCColor*)glowColor fillColor:(CCColor*)fillColor glowWidth:(int)glowWidth fieldScale:(float)fieldScale distanceField:(CCTexture*)distanceField
++(instancetype)effectWithGlowColor:(CCColor*)glowColor fillColor:(CCColor*)fillColor glowWidth:(int)glowWidth fieldScale:(float)fieldScale distanceField:(CCTexture*)distanceField
 {
     return [[self alloc] initWithGlowColor:glowColor fillColor:fillColor glowWidth:glowWidth fieldScale:fieldScale distanceField:distanceField];
 }

--- a/cocos2d/CCEffectDFOutline.h
+++ b/cocos2d/CCEffectDFOutline.h
@@ -37,7 +37,7 @@
  *  @see CCColor
  *  @see CCTexture
  */
-+(id)effectWithOutlineColor:(CCColor*)outlineColor fillColor:(CCColor*)fillColor outlineWidth:(int)outlineWidth fieldScale:(float)fieldScale distanceField:(CCTexture*)distanceField;
++(instancetype)effectWithOutlineColor:(CCColor*)outlineColor fillColor:(CCColor*)fillColor outlineWidth:(int)outlineWidth fieldScale:(float)fieldScale distanceField:(CCTexture*)distanceField;
 
 /**
  *  Initializes a CCEffectDFOutline.

--- a/cocos2d/CCEffectDFOutline.m
+++ b/cocos2d/CCEffectDFOutline.m
@@ -152,7 +152,7 @@
     return self;
 }
 
-+(id)effectWithOutlineColor:(CCColor*)outlineColor fillColor:(CCColor*)fillColor outlineWidth:(int)outlineWidth fieldScale:(float)fieldScale distanceField:(CCTexture*)distanceField
++(instancetype)effectWithOutlineColor:(CCColor*)outlineColor fillColor:(CCColor*)fillColor outlineWidth:(int)outlineWidth fieldScale:(float)fieldScale distanceField:(CCTexture*)distanceField
 {
     return [[self alloc] initWithOutlineColor:outlineColor fillColor:fillColor outlineWidth:outlineWidth fieldScale:fieldScale distanceField:distanceField];
 }

--- a/cocos2d/CCEffectDistanceField.h
+++ b/cocos2d/CCEffectDistanceField.h
@@ -31,7 +31,7 @@
  *  @since v3.3 and later
  *  @see CCColor
  */
-+(id)effectWithGlowColor:(CCColor*)glowColor outlineColor:(CCColor*)outlineColor;
++(instancetype)effectWithGlowColor:(CCColor*)glowColor outlineColor:(CCColor*)outlineColor;
 
 /**
  *  Initializes a CCEffectDistanceField object with a (5, -5) black drop shadow offset .

--- a/cocos2d/CCEffectDistanceField.m
+++ b/cocos2d/CCEffectDistanceField.m
@@ -187,7 +187,7 @@
     return self;
 }
 
-+(id)effectWithGlowColor:(CCColor*)glowColor outlineColor:(CCColor*)outlineColor
++(instancetype)effectWithGlowColor:(CCColor*)glowColor outlineColor:(CCColor*)outlineColor
 {
     return [[self alloc] initWithGlowColor:glowColor outlineColor:outlineColor];
 }

--- a/cocos2d/CCEffectDropShadow.h
+++ b/cocos2d/CCEffectDropShadow.h
@@ -30,7 +30,7 @@
  *  @since v3.3 and later
  *  @see CCColor
  */
-+(id)effectWithShadowOffset:(GLKVector2)shadowOffset shadowColor:(CCColor*)shadowColor blurRadius:(NSUInteger)blurRadius;
++(instancetype)effectWithShadowOffset:(GLKVector2)shadowOffset shadowColor:(CCColor*)shadowColor blurRadius:(NSUInteger)blurRadius;
 
 /**
  *  Initializes a CCEffectDropShadow object with a (5, -5) black drop shadow offset .

--- a/cocos2d/CCEffectDropShadow.m
+++ b/cocos2d/CCEffectDropShadow.m
@@ -319,7 +319,7 @@
     return self;
 }
 
-+(id)effectWithShadowOffset:(GLKVector2)shadowOffset shadowColor:(CCColor*)shadowColor blurRadius:(NSUInteger)blurRadius
++(instancetype)effectWithShadowOffset:(GLKVector2)shadowOffset shadowColor:(CCColor*)shadowColor blurRadius:(NSUInteger)blurRadius
 {
     return [[self alloc] initWithShadowOffset:shadowOffset shadowColor:shadowColor blurRadius:blurRadius];
 }

--- a/cocos2d/CCEffectGlass.h
+++ b/cocos2d/CCEffectGlass.h
@@ -34,7 +34,7 @@
  *  @since v3.2 and later
  *  @see CCSprite
  */
-+(id)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment;
++(instancetype)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment;
 
 /**
  *  Creates a CCEffectGlass object with the supplied parameters.
@@ -50,7 +50,7 @@
  *  @see CCSprite
  *  @see CCSpriteFrame
  */
-+(id)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap;
++(instancetype)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap;
 
 /**
  *  Initializes a CCEffectGlass object with the following default parameters:

--- a/cocos2d/CCEffectGlass.m
+++ b/cocos2d/CCEffectGlass.m
@@ -300,12 +300,12 @@ static const float CCEffectGlassDefaultFresnelPower = 2.0f;
     return self;
 }
 
-+(id)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment
++(instancetype)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment
 {
     return [[self alloc] initWithShininess:shininess refraction:refraction refractionEnvironment:refractionEnvironment reflectionEnvironment:reflectionEnvironment];
 }
 
-+(id)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap
++(instancetype)effectWithShininess:(float)shininess refraction:(float)refraction refractionEnvironment:(CCSprite *)refractionEnvironment reflectionEnvironment:(CCSprite *)reflectionEnvironment normalMap:(CCSpriteFrame *)normalMap
 {
     return [[self alloc] initWithShininess:shininess refraction:refraction refractionEnvironment:refractionEnvironment reflectionEnvironment:reflectionEnvironment normalMap:normalMap];
 }

--- a/cocos2d/CCEffectHue.h
+++ b/cocos2d/CCEffectHue.h
@@ -27,7 +27,7 @@
 *  @return The CCEffectHue object.
 *  @since v3.2 and later
 */
-+(id)effectWithHue:(float)hue;
++(instancetype)effectWithHue:(float)hue;
 
 /**
  *  Initializes a CCEffectHue object with a hue adjustment of 0.

--- a/cocos2d/CCEffectHue.m
+++ b/cocos2d/CCEffectHue.m
@@ -97,7 +97,7 @@ static GLKMatrix4 matrixWithHue(float hue);
     return self;
 }
 
-+(id)effectWithHue:(float)hue
++(instancetype)effectWithHue:(float)hue
 {
     return [[self alloc] initWithHue:hue];
 }

--- a/cocos2d/CCEffectInvert.m
+++ b/cocos2d/CCEffectInvert.m
@@ -73,7 +73,7 @@
     return self;
 }
 
-+(id)effect
++(instancetype)effect
 {
     return [[self alloc] init];
 }

--- a/cocos2d/CCEffectLighting.h
+++ b/cocos2d/CCEffectLighting.h
@@ -33,7 +33,7 @@
  *  @since v3.4 and later
  *  @see CCColor
  */
-+(id)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess;
++(instancetype)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess;
 
 /**
  *  Initializes a CCEffectLighting object.

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -371,7 +371,7 @@ static float conditionShininess(float shininess);
 }
 
 
-+(id)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess
++(instancetype)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess
 {
     return [[self alloc] initWithGroups:groups specularColor:specularColor shininess:shininess];
 }

--- a/cocos2d/CCEffectNode.h
+++ b/cocos2d/CCEffectNode.h
@@ -40,7 +40,7 @@
  *
  *  @return An initialized CCRenderTarget object.
  */
-+(id)effectNodeWithWidth:(int)w height:(int)h;
++(instancetype)effectNodeWithWidth:(int)w height:(int)h;
 
 /**
  *  Creates a CCEffectNode object with width and height in Points and a pixel format( only RGB and RGBA formats are valid ) and no depth-stencil buffer.
@@ -52,7 +52,7 @@
  *  @return An initialized CCRenderTarget object.
  *  @see CCTexturePixelFormat
  */
-+(id)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format;
++(instancetype)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format;
 
 /**
  *  Creates a CCEffectNode object with width and height in Points and a pixel format( only RGB and RGBA formats are valid ) and depthStencil format
@@ -65,7 +65,7 @@
  *  @return An initialized CCRenderTarget object.
  *  @see CCTexturePixelFormat
  */
-+(id)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format depthStencilFormat:(GLuint)depthStencilFormat;
++(instancetype)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format depthStencilFormat:(GLuint)depthStencilFormat;
 
 /**
  *  Initializes a CCEffectNode object with the specified parameters.
@@ -75,7 +75,7 @@
  *
  *  @return The CCEffectNode object.
  */
--(id)initWithWidth:(int)w height:(int)h;
+-(instancetype)initWithWidth:(int)w height:(int)h;
 
 /**
  *  Initializes a CCEffectNode object with width and height in Points and a pixel format( only RGB and RGBA formats are valid ) and no depth-stencil buffer.

--- a/cocos2d/CCEffectNode.m
+++ b/cocos2d/CCEffectNode.m
@@ -66,17 +66,17 @@
 	return self;
 }
 
-+(id)effectNodeWithWidth:(int)w height:(int)h
++(instancetype)effectNodeWithWidth:(int)w height:(int)h
 {
     return [[CCEffectNode alloc] initWithWidth:w height:h];
 }
 
-+(id)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format
++(instancetype)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format
 {
     return [[CCEffectNode alloc] initWithWidth:w height:h pixelFormat:format];
 }
 
-+(id)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format depthStencilFormat:(GLuint)depthStencilFormat
++(instancetype)effectNodeWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format depthStencilFormat:(GLuint)depthStencilFormat
 {
     return [[CCEffectNode alloc] initWithWidth:w height:h pixelFormat:format depthStencilFormat:depthStencilFormat];
 }

--- a/cocos2d/CCEffectOutline.h
+++ b/cocos2d/CCEffectOutline.h
@@ -47,7 +47,7 @@
  *  @return The CCEffectOutline object.
  */
 -(id)initWithOutlineColor:(CCColor*)outlineColor outlineWidth:(int)outlineWidth;
-+(id)effectWithOutlineColor:(CCColor*)outlineColor outlineWidth:(int)outlineWidth;
++(instancetype)effectWithOutlineColor:(CCColor*)outlineColor outlineWidth:(int)outlineWidth;
 
 @end
 

--- a/cocos2d/CCEffectOutline.m
+++ b/cocos2d/CCEffectOutline.m
@@ -184,7 +184,7 @@
     return self;
 }
 
-+(id)effectWithOutlineColor:(CCColor*)outlineColor outlineWidth:(int)outlineWidth
++(instancetype)effectWithOutlineColor:(CCColor*)outlineColor outlineWidth:(int)outlineWidth
 {
     return [[self alloc] initWithOutlineColor:outlineColor outlineWidth:outlineWidth];
 }

--- a/cocos2d/CCEffectPixellate.h
+++ b/cocos2d/CCEffectPixellate.h
@@ -26,7 +26,7 @@
  *  @return The CCEffectPixellate object.
  *  @since v3.2 and later
  */
-+(id)effectWithBlockSize:(float)blockSize;
++(instancetype)effectWithBlockSize:(float)blockSize;
 
 /**
  *  Initializes a CCEffectPixellate object with a block size of 1.

--- a/cocos2d/CCEffectPixellate.m
+++ b/cocos2d/CCEffectPixellate.m
@@ -139,7 +139,7 @@ static float conditionBlockSize(float blockSize);
     return self;
 }
 
-+(id)effectWithBlockSize:(float)blockSize
++(instancetype)effectWithBlockSize:(float)blockSize
 {
     return [[self alloc] initWithBlockSize:blockSize];
 }

--- a/cocos2d/CCEffectReflection.h
+++ b/cocos2d/CCEffectReflection.h
@@ -32,7 +32,7 @@
 *  @since v3.2 and later
 *  @see CCSprite
 */
-+(id)effectWithShininess:(float)shininess environment:(CCSprite *)environment;
++(instancetype)effectWithShininess:(float)shininess environment:(CCSprite *)environment;
 
 /**
  *  Creates a CCEffectReflection object with the specified environment and normal map and the following default parameters:
@@ -47,7 +47,7 @@
  *  @see CCSprite
  *  @see CCSpriteFrame
  */
-+(id)effectWithShininess:(float)shininess environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
++(instancetype)effectWithShininess:(float)shininess environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
 
 /**
  *  Creates a CCEffectReflection object with the specified parameters and nil normal map.
@@ -61,7 +61,7 @@
  *  @since v3.2 and later
  *  @see CCSprite
  */
-+(id)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment;
++(instancetype)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment;
 
 /**
  *  Creates a CCEffectReflection object with the specified parameters.
@@ -77,7 +77,7 @@
  *  @see CCSprite
  *  @see CCSpriteFrame
  */
-+(id)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
++(instancetype)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
 
 
 /**

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -232,22 +232,22 @@
     return self;
 }
 
-+(id)effectWithShininess:(float)shininess environment:(CCSprite *)environment
++(instancetype)effectWithShininess:(float)shininess environment:(CCSprite *)environment
 {
     return [[self alloc] initWithShininess:shininess environment:environment];
 }
 
-+(id)effectWithShininess:(float)shininess environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
++(instancetype)effectWithShininess:(float)shininess environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
 {
     return [[self alloc] initWithShininess:shininess environment:environment normalMap:normalMap];
 }
 
-+(id)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment
++(instancetype)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment
 {
     return [[self alloc] initWithShininess:shininess fresnelBias:bias fresnelPower:power environment:environment];
 }
 
-+(id)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
++(instancetype)effectWithShininess:(float)shininess fresnelBias:(float)bias fresnelPower:(float)power environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
 {
     return [[self alloc] initWithShininess:shininess fresnelBias:bias fresnelPower:power environment:environment normalMap:normalMap];
 }

--- a/cocos2d/CCEffectRefraction.h
+++ b/cocos2d/CCEffectRefraction.h
@@ -29,7 +29,7 @@
 *  @since v3.2 and later
 *  @see CCSprite
 */
-+(id)effectWithRefraction:(float)refraction environment:(CCSprite *)environment;
++(instancetype)effectWithRefraction:(float)refraction environment:(CCSprite *)environment;
 
 /**
 *  Creates a CCEffectRefraction object with the supplied parameters.
@@ -43,7 +43,7 @@
  *  @see CCSprite
  *  @see CCSpriteFrame
  */
-+(id)effectWithRefraction:(float)refraction environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
++(instancetype)effectWithRefraction:(float)refraction environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap;
 
 /**
  *  Initializes a CCEffectRefraction object with the following default parameters:

--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -200,12 +200,12 @@
     return self;
 }
 
-+(id)effectWithRefraction:(float)refraction environment:(CCSprite *)environment
++(instancetype)effectWithRefraction:(float)refraction environment:(CCSprite *)environment
 {
     return [[self alloc] initWithRefraction:refraction environment:environment];
 }
 
-+(id)effectWithRefraction:(float)refraction environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
++(instancetype)effectWithRefraction:(float)refraction environment:(CCSprite *)environment normalMap:(CCSpriteFrame *)normalMap
 {
     return [[self alloc] initWithRefraction:refraction environment:environment normalMap:normalMap];
 }

--- a/cocos2d/CCEffectSaturation.h
+++ b/cocos2d/CCEffectSaturation.h
@@ -27,7 +27,7 @@
  *  @return The CCEffectSaturation object.
  *  @since v3.2 and later
  */
-+(id)effectWithSaturation:(float)saturation;
++(instancetype)effectWithSaturation:(float)saturation;
 
 /**
  *  Initializes a CCEffectSaturation object with a saturation adjustment of 0.

--- a/cocos2d/CCEffectSaturation.m
+++ b/cocos2d/CCEffectSaturation.m
@@ -136,7 +136,7 @@ static float conditionSaturation(float saturation);
     return self;
 }
 
-+(id)effectWithSaturation:(float)saturation
++(instancetype)effectWithSaturation:(float)saturation
 {
     return [[self alloc] initWithSaturation:saturation];
 }

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -66,7 +66,7 @@ typedef NS_ENUM(NSUInteger, CCEffectTexCoordMapping)
 @property (nonatomic, readonly) NSString* function;
 
 -(id)initWithName:(NSString*)name body:(NSString*)body inputs:(NSArray*)inputs returnType:(NSString*)returnType;
-+(id)functionWithName:(NSString*)name body:(NSString*)body inputs:(NSArray*)inputs returnType:(NSString*)returnType;
++(instancetype)functionWithName:(NSString*)name body:(NSString*)body inputs:(NSArray*)inputs returnType:(NSString*)returnType;
 
 -(NSString*)callStringWithInputs:(NSArray*)inputs;
 
@@ -80,7 +80,7 @@ typedef NS_ENUM(NSUInteger, CCEffectTexCoordMapping)
 @property (nonatomic, readonly) NSString* snippet;
 
 -(id)initWithType:(NSString*)type name:(NSString*)name initialSnippet:(NSString*)initialSnippet snippet:(NSString*)snippet;
-+(id)inputWithType:(NSString*)type name:(NSString*)name initialSnippet:(NSString*)initialSnippet snippet:(NSString*)snippet;
++(instancetype)inputWithType:(NSString*)type name:(NSString*)name initialSnippet:(NSString*)initialSnippet snippet:(NSString*)snippet;
 
 @end
 
@@ -92,7 +92,7 @@ typedef NS_ENUM(NSUInteger, CCEffectTexCoordMapping)
 @property (nonatomic, readonly) NSValue* value;
 
 -(id)initWithType:(NSString*)type name:(NSString*)name value:(NSValue*)value;
-+(id)uniform:(NSString*)type name:(NSString*)name value:(NSValue*)value;
++(instancetype)uniform:(NSString*)type name:(NSString*)name value:(NSValue*)value;
 
 @end
 
@@ -105,8 +105,8 @@ typedef NS_ENUM(NSUInteger, CCEffectTexCoordMapping)
 
 -(id)initWithType:(NSString*)type name:(NSString*)name;
 -(id)initWithType:(NSString*)type name:(NSString*)name count:(NSInteger)count;
-+(id)varying:(NSString*)type name:(NSString*)name;
-+(id)varying:(NSString*)type name:(NSString*)name count:(NSInteger)count;
++(instancetype)varying:(NSString*)type name:(NSString*)name;
++(instancetype)varying:(NSString*)type name:(NSString*)name count:(NSInteger)count;
 
 @end
 

--- a/cocos2d/CCLabelBMFont.h
+++ b/cocos2d/CCLabelBMFont.h
@@ -73,7 +73,7 @@
  *
  *  @return The CCLabelBMFont Object.
  */
-+(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile;
++(instancetype) labelWithString:(NSString*)string fntFile:(NSString*)fntFile;
 
 /**
  *  Creates and returns a label object using the specified text, font file and alignment values.
@@ -86,7 +86,7 @@
  *  @return The CCLabelBMFont Object.
  *  @see CCTextAlignment
  */
-+(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment;
++(instancetype) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment;
 
 /**
  *  Creates and returns a label object using the specified text, font file, alignment and image offset values.
@@ -100,7 +100,7 @@
  *  @return The CCLabelBMFont Object.
  *  @see CCTextAlignment
  */
-+(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment imageOffset:(CGPoint)offset;
++(instancetype) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment imageOffset:(CGPoint)offset;
 
 /**
  *  Initializes and returns a label object using the specified text and font file values.

--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -95,7 +95,7 @@ void FNTConfigRemoveCache( void )
 @synthesize characterSet=_characterSet;
 @synthesize atlasName=_atlasName;
 
-+(id) configurationWithFNTFile:(NSString*)FNTfile
++(instancetype) configurationWithFNTFile:(NSString*)FNTfile
 {
 	return [[self alloc] initWithFNTfile:FNTfile];
 }
@@ -475,17 +475,17 @@ void FNTConfigRemoveCache( void )
 
 #pragma mark LabelBMFont - Creation & Init
 
-+(id) labelWithString:(NSString *)string fntFile:(NSString *)fntFile
++(instancetype) labelWithString:(NSString *)string fntFile:(NSString *)fntFile
 {
 	return [[self alloc] initWithString:string fntFile:fntFile width:kCCLabelAutomaticWidth alignment:CCTextAlignmentLeft imageOffset:CGPointZero];
 }
 
-+(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment
++(instancetype) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment
 {
     return [[self alloc] initWithString:string fntFile:fntFile width:width alignment:alignment imageOffset:CGPointZero];
 }
 
-+(id) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment imageOffset:(CGPoint)offset
++(instancetype) labelWithString:(NSString*)string fntFile:(NSString*)fntFile width:(float)width alignment:(CCTextAlignment)alignment imageOffset:(CGPoint)offset
 {
     return [[self alloc] initWithString:string fntFile:fntFile width:width alignment:alignment imageOffset:offset];
 }

--- a/cocos2d/CCLabelBMFont_Private.h
+++ b/cocos2d/CCLabelBMFont_Private.h
@@ -134,7 +134,7 @@ typedef struct _KerningHashElement {
 /// -----------------------------------------------------------------------
 
 // Creates and returns a CCBMFontConfiguration object from a specified font file value.
-+(id) configurationWithFNTFile:(NSString*)FNTfile;
++(instancetype) configurationWithFNTFile:(NSString*)FNTfile;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCLabelTTF.h
+++ b/cocos2d/CCLabelTTF.h
@@ -88,7 +88,7 @@
  *
  *  @return The CCLabelTTF Object.
  */
-+(id) labelWithString:(NSString *)string fontName:(NSString *)name fontSize:(CGFloat)size;
++(instancetype) labelWithString:(NSString *)string fontName:(NSString *)name fontSize:(CGFloat)size;
 
 /**
  *  Creates and returns a label object using the specified text, font name, font size and dimensions.
@@ -100,7 +100,7 @@
  *
  *  @return The CCLabelTTF Object.
  */
-+(id) labelWithString:(NSString *)string fontName:(NSString *)name fontSize:(CGFloat)size dimensions:(CGSize)dimensions;
++(instancetype) labelWithString:(NSString *)string fontName:(NSString *)name fontSize:(CGFloat)size dimensions:(CGSize)dimensions;
 
 /**
  *  Initializes and returns a label object using the specified text, font name and font size.
@@ -138,7 +138,7 @@
  *
  *  @return The CCLabelTTF Object.
  */
-+(id) labelWithAttributedString:(NSAttributedString *)attrString;
++(instancetype) labelWithAttributedString:(NSAttributedString *)attrString;
 
 /**
  *  Creates and returns a label object using the specified attributed text and dimensions.
@@ -150,7 +150,7 @@
  *
  *  @return The CCLabelTTF Object.
  */
-+(id) labelWithAttributedString:(NSAttributedString *)attrString dimensions:(CGSize)dimensions;
++(instancetype) labelWithAttributedString:(NSAttributedString *)attrString dimensions:(CGSize)dimensions;
 
 /**
  *  Initializes and returns a label object using the specified attributed text.

--- a/cocos2d/CCLightNode.h
+++ b/cocos2d/CCLightNode.h
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSUInteger, CCLightType)
  *  @see CCLightType
  *  @see CCColor
  */
-+(id)lightWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity;
++(instancetype)lightWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity;
 
 /**
  *  Creates a CCLightNode object with the specified parameters.
@@ -61,7 +61,7 @@ typedef NS_ENUM(NSUInteger, CCLightType)
  *  @see CCLightType
  *  @see CCColor
  */
-+(id)lightWithType:(CCLightType)type
++(instancetype)lightWithType:(CCLightType)type
             groups:(NSArray*)groups
              color:(CCColor *)color
          intensity:(float)intensity

--- a/cocos2d/CCLightNode.m
+++ b/cocos2d/CCLightNode.m
@@ -58,12 +58,12 @@
     return self;
 }
 
-+(id)lightWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity
++(instancetype)lightWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity
 {
     return [[self alloc] initWithType:type groups:groups color:color intensity:intensity];
 }
 
-+(id)lightWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity specularColor:(CCColor *)specularColor specularIntensity:(float)specularIntensity ambientColor:(CCColor *)ambientColor ambientIntensity:(float)ambientIntensity
++(instancetype)lightWithType:(CCLightType)type groups:(NSArray*)groups color:(CCColor *)color intensity:(float)intensity specularColor:(CCColor *)specularColor specularIntensity:(float)specularIntensity ambientColor:(CCColor *)ambientColor ambientIntensity:(float)ambientIntensity
 {
     return [[self alloc] initWithType:type groups:groups color:color intensity:intensity specularColor:specularColor specularIntensity:specularIntensity ambientColor:ambientColor ambientIntensity:ambientIntensity];
 }

--- a/cocos2d/CCMotionStreak.h
+++ b/cocos2d/CCMotionStreak.h
@@ -54,7 +54,7 @@
  *  @return The CCMotionStreak object.
  *  @see CCColor
  */
-+(id)streakWithFade:(float)fade minSeg:(float)minSeg width:(float)stroke color:(CCColor*)color textureFilename:(NSString*)path;
++(instancetype)streakWithFade:(float)fade minSeg:(float)minSeg width:(float)stroke color:(CCColor*)color textureFilename:(NSString*)path;
 
 /**
  *  Creates and returns a motion streak object from the specified fade time, segments, stroke, color and texture values.
@@ -69,7 +69,7 @@
  *  @see CCColor
  *  @see CCTexture
  */
-+(id)streakWithFade:(float)fade minSeg:(float)minSeg width:(float)stroke color:(CCColor*)color texture:(CCTexture*)texture;
++(instancetype)streakWithFade:(float)fade minSeg:(float)minSeg width:(float)stroke color:(CCColor*)color texture:(CCTexture*)texture;
 
 /**
  *  Initializes and returns a motion streak object from the specified fade time, segments, stroke, color and texture file path values.

--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -245,7 +245,7 @@
 /** Creates and returns a new node.
  @note Not all subclasses support initialization via the `node` initializer. Prefer to use specialized initializers
  in CCNode subclasses, where available. */
-+(id) node;
++(instancetype) node;
 
 // purposefully undocumented: init is inherited from NSObject
 -(id) init;

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -137,7 +137,7 @@ static NSUInteger globalOrderOfArrival = 1;
 
 #pragma mark CCNode - Init & cleanup
 
-+(id) node
++(instancetype) node
 {
 	return [[self alloc] init];
 }

--- a/cocos2d/CCNodeColor.h
+++ b/cocos2d/CCNodeColor.h
@@ -55,7 +55,7 @@
  *  @return The CCNodeColor Object.
  *  @see CCColor
  */
-+(id) nodeWithColor: (CCColor*)color width:(GLfloat)w height:(GLfloat)h;
++(instancetype) nodeWithColor: (CCColor*)color width:(GLfloat)w height:(GLfloat)h;
 
 /**
  *  Creates a node with color. Width and height are the window size.
@@ -65,7 +65,7 @@
  *  @return The CCNodeColor Object.
  *  @see CCColor
  */
-+(id) nodeWithColor: (CCColor*)color;
++(instancetype) nodeWithColor: (CCColor*)color;
 
 /**
  *  Creates a node with color, width and height in Points.
@@ -123,7 +123,7 @@
  *  @return The CCNodeGradient Object.
  *  @see CCColor
  */
-+(id)nodeWithColor:(CCColor*)start fadingTo:(CCColor*)end;
++(instancetype)nodeWithColor:(CCColor*)start fadingTo:(CCColor*)end;
 
 /**
  *  Creates a full-screen CCNode with a gradient between start and end color values with gradient direction vector.
@@ -135,7 +135,7 @@
  *  @return The CCNodeGradient Object.
  *  @see CCColor
  */
-+(id)nodeWithColor:(CCColor*)start fadingTo:(CCColor*)end alongVector:(CGPoint)v;
++(instancetype)nodeWithColor:(CCColor*)start fadingTo:(CCColor*)end alongVector:(CGPoint)v;
 
 /**
  *  Creates a full-screen CCNode with a gradient between start and end color values.
@@ -229,7 +229,7 @@
  *
  *  @return The CCNodeMultiplexer object.
  */
-+(id)nodeWithArray:(NSArray*)arrayOfNodes;
++(instancetype)nodeWithArray:(NSArray*)arrayOfNodes;
 
 /* Creates a CCMultiplexLayer with one or more nodes using a variable argument list.
  *  Example: 
@@ -239,7 +239,7 @@
  *  @param ... Nil terminator.
  *  @return The CCNodeMultiplexer object.
  */
-+(id)nodeWithNodes:(CCNode*)node, ... NS_REQUIRES_NIL_TERMINATION;
++(instancetype)nodeWithNodes:(CCNode*)node, ... NS_REQUIRES_NIL_TERMINATION;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCNodeColor.m
+++ b/cocos2d/CCNodeColor.m
@@ -259,12 +259,12 @@
 #pragma mark MultiplexLayer
 
 @implementation CCNodeMultiplexer
-+(id) nodeWithArray:(NSArray *)arrayOfNodes
++(instancetype) nodeWithArray:(NSArray *)arrayOfNodes
 {
 	return [[self alloc] initWithArray:arrayOfNodes];
 }
 
-+(id) nodeWithNodes: (CCNode*) layer, ...
++(instancetype) nodeWithNodes: (CCNode*) layer, ...
 {
 	va_list args;
 	va_start(args,layer);

--- a/cocos2d/CCParallaxNode.m
+++ b/cocos2d/CCParallaxNode.m
@@ -37,7 +37,7 @@
 @property (nonatomic,readwrite) CGPoint ratio;
 @property (nonatomic,readwrite) CGPoint offset;
 @property (nonatomic,readwrite,unsafe_unretained) CCNode *child;
-+(id) pointWithCGPoint:(CGPoint)point offset:(CGPoint)offset;
++(instancetype) pointWithCGPoint:(CGPoint)point offset:(CGPoint)offset;
 -(id) initWithCGPoint:(CGPoint)point offset:(CGPoint)offset;
 @end
 @implementation CGPointObject
@@ -45,7 +45,7 @@
 @synthesize offset = _offset;
 @synthesize child = _child;
 
-+(id) pointWithCGPoint:(CGPoint)ratio offset:(CGPoint)offset
++(instancetype) pointWithCGPoint:(CGPoint)ratio offset:(CGPoint)offset
 {
 	return [[self alloc] initWithCGPoint:ratio offset:offset];
 }

--- a/cocos2d/CCParticleBatchNode.h
+++ b/cocos2d/CCParticleBatchNode.h
@@ -62,7 +62,7 @@ __attribute__((deprecated))
  *
  *  @return The CCParticleBatchNode Object.
  */
-+(id)batchNodeWithTexture:(CCTexture *)tex;
++(instancetype)batchNodeWithTexture:(CCTexture *)tex;
 
 /**
  *  Creates and returns a particle batch node object from the specified image file value.
@@ -71,7 +71,7 @@ __attribute__((deprecated))
  *
  *  @return The CCParticleBatchNode Object.
  */
-+(id)batchNodeWithFile:(NSString*) imageFile;
++(instancetype)batchNodeWithFile:(NSString*) imageFile;
 
 /**
  *  Creates and returns a particle batch node object from the specified texture and capacity values.
@@ -81,7 +81,7 @@ __attribute__((deprecated))
  *
  *  @return The CCParticleBatchNode Object.
  */
-+(id)batchNodeWithTexture:(CCTexture *)tex capacity:(NSUInteger) capacity;
++(instancetype)batchNodeWithTexture:(CCTexture *)tex capacity:(NSUInteger) capacity;
 
 /**
  *  Creates and returns a particle batch node object from the specified texture and capacity values.
@@ -92,7 +92,7 @@ __attribute__((deprecated))
  *  @return The CCParticleBatchNode Object.
  */
 
-+(id)batchNodeWithFile:(NSString*)fileImage capacity:(NSUInteger)capacity;
++(instancetype)batchNodeWithFile:(NSString*)fileImage capacity:(NSUInteger)capacity;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCParticleBatchNode.m
+++ b/cocos2d/CCParticleBatchNode.m
@@ -63,12 +63,12 @@
 /*
  * creation with CCTexture2D
  */
-+(id)batchNodeWithTexture:(CCTexture *)tex
++(instancetype)batchNodeWithTexture:(CCTexture *)tex
 {
 	return [[self alloc] initWithTexture:tex capacity:kCCParticleDefaultCapacity];
 }
 
-+(id)batchNodeWithTexture:(CCTexture *)tex capacity:(NSUInteger) capacity
++(instancetype)batchNodeWithTexture:(CCTexture *)tex capacity:(NSUInteger) capacity
 { 
 	return [[self alloc] initWithTexture:tex capacity:capacity];
 }
@@ -76,12 +76,12 @@
 /*
  * creation with File Image
  */
-+(id)batchNodeWithFile:(NSString*)fileImage capacity:(NSUInteger)capacity
++(instancetype)batchNodeWithFile:(NSString*)fileImage capacity:(NSUInteger)capacity
 {
 	return [[self alloc] initWithFile:fileImage capacity:capacity];
 }
 
-+(id)batchNodeWithFile:(NSString*) imageFile
++(instancetype)batchNodeWithFile:(NSString*) imageFile
 {
 	return [[self alloc] initWithFile:imageFile capacity:kCCParticleDefaultCapacity];
 }

--- a/cocos2d/CCParticleSystemBase.h
+++ b/cocos2d/CCParticleSystemBase.h
@@ -312,7 +312,7 @@ typedef void (*_CC_UPDATE_PARTICLE_IMP)(id, SEL, _CCParticle*, CGPoint);
  *
  *  @return The CCParticleSystem Object.
  */
-+(id) particleWithFile:(NSString*)plistFile;
++(instancetype) particleWithFile:(NSString*)plistFile;
 
 /**
  *  Creates and returns an empty particle system object with the specified maxmium number of particles.
@@ -321,7 +321,7 @@ typedef void (*_CC_UPDATE_PARTICLE_IMP)(id, SEL, _CCParticle*, CGPoint);
  *
  *  @return The CCParticleSystem Object.
  */
-+(id) particleWithTotalParticles:(NSUInteger) numberOfParticles;
++(instancetype) particleWithTotalParticles:(NSUInteger) numberOfParticles;
 
 /**
  *  Initializes and returns a particle system object from the specified plist source file.

--- a/cocos2d/CCParticleSystemBase.m
+++ b/cocos2d/CCParticleSystemBase.m
@@ -81,12 +81,12 @@
 @synthesize emitterMode = _emitterMode;
 @synthesize totalParticles = _totalParticles;
 
-+(id) particleWithFile:(NSString*) plistFile
++(instancetype) particleWithFile:(NSString*) plistFile
 {
 	return [[self alloc] initWithFile:plistFile];
 }
 
-+(id) particleWithTotalParticles:(NSUInteger) numberOfParticles
++(instancetype) particleWithTotalParticles:(NSUInteger) numberOfParticles
 {
 	return [[self alloc] initWithTotalParticles:numberOfParticles];
 }

--- a/cocos2d/CCProgressNode.h
+++ b/cocos2d/CCProgressNode.h
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSUInteger, CCProgressNodeType) {
  *  @return The CCProgressNode Object.
  *  @see CCSprite
  */
-+(id)progressWithSprite:(CCSprite*) sprite;
++(instancetype)progressWithSprite:(CCSprite*) sprite;
 
 /**
  *  Initializes and returns a progress node object using the specified sprite value.

--- a/cocos2d/CCProgressNode.m
+++ b/cocos2d/CCProgressNode.m
@@ -60,7 +60,7 @@
 @synthesize midpoint = _midpoint;
 @synthesize barChangeRate = _barChangeRate;
 
-+(id)progressWithSprite:(CCSprite*) sprite
++(instancetype)progressWithSprite:(CCSprite*) sprite
 {
 	return [[self alloc]initWithSprite:sprite];
 }

--- a/cocos2d/CCRenderTexture.h
+++ b/cocos2d/CCRenderTexture.h
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSInteger, CCRenderTextureImageFormat)
  *  @return An initialized CCRenderTarget object.
  *  @see CCTexturePixelFormat
  */
-+(id)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat) format depthStencilFormat:(GLuint)depthStencilFormat;
++(instancetype)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat) format depthStencilFormat:(GLuint)depthStencilFormat;
 
 /**
  *  Creates a RenderTexture object with width and height in Points and a pixel format, only RGB and RGBA formats are valid
@@ -85,7 +85,7 @@ typedef NS_ENUM(NSInteger, CCRenderTextureImageFormat)
  *  @return An initialized CCRenderTarget object.
  *  @see CCTexturePixelFormat
  */
-+(id)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat) format;
++(instancetype)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat) format;
 
 /**
  *  Creates a RenderTexture object with width and height in Points, pixel format is RGBA8888
@@ -95,7 +95,7 @@ typedef NS_ENUM(NSInteger, CCRenderTextureImageFormat)
  *
  *  @return An initialized CCRenderTarget object.
  */
-+(id)renderTextureWithWidth:(int)w height:(int)h;
++(instancetype)renderTextureWithWidth:(int)w height:(int)h;
 
 /**
  *  Initializes a RenderTexture object with width and height in Points and a pixel format, only RGB and RGBA formats are valid

--- a/cocos2d/CCRenderTexture.m
+++ b/cocos2d/CCRenderTexture.m
@@ -80,18 +80,18 @@
 
 @implementation CCRenderTexture
 
-+(id)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat) format depthStencilFormat:(GLuint)depthStencilFormat
++(instancetype)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat) format depthStencilFormat:(GLuint)depthStencilFormat
 {
   return [[self alloc] initWithWidth:w height:h pixelFormat:format depthStencilFormat:depthStencilFormat];
 }
 
 // issue #994
-+(id)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format
++(instancetype)renderTextureWithWidth:(int)w height:(int)h pixelFormat:(CCTexturePixelFormat)format
 {
 	return [[self alloc] initWithWidth:w height:h pixelFormat:format];
 }
 
-+(id)renderTextureWithWidth:(int)w height:(int)h
++(instancetype)renderTextureWithWidth:(int)w height:(int)h
 {
 	return [[self alloc] initWithWidth:w height:h pixelFormat:CCTexturePixelFormat_RGBA8888 depthStencilFormat:0];
 }

--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -59,37 +59,37 @@
 	BOOL _flipX, _flipY;
 }
 
-+(id)spriteWithImageNamed:(NSString*)imageName
++(instancetype)spriteWithImageNamed:(NSString*)imageName
 {
     return [[self alloc] initWithImageNamed:imageName];
 }
 
-+(id)spriteWithTexture:(CCTexture*)texture
++(instancetype)spriteWithTexture:(CCTexture*)texture
 {
 	return [[self alloc] initWithTexture:texture];
 }
 
-+(id)spriteWithTexture:(CCTexture*)texture rect:(CGRect)rect
++(instancetype)spriteWithTexture:(CCTexture*)texture rect:(CGRect)rect
 {
 	return [[self alloc] initWithTexture:texture rect:rect];
 }
 
-+(id)spriteWithFile:(NSString*)filename
++(instancetype)spriteWithFile:(NSString*)filename
 {
 	return [[self alloc] initWithFile:filename];
 }
 
-+(id)spriteWithFile:(NSString*)filename rect:(CGRect)rect
++(instancetype)spriteWithFile:(NSString*)filename rect:(CGRect)rect
 {
 	return [[self alloc] initWithFile:filename rect:rect];
 }
 
-+(id)spriteWithSpriteFrame:(CCSpriteFrame*)spriteFrame
++(instancetype)spriteWithSpriteFrame:(CCSpriteFrame*)spriteFrame
 {
 	return [[self alloc] initWithSpriteFrame:spriteFrame];
 }
 
-+(id)spriteWithSpriteFrameName:(NSString*)spriteFrameName
++(instancetype)spriteWithSpriteFrameName:(NSString*)spriteFrameName
 {
 	CCSpriteFrame *frame = [[CCSpriteFrameCache sharedSpriteFrameCache] spriteFrameByName:spriteFrameName];
 
@@ -97,12 +97,12 @@
 	return [self spriteWithSpriteFrame:frame];
 }
 
-+(id)spriteWithCGImage:(CGImageRef)image key:(NSString*)key
++(instancetype)spriteWithCGImage:(CGImageRef)image key:(NSString*)key
 {
 	return [[self alloc] initWithCGImage:image key:key];
 }
 
-+(id) emptySprite
++(instancetype) emptySprite
 {
     return [[self alloc] init];
 }

--- a/cocos2d/CCSpriteBatchNode.h
+++ b/cocos2d/CCSpriteBatchNode.h
@@ -59,7 +59,7 @@ __attribute__((deprecated))
  *  @return The CCSpriteBatchNode Object.
  *  @see CCTexture
  */
-+(id)batchNodeWithTexture:(CCTexture *)tex;
++(instancetype)batchNodeWithTexture:(CCTexture *)tex;
 
 /**
  *  Creates and returns a batch node with the specified image file value.
@@ -68,7 +68,7 @@ __attribute__((deprecated))
  *
  *  @return The CCSpriteBatchNode Object.
  */
-+(id)batchNodeWithFile:(NSString*) fileImage;
++(instancetype)batchNodeWithFile:(NSString*) fileImage;
 
 /**
  *  Creates and returns a batch node with the specified texture and capacity values.

--- a/cocos2d/CCSpriteBatchNode.m
+++ b/cocos2d/CCSpriteBatchNode.m
@@ -35,22 +35,22 @@
 @implementation CCSpriteBatchNode {
 }
 
-+(id)batchNodeWithTexture:(CCTexture *)tex
++(instancetype)batchNodeWithTexture:(CCTexture *)tex
 {
 	return [[self alloc] initWithTexture:tex capacity:0];
 }
 
-+(id)batchNodeWithTexture:(CCTexture *)tex capacity:(NSUInteger)capacity
++(instancetype)batchNodeWithTexture:(CCTexture *)tex capacity:(NSUInteger)capacity
 {
 	return [[self alloc] initWithTexture:tex capacity:capacity];
 }
 
-+(id)batchNodeWithFile:(NSString*)fileImage capacity:(NSUInteger)capacity
++(instancetype)batchNodeWithFile:(NSString*)fileImage capacity:(NSUInteger)capacity
 {
 	return [[self alloc] initWithFile:fileImage capacity:capacity];
 }
 
-+(id)batchNodeWithFile:(NSString*) imageFile
++(instancetype)batchNodeWithFile:(NSString*) imageFile
 {
 	return [[self alloc] initWithFile:imageFile capacity:0];
 }

--- a/cocos2d/CCSpriteFrame.h
+++ b/cocos2d/CCSpriteFrame.h
@@ -54,7 +54,7 @@
  *
  *  @return The CCSpriteFrame Object.
  */
-+(id) frameWithImageNamed:(NSString*)imageName;
++(instancetype) frameWithImageNamed:(NSString*)imageName;
 
 /**
  *  Create and return a sprite frame object from the specified texture, texture rectangle, rotation status, offset and originalSize values.
@@ -68,7 +68,7 @@
  *  @return The CCSpriteFrame Object.
  *  @see CCTexture
  */
-+(id) frameWithTexture:(CCTexture*)texture rectInPixels:(CGRect)rect rotated:(BOOL)rotated offset:(CGPoint)offset originalSize:(CGSize)originalSize;
++(instancetype) frameWithTexture:(CCTexture*)texture rectInPixels:(CGRect)rect rotated:(BOOL)rotated offset:(CGPoint)offset originalSize:(CGSize)originalSize;
 
 /**
  *  Create and return a sprite frame object from the specified texture file name, texture rectangle, rotation status, offset and originalSize values.
@@ -81,7 +81,7 @@
  *
  *  @return The CCSpriteFrame Object.
  */
-+(id) frameWithTextureFilename:(NSString*)filename rectInPixels:(CGRect)rect rotated:(BOOL)rotated offset:(CGPoint)offset originalSize:(CGSize)originalSize;
++(instancetype) frameWithTextureFilename:(NSString*)filename rectInPixels:(CGRect)rect rotated:(BOOL)rotated offset:(CGPoint)offset originalSize:(CGSize)originalSize;
 
 /**
  *  Initializes and returns a sprite frame object from the specified texture, texture rectangle, rotation status, offset and originalSize values.

--- a/cocos2d/CCSpriteFrame.m
+++ b/cocos2d/CCSpriteFrame.m
@@ -50,7 +50,7 @@
 
 @dynamic rect;
 
-+(id) frameWithImageNamed:(NSString*)imageName
++(instancetype) frameWithImageNamed:(NSString*)imageName
 {
     CCSpriteFrame* frame = [[CCSpriteFrameCache sharedSpriteFrameCache] spriteFrameByName:imageName];
     if (!frame)
@@ -62,12 +62,12 @@
     return frame;
 }
 
-+(id) frameWithTexture:(CCTexture*)texture rectInPixels:(CGRect)rect rotated:(BOOL)rotated offset:(CGPoint)offset originalSize:(CGSize)originalSize
++(instancetype) frameWithTexture:(CCTexture*)texture rectInPixels:(CGRect)rect rotated:(BOOL)rotated offset:(CGPoint)offset originalSize:(CGSize)originalSize
 {
 	return [[self alloc] initWithTexture:texture rectInPixels:rect rotated:rotated offset:offset originalSize:originalSize];
 }
 
-+(id) frameWithTextureFilename:(NSString*)filename rectInPixels:(CGRect)rect rotated:(BOOL)rotated offset:(CGPoint)offset originalSize:(CGSize)originalSize
++(instancetype) frameWithTextureFilename:(NSString*)filename rectInPixels:(CGRect)rect rotated:(BOOL)rotated offset:(CGPoint)offset originalSize:(CGSize)originalSize
 {
 	return [[self alloc] initWithTextureFilename:filename rectInPixels:rect rotated:rotated offset:offset originalSize:originalSize];
 }

--- a/cocos2d/CCTMXXMLParser.h
+++ b/cocos2d/CCTMXXMLParser.h
@@ -204,7 +204,7 @@ typedef NS_ENUM(uint32_t, ccTMXTileFlags) {
  *
  *  @return The CCTiledMapInfo Object.
  */
-+(id) formatWithTMXFile:(NSString*)tmxFile;
++(instancetype) formatWithTMXFile:(NSString*)tmxFile;
 
 /**
  *  Creates and returns a CCTiledMapInfo object using the TMX XML and resource file path.
@@ -214,7 +214,7 @@ typedef NS_ENUM(uint32_t, ccTMXTileFlags) {
  *
  *  @return The CCTiledMapInfo Object.
  */
-+(id) formatWithXML:(NSString*)tmxString resourcePath:(NSString*)resourcePath;
++(instancetype) formatWithXML:(NSString*)tmxString resourcePath:(NSString*)resourcePath;
 
 /**
  *  Initializes and returns a CCTiledMapInfo object using the TMX format file specified.

--- a/cocos2d/CCTMXXMLParser.m
+++ b/cocos2d/CCTMXXMLParser.m
@@ -139,12 +139,12 @@
 @synthesize orientation = _orientation, mapSize = _mapSize, layers = _layers, tilesets = _tilesets, tileSize = _tileSize, filename = _filename, resources = _resources, objectGroups = _objectGroups, properties = _properties;
 @synthesize tileProperties = _tileProperties;
 
-+(id) formatWithTMXFile:(NSString*)tmxFile
++(instancetype) formatWithTMXFile:(NSString*)tmxFile
 {
 	return [[self alloc] initWithFile:tmxFile];
 }
 
-+(id) formatWithXML:(NSString*)tmxString resourcePath:(NSString*)resourcePath
++(instancetype) formatWithXML:(NSString*)tmxString resourcePath:(NSString*)resourcePath
 {
 	return [[self alloc] initWithXML:tmxString resourcePath:resourcePath];
 }

--- a/cocos2d/CCTexturePVR.h
+++ b/cocos2d/CCTexturePVR.h
@@ -127,7 +127,7 @@ enum {
  *
  *  @return The CCTexturePVR object.
  */
-+(id)pvrTextureWithContentsOfFile:(NSString *)path;
++(instancetype)pvrTextureWithContentsOfFile:(NSString *)path;
 
 /**
  *  Creates and returns a PVR Texture from the specified URL value.
@@ -136,7 +136,7 @@ enum {
  *
  *  @return The CCTexturePVR object.
  */
-+(id)pvrTextureWithContentsOfURL:(NSURL *)url;
++(instancetype)pvrTextureWithContentsOfURL:(NSURL *)url;
 
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/CCTiledMap.h
+++ b/cocos2d/CCTiledMap.h
@@ -114,7 +114,7 @@ typedef NS_ENUM(NSUInteger, CCTiledMapOrientation)
  *
  *  @return The CCTiledMap Object.
  */
-+(id) tiledMapWithFile:(NSString*)tmxFile;
++(instancetype) tiledMapWithFile:(NSString*)tmxFile;
 
 /**
  *  Creates a returns a Tile Map object using the specified TMX XML and path to TMX resources.
@@ -124,7 +124,7 @@ typedef NS_ENUM(NSUInteger, CCTiledMapOrientation)
  *
  *  @return The CCTiledMap Object.
  */
-+(id) tiledMapWithXML:(NSString*)tmxString resourcePath:(NSString*)resourcePath;
++(instancetype) tiledMapWithXML:(NSString*)tmxString resourcePath:(NSString*)resourcePath;
 
 /**
  *  Initializes and returns a Tile Map object using the specified TMX file.

--- a/cocos2d/CCTiledMap.m
+++ b/cocos2d/CCTiledMap.m
@@ -55,12 +55,12 @@
 @synthesize objectGroups = _objectGroups;
 @synthesize properties = _properties;
 
-+(id) tiledMapWithFile:(NSString*)tmxFile
++(instancetype) tiledMapWithFile:(NSString*)tmxFile
 {
 	return [[self alloc] initWithFile:tmxFile];
 }
 
-+(id) tiledMapWithXML:(NSString*)tmxString resourcePath:(NSString*)resourcePath
++(instancetype) tiledMapWithXML:(NSString*)tmxString resourcePath:(NSString*)resourcePath
 {
 	return [[self alloc] initWithXML:tmxString resourcePath:resourcePath];
 }

--- a/cocos2d/CCTiledMapLayer.h
+++ b/cocos2d/CCTiledMapLayer.h
@@ -59,7 +59,7 @@
  *  @see CCTiledMapLayerInfo
  *  @see CCTiledMapInfo
  */
-+(id) layerWithTilesetInfo:(CCTiledMapTilesetInfo*)tilesetInfo layerInfo:(CCTiledMapLayerInfo*)layerInfo mapInfo:(CCTiledMapInfo*)mapInfo;
++(instancetype) layerWithTilesetInfo:(CCTiledMapTilesetInfo*)tilesetInfo layerInfo:(CCTiledMapLayerInfo*)layerInfo mapInfo:(CCTiledMapInfo*)mapInfo;
 
 /**
  *  Initializes and returns a CCTiledMapLayer using the specified tileset info, layerinfo and mapinfo values.

--- a/cocos2d/CCTiledMapLayer.m
+++ b/cocos2d/CCTiledMapLayer.m
@@ -67,7 +67,7 @@
 
 #pragma mark CCTMXLayer - init & alloc & dealloc
 
-+(id) layerWithTilesetInfo:(CCTiledMapTilesetInfo*)tilesetInfo layerInfo:(CCTiledMapLayerInfo*)layerInfo mapInfo:(CCTiledMapInfo*)mapInfo
++(instancetype) layerWithTilesetInfo:(CCTiledMapTilesetInfo*)tilesetInfo layerInfo:(CCTiledMapLayerInfo*)layerInfo mapInfo:(CCTiledMapInfo*)mapInfo
 {
 	return [[self alloc] initWithTilesetInfo:tilesetInfo layerInfo:layerInfo mapInfo:mapInfo];
 }


### PR DESCRIPTION
When factory methods use `instancetype` as a return type Swift can infer convenience initializers correctly. When returning `id` this is not possible.

Currently a `CCSpriteFrame` needs to be initialized like this:

```
let spriteFrame = CCSpriteFrame.frameWithImageNamed(imageName) as CCSpriteFrame
```

When returning `instancetype` the initializer can be used like this:

```
let spriteFrame = CCSpriteFrame(imageNamed: imageName)
```

**Changing to `instancetype` will cause the first solution to no longer work - breaking backwards compatibility with existing Swift code.**

So I guess this should be changed for 4.0? It definitely would be nice to have the second more concise option available soon.

Note: I had refactored this in the following pull request, but had messed it up prior to the merge: https://github.com/cocos2d/cocos2d-swift/pull/467
