### PR TITLE
Fixed calculation of tangent/binormal vectors.

### DIFF
--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -327,6 +327,8 @@
         sprite.effect = lightingEffect;
         sprite.scale = 0.5f;
         
+        [sprite runAction:[CCActionRepeatForever actionWithAction:[CCActionRotateBy actionWithDuration:1.0 angle:90.0]]];
+        
         CCNode *root = [[CCNode alloc] init];
         root.positionType = CCPositionTypeNormalized;
         root.position = position;

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -242,10 +242,9 @@ static float conditionShininess(float shininess);
         GLKMatrix4 nodeLocalToWorld = CCEffectUtilsMat4FromAffineTransform(passInputs.sprite.nodeToWorldTransform);
         GLKMatrix4 ndcToWorld = GLKMatrix4Multiply(nodeLocalToWorld, passInputs.ndcToNodeLocal);
         
-
-        GLKMatrix2 tangentMatrix = CCEffectUtilsMatrix2InvertAndTranspose(GLKMatrix4GetMatrix2(nodeLocalToWorld), nil);
-        GLKVector2 reflectTangent = GLKVector2Normalize(CCEffectUtilsMatrix2MultiplyVector2(tangentMatrix, GLKVector2Make(1.0f, 0.0f)));
-        GLKVector2 reflectBinormal = GLKVector2Make(-reflectTangent.y, reflectTangent.x);
+        // Tangent and binormal vectors are the x/y basis vectors from the nodeLocalToWorldMatrix
+        GLKVector2 reflectTangent = GLKVector2Normalize(GLKVector2Make(nodeLocalToWorld.m[0], nodeLocalToWorld.m[1]));
+        GLKVector2 reflectBinormal = GLKVector2Normalize(GLKVector2Make(nodeLocalToWorld.m[4], nodeLocalToWorld.m[5]));
 
         passInputs.shaderUniforms[pass.uniformTranslationTable[@"u_worldSpaceTangent"]] = [NSValue valueWithGLKVector2:reflectTangent];
         passInputs.shaderUniforms[pass.uniformTranslationTable[@"u_worldSpaceBinormal"]] = [NSValue valueWithGLKVector2:reflectBinormal];


### PR DESCRIPTION
This is a relatively major bug in the lighting effect. The code was inverting the node-to-local matrix, effectively passing the reverse of the object's transform to the lighting effect. This would undo the rotation or skewing of an object in the lighting calculations. Only the position of the sprite affected the lighting calculations.

I think this fixes the intent of the original code, but I don't see any tests that use normal maps that are asymmetric. I'm not 100% certain that this is correct without an extra y-flip or 180 degree rotation or something silly like that.
