### PR TITLE
synthesize paused = _isPaused in CCDirector.

### DIFF
--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -92,6 +92,8 @@ extern NSString * cocos2dVersion(void);
 	CCFrameBufferObject *_framebuffer;
 }
 
+@synthesize paused = _isPaused;
+
 static NSString * const CCDirectorCurrentKey = @"CCDirectorCurrentKey";
 static NSString * const CCDirectorStackKey = @"CCDirectorStackKey";
 


### PR DESCRIPTION
CCDirector has a property `paused` with the getter `isPaused` set in the header. This is implicitly synthesized and backed by a generated ivar named `_paused` which is never used. The director instead uses and operates on an existing ivar named `_isPaused`. This PR fixes that.

This is needed to fix a bug on SpriteBuilder introduced by v4 changes, where the cocos scene becomes unresponsive as it can never be unpaused after returning to focus.
