### PR TITLE
CCAppController

### DIFF
--- a/cocos2d.xcodeproj/project.pbxproj
+++ b/cocos2d.xcodeproj/project.pbxproj
@@ -23,6 +23,12 @@
 /* Begin PBXBuildFile section */
 		1426D9951A38D24A00A579AF /* CCGestureListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BC3CB5719626FA000C4F0D0 /* CCGestureListener.h */; };
 		1435EB831A37BA7000BD04D4 /* GLActivityKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1435EB821A37BA7000BD04D4 /* GLActivityKit.framework */; };
+		14B84C921A700B55002C4D20 /* CCAppController.h in Headers */ = {isa = PBXBuildFile; fileRef = 14B84C901A700B55002C4D20 /* CCAppController.h */; };
+		14B84C931A700B55002C4D20 /* CCAppController.h in Headers */ = {isa = PBXBuildFile; fileRef = 14B84C901A700B55002C4D20 /* CCAppController.h */; };
+		14B84C941A700B55002C4D20 /* CCAppController.h in Headers */ = {isa = PBXBuildFile; fileRef = 14B84C901A700B55002C4D20 /* CCAppController.h */; };
+		14B84C951A700B55002C4D20 /* CCAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 14B84C911A700B55002C4D20 /* CCAppController.m */; };
+		14B84C961A700B55002C4D20 /* CCAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 14B84C911A700B55002C4D20 /* CCAppController.m */; };
+		14B84C971A700B55002C4D20 /* CCAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 14B84C911A700B55002C4D20 /* CCAppController.m */; };
 		14C4C33E1A37E39E00DD3957 /* AndroidKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14C4C33D1A37E39E00DD3957 /* AndroidKit.framework */; };
 		14E6FBF31A792E5200A80C55 /* CCActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 14E6FBF21A792E5200A80C55 /* CCActivity.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		14E6FBFD1A793DB300A80C55 /* CCActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 14E6FBFC1A793DB300A80C55 /* CCActivity.h */; };
@@ -1108,6 +1114,8 @@
 		1435EB821A37BA7000BD04D4 /* GLActivityKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLActivityKit.framework; path = "../../Library/Application Support/Developer/Shared/Xcode/Platforms/Android.platform/Developer/SDKs/SBAndroid.sdk/System/Library/Frameworks/GLActivityKit.framework"; sourceTree = "<group>"; };
 		143F32D71A3A2E8A0019FD3C /* CoreJava.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreJava.framework; path = "../../Library/Application Support/Developer/Shared/Xcode/Platforms/Android.platform/Developer/SDKs/SBAndroid.sdk/System/Library/Frameworks/CoreJava.framework"; sourceTree = "<group>"; };
 		1493BC951A77AA3700840737 /* CoreJava.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreJava.framework; path = "../../../../Library/SBAndroid/Application Support/Developer/Shared/Xcode/Platforms/Android.platform/Developer/SDKs/SBAndroid.sdk/System/Library/Frameworks/CoreJava.framework"; sourceTree = "<group>"; };
+		14B84C901A700B55002C4D20 /* CCAppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCAppController.h; sourceTree = "<group>"; };
+		14B84C911A700B55002C4D20 /* CCAppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCAppController.m; sourceTree = "<group>"; };
 		14C4C33D1A37E39E00DD3957 /* AndroidKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AndroidKit.framework; path = "../../Library/Application Support/Developer/Shared/Xcode/Platforms/Android.platform/Developer/SDKs/SBAndroid.sdk/System/Library/Frameworks/AndroidKit.framework"; sourceTree = "<group>"; };
 		14E6FBF21A792E5200A80C55 /* CCActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CCActivity.m; path = Android/CCActivity.m; sourceTree = "<group>"; };
 		14E6FBFC1A793DB300A80C55 /* CCActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CCActivity.h; path = Android/CCActivity.h; sourceTree = "<group>"; };
@@ -2236,6 +2244,8 @@
 		E0EAD0E8121F4B4600B0C81C /* Platforms */ = {
 			isa = PBXGroup;
 			children = (
+				14B84C901A700B55002C4D20 /* CCAppController.h */,
+				14B84C911A700B55002C4D20 /* CCAppController.m */,
 				D285ECED192E7E06009F4E88 /* Android */,
 				E0EAD0E9121F4B4600B0C81C /* iOS */,
 				E0E9749E1237E4EA00E3E64B /* Mac */,
@@ -2362,6 +2372,7 @@
 				D2DDB09F19805E8400233D80 /* CCVector3.h in Headers */,
 				9D1B4A991A02E90300B2DD9B /* CCLightGroups.h in Headers */,
 				D3903B10199528A0003AA81A /* CCRenderDispatch.h in Headers */,
+				14B84C921A700B55002C4D20 /* CCAppController.h in Headers */,
 				D272032418FC89A000B100FF /* CCEffect_Private.h in Headers */,
 				9D03A5EB1A02F61700C651C8 /* CCLightNode_Private.h in Headers */,
 				D272032D18FC89A000B100FF /* CCEffectStack.h in Headers */,
@@ -2540,6 +2551,7 @@
 				7A5946A119E372F100F65F90 /* CCTiledMap.h in Headers */,
 				7A5946A219E372F100F65F90 /* CCTiledMap.m in Headers */,
 				7A5946A319E372F100F65F90 /* CCTiledMapLayer.h in Headers */,
+				14B84C941A700B55002C4D20 /* CCAppController.h in Headers */,
 				7A5946A419E372F100F65F90 /* CCTiledMapLayer.m in Headers */,
 				7A5946A519E372F200F65F90 /* CCTiledMapObjectGroup.h in Headers */,
 				7A5946A619E372F200F65F90 /* CCTiledMapObjectGroup.m in Headers */,
@@ -2740,6 +2752,8 @@
 				D2FEB64A194F6C9E00FC0574 /* CCTextField.h in Headers */,
 				D2FEB64B194F6C9E00FC0574 /* CCBReader.h in Headers */,
 				D2FEB64C194F6C9E00FC0574 /* CCEffectPixellate.h in Headers */,
+				14B84C931A700B55002C4D20 /* CCAppController.h in Headers */,
+				D2FEB64D194F6C9E00FC0574 /* CCActionManager.h in Headers */,
 				D2FEB64E194F6C9E00FC0574 /* CCTiledMap.h in Headers */,
 				BC9F4E9819DB644600B25F01 /* CCPackageManager.h in Headers */,
 				BC9F4E9919DB644900B25F01 /* CCPackageManagerDelegate.h in Headers */,
@@ -3104,6 +3118,7 @@
 				502C8BE110A661E200D137BA /* CCSpriteFrameCache.m in Sources */,
 				50E1357610ADEB1B00C9E7FA /* CCTexture.m in Sources */,
 				503862E6110072BC005D2C92 /* CCDeviceInfo.m in Sources */,
+				14B84C951A700B55002C4D20 /* CCAppController.m in Sources */,
 				5015043C113300F900A9CA65 /* CCActionProgressTimer.m in Sources */,
 				D37D197818B6665700B23FDE /* CCTiledMapLayer.m in Sources */,
 				D272032618FC89A000B100FF /* CCEffect.m in Sources */,
@@ -3245,6 +3260,7 @@
 				7A59480719E375A400F65F90 /* CCClippingNode.m in Sources */,
 				7A59480919E375A400F65F90 /* CCMotionStreak.m in Sources */,
 				7A59480B19E375A400F65F90 /* CCProgressNode.m in Sources */,
+				14B84C971A700B55002C4D20 /* CCAppController.m in Sources */,
 				7A59480D19E375A400F65F90 /* CCRenderTexture.m in Sources */,
 				7A59481119E375A500F65F90 /* CCPackage.m in Sources */,
 				7A59481319E375A500F65F90 /* CCPackageConstants.m in Sources */,
@@ -3362,6 +3378,8 @@
 				D2FEB6D6194F6C9E00FC0574 /* CCTMXXMLParser.m in Sources */,
 				D2FEB6D7194F6C9E00FC0574 /* CCSprite.m in Sources */,
 				D2FEB6D8194F6C9E00FC0574 /* CCTiledMap.m in Sources */,
+				D2FEB6D9194F6C9E00FC0574 /* CCFileUtils.m in Sources */,
+				14B84C961A700B55002C4D20 /* CCAppController.m in Sources */,
 				D2FEB6DB194F6C9E00FC0574 /* CCTouch.m in Sources */,
 				D2EC6039199D9F82001A15E9 /* CCRendererGLSupport.m in Sources */,
 				D27451C919B111A9006DA0A1 /* CCEffectDFOutline.m in Sources */,

--- a/cocos2d/CCDeviceInfo.h
+++ b/cocos2d/CCDeviceInfo.h
@@ -53,6 +53,7 @@ extern NSString* const CCSetupDepthFormat;
 extern NSString* const CCSetupPreserveBackbuffer;
 extern NSString* const CCSetupMultiSampling;
 extern NSString* const CCSetupNumberOfSamples;
+extern NSString* const CCScreenModeFixedDimensions;
 
 // Landscape screen orientation. Used with CCSetupScreenOrientation.
 extern NSString* const CCScreenOrientationLandscape;
@@ -69,6 +70,10 @@ extern NSString* const CCScreenModeFlexible;
 
 // The fixed screen mode will setup the working area to be 568 x 384 points. Depending on the device, the outer edges may be cropped. The safe area, that will be displayed on all sorts of devices, is 480 x 320 points and placed in the center of the working area.
 extern NSString* const CCScreenModeFixed;
+
+// The desired default window size for mac
+extern NSString* const CCMacDefaultWindowSize;
+
 
 typedef NS_ENUM(NSUInteger, CCDevice) {
 	CCDeviceiPhone,

--- a/cocos2d/CCDeviceInfo.m
+++ b/cocos2d/CCDeviceInfo.m
@@ -59,6 +59,10 @@ NSString* const CCScreenOrientationAll = @"CCScreenOrientationAll";
 
 NSString* const CCScreenModeFlexible = @"CCScreenModeFlexible";
 NSString* const CCScreenModeFixed = @"CCScreenModeFixed";
+NSString* const CCScreenModeFixedDimensions = @"CCScreenModeFixedDimensions";
+
+NSString* const CCMacDefaultWindowSize = @"CCMacDefaultWindowSize";
+
 
 
 @implementation CCDeviceInfo

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -206,7 +206,7 @@ CCDirectorStack()
         return;
     
     [CCDirector pushCurrentDirector:self];
-    
+
     /* calculate "global" dt */
 	[self calculateDeltaTime];
 
@@ -376,13 +376,16 @@ CCDirectorStack()
 
 		// it could be nil
 		if( view ) {
-            
+#if !__CC_PLATFORM_ANDROID
 			[self createStatsLabel];
+#endif
 			[self setProjection: _projection];
 		}
 
+#if !__CC_PLATFORM_ANDROID
 		// Dump info once OpenGL was initilized
-		[[CCDeviceInfo sharedDeviceInfo] dumpInfo];
+		[[CCDeviceInfo sharedConfiguration] dumpInfo];
+#endif
 }
 
 
@@ -405,7 +408,6 @@ CCDirectorStack()
 		[self setProjection:_projection];
 		
 		[[CCFileUtils sharedFileUtils] buildSearchResolutionsOrder];
-		[self createStatsLabel];
 	}
 }
 
@@ -892,9 +894,6 @@ static const float CCFPSLabelItemHeight = 32;
 			_frameRate = _frames/_accumDt;
 			_frames = 0;
 			_accumDt = 0;
-
-//			sprintf(format,"%.1f",frameRate);
-//			[FPSLabel setCString:format];
 
 			NSString *fpsstr = [[NSString alloc] initWithFormat:@"%.1f", _frameRate];
 			[_FPSLabel setString:fpsstr];

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -384,7 +384,7 @@ CCDirectorStack()
 
 #if !__CC_PLATFORM_ANDROID
 		// Dump info once OpenGL was initilized
-		[[CCDeviceInfo sharedConfiguration] dumpInfo];
+		[[CCDeviceInfo sharedDeviceInfo] dumpInfo];
 #endif
 }
 

--- a/cocos2d/Platforms/Android/CCActivity.h
+++ b/cocos2d/Platforms/Android/CCActivity.h
@@ -6,26 +6,40 @@
 //  Copyright (c) 2014 Apportable. All rights reserved.
 //
 
-#import "ccMacros.h"
+#import "CCMacros.h"
 #if __CC_PLATFORM_ANDROID
 
 #import <GLActivityKit/GLActivity.h>
 #import "../../Platforms/CCGL.h"
 #import "CCDirector.h"
+#import "CCProtocols.h"
+#import "CCGLView.h"
 
 @class CCScene;
 @class AndroidAbsoluteLayout;
+@class AndroidDisplayMetrics;
+
 
 @interface CCActivity : GLActivity <AndroidSurfaceHolderCallback, CCDirectorDelegate>
 @property (readonly, nonatomic) AndroidAbsoluteLayout *layout;
+@property (nonatomic, strong) NSDictionary *cocos2dSetupConfig;
+@property (nonatomic, readonly) CCGLView *glView;
+@property (nonatomic, strong) NSString *startScene;
 + (instancetype)currentActivity;
 
 
+- (void)run;
+
+- (void)scheduleInRunLoop;
+
+- (void)applyRequestedOrientation:(NSDictionary *)config;
+
+- (void)constructViewWithConfig:(NSDictionary *)config andDensity:(float)density;
+
+- (AndroidDisplayMetrics *)getDisplayMetrics;
+
 - (void)runOnGameThread:(dispatch_block_t)block;
 - (void)runOnGameThread:(dispatch_block_t)block waitUntilDone:(BOOL)waitUntilDone;
-
-- (void)setupPaths;
-- (CCScene *)startScene;
 
 - (EGLContext)pushApplicationContext;
 - (void)popApplicationContext:(EGLContext)ctx;

--- a/cocos2d/Platforms/Android/CCActivity.h
+++ b/cocos2d/Platforms/Android/CCActivity.h
@@ -23,7 +23,7 @@
 @interface CCActivity : GLActivity <AndroidSurfaceHolderCallback, CCDirectorDelegate>
 @property (readonly, nonatomic) AndroidAbsoluteLayout *layout;
 @property (nonatomic, strong) NSDictionary *cocos2dSetupConfig;
-@property (nonatomic, readonly) CCGLView *glView;
+@property (nonatomic, strong) CCGLView *glView;
 @property (nonatomic, strong) NSString *startScene;
 + (instancetype)currentActivity;
 

--- a/cocos2d/Platforms/Android/CCActivity.m
+++ b/cocos2d/Platforms/Android/CCActivity.m
@@ -79,10 +79,10 @@ static void handler(NSException *e)
 
 static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
 {
-	int scale = 1;
-	while(fixedSize*scale < size) scale++;
+    int scale = 1;
+    while(fixedSize*scale < size) scale++;
 
-	return scale;
+    return scale;
 }
 
 - (void)run
@@ -123,7 +123,7 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
     enum CCAndroidScreenMode screenMode = CCNativeScreenMode;
 
     if([config[CCSetupScreenMode] isEqual:CCScreenModeFlexible] ||
-       [config[CCSetupScreenMode] isEqual:CCScreenModeFixed])
+            [config[CCSetupScreenMode] isEqual:CCScreenModeFixed])
     {
         screenMode = CCScreenScaledAspectFitEmulationMode;
     }
@@ -157,7 +157,7 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
     {
         return;
     }
-    
+
     [self performSelector:@selector(handleResume) onThread:_thread withObject:nil waitUntilDone:YES modes:@[NSDefaultRunLoopMode]];
 #endif
 }
@@ -177,7 +177,7 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
     {
         return;
     }
-    
+
     [self performSelector:@selector(handlePause) onThread:_thread withObject:nil waitUntilDone:YES modes:@[NSDefaultRunLoopMode]];
 #endif
 }
@@ -212,16 +212,16 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
 - (void)reshape:(NSValue *)value
 {
     CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector currentDirector];
-	[director reshapeProjection:value.CGSizeValue]; // crashes sometimes..
+    [director reshapeProjection:value.CGSizeValue]; // crashes sometimes..
 }
 
 - (void)surfaceChanged:(JavaObject<AndroidSurfaceHolder> *)holder format:(int)format width:(int)width height:(int)height
 {
     if(_glView == nil)
         return;
-    
+
     _glView.bounds = CGRectMake(0, 0, width/_glView.contentScaleFactor, height/_glView.contentScaleFactor);
-    
+
 #if USE_MAIN_THREAD
     [self reshape:[NSValue valueWithCGSize:CGSizeMake(width, height)]];
 #else
@@ -238,7 +238,7 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
 - (void)startGL:(JavaObject<AndroidSurfaceHolder> *)holder
 {
     @autoreleasepool {
-        CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector sharedDirector];
+        CCDirectorAndroid *director = (CCDirectorAndroid*)_glView.director;
 
         _gameLoop = [NSRunLoop currentRunLoop];
         [_gameLoop addPort:[NSPort port] forMode:NSDefaultRunLoopMode]; // Ensure that _gameLoop always has a source.
@@ -325,22 +325,22 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
     EGLDisplay display;
     EGLSurface surfaceR;
     EGLSurface surfaceD;
-    
+
     EGLContext ctx = eglGetCurrentContext();
-    
+
     EGLContext appContext = _glView.eglContext;
     if (appContext != ctx)
     {
         display = eglGetCurrentDisplay();
         surfaceD = eglGetCurrentSurface(EGL_DRAW);
         surfaceR = eglGetCurrentSurface(EGL_READ);
-        
+
         EGLSurface surface = _glView.eglSurface;
-        
+
         eglMakeCurrent(_glView.eglDisplay, surface, surface, appContext);
         return ctx;
     }
-    
+
     return NULL;
 }
 
@@ -351,11 +351,11 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
         EGLDisplay display;
         EGLSurface surfaceR;
         EGLSurface surfaceD;
-        
+
         display = eglGetCurrentDisplay();
         surfaceD = eglGetCurrentSurface(EGL_DRAW);
         surfaceR = eglGetCurrentSurface(EGL_READ);
-        
+
         eglMakeCurrent(display, surfaceD, surfaceR, ctx);
     }
 }
@@ -365,13 +365,13 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
 // Projection delegate is only used if the fixed resolution mode is enabled
 -(GLKMatrix4)updateProjection
 {
-	CGSize sizePoint = [CCDirector currentDirector].viewSize;
-	CGSize fixed = [CCDirector currentDirector].designSize;
+    CGSize sizePoint = [CCDirector currentDirector].viewSize;
+    CGSize fixed = [CCDirector currentDirector].designSize;
 
-	// Half of the extra size that will be cut off
-	CGPoint offset = ccpMult(ccp(fixed.width - sizePoint.width, fixed.height - sizePoint.height), 0.5);
-	
-	return CCMatrix4MakeOrtho(offset.x, sizePoint.width + offset.x, offset.y, sizePoint.height + offset.y, -1024, 1024);
+    // Half of the extra size that will be cut off
+    CGPoint offset = ccpMult(ccp(fixed.width - sizePoint.width, fixed.height - sizePoint.height), 0.5);
+
+    return CCMatrix4MakeOrtho(offset.x, sizePoint.width + offset.x, offset.y, sizePoint.height + offset.y, -1024, 1024);
 }
 
 @end

--- a/cocos2d/Platforms/Android/CCDirectorAndroid.h
+++ b/cocos2d/Platforms/Android/CCDirectorAndroid.h
@@ -19,6 +19,8 @@
 
 @interface CCDirectorAndroid : CCDirector
 
+- (void)onGLInitialization;
+
 @end
 
 /* DisplayLinkDirector is a Director that synchronizes timers with the refresh rate of the display.

--- a/cocos2d/Platforms/Android/CCDirectorAndroid.m
+++ b/cocos2d/Platforms/Android/CCDirectorAndroid.m
@@ -44,17 +44,6 @@
 
 @implementation CCDirectorAndroid
 
-- (id) init
-{
-	if( (self=[super init]) ) {
-		// main thread
-		_runningThread = [NSThread currentThread];
-	}
-    
-	return self;
-}
-
-
 -(void) setViewport
 {
 	CGSize size = _winSizeInPixels;
@@ -64,9 +53,7 @@
 -(void) setProjection:(CCDirectorProjection)projection
 {
 	CGSize sizePoint = _winSizeInPoints;
-    
-	[self setViewport];
-    
+        
 	switch (projection) {
 		case CCDirectorProjection2D:
 			_projectionMatrix = GLKMatrix4MakeOrtho(0, sizePoint.width, 0, sizePoint.height, -1024, 1024 );
@@ -92,7 +79,6 @@
 	}
     
 	_projection = projection;
-	[self createStatsLabel];
 }
 
 
@@ -124,6 +110,17 @@
     [[CCActivity currentActivity] runOnGameThread:block];
 }
 
+// Unlike iOS, GL isn't initialized on Android before the config is read
+// Here we can perform the necessary configuration functions that operate on a GL context
+- (void) onGLInitialization
+{
+    [self setViewport];
+    [self createStatsLabel];
+
+	[[CCConfiguration sharedConfiguration] dumpInfo];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"GL_INITIALIZED" object:nil];
+}
 @end
 
 

--- a/cocos2d/Platforms/Android/CCDirectorAndroid.m
+++ b/cocos2d/Platforms/Android/CCDirectorAndroid.m
@@ -117,7 +117,7 @@
     [self setViewport];
     [self createStatsLabel];
 
-	[[CCConfiguration sharedConfiguration] dumpInfo];
+	[[CCDeviceInfo sharedDeviceInfo] dumpInfo];
     
     [[NSNotificationCenter defaultCenter] postNotificationName:@"GL_INITIALIZED" object:nil];
 }

--- a/cocos2d/Platforms/Android/CCGLView.m
+++ b/cocos2d/Platforms/Android/CCGLView.m
@@ -161,6 +161,8 @@ static CCTouchEvent *currentEvent = nil;
         }
         
         [[CCActivity currentActivity] runOnGameThread:^{
+            [CCDirector pushCurrentDirector:_director];
+
             CCResponderManager *mgr = [[CCDirector currentDirector] responderManager];
             switch (phase) {
                 case CCTouchPhaseBegan:
@@ -178,6 +180,9 @@ static CCTouchEvent *currentEvent = nil;
                 default:
                     break;
             }
+
+            [CCDirector popCurrentDirector];
+
             
         } waitUntilDone:YES];
     }

--- a/cocos2d/Platforms/CCAppController.h
+++ b/cocos2d/Platforms/CCAppController.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "CCDirector.h"
 
 @class NSWindow;
 @class CCGLView;
@@ -44,7 +45,7 @@
 /**
  *  The GLView (set from .xib)
  */
-@property (weak) CCGLView *glView;
+@property (weak) CC_VIEW<CCView> *glView;
 
 /**
  *  The application window size to be displayed on mac.

--- a/cocos2d/Platforms/CCAppController.h
+++ b/cocos2d/Platforms/CCAppController.h
@@ -10,16 +10,52 @@
 
 @class NSWindow;
 @class CCGLView;
+
+/**
+ *  
+ CCAppController serves as the setup point for the application and prepares cocos2d to run with various platform specific settings.
+ It exists outside of cocos scene management, and as such can be used to start application specific logic.
+ 
+ An instance of this class (or a subclass) should be invoked from the entry point of execution for each platform. These points are:
+ 
+ * AppDelegate#application:didFinishLaunchingWithOptions: (iOS)
+ * AppDelegate#applicationDidFinishLaunching: (Mac)
+ * CCActivity#run (Android)
+  
+ For SpriteBuilder projects the above files will be generated automatically with the correct invocations. 
+ 
+ Caveats exist for Android, as unlike with other platforms the GL context is not initialized before the setup process begins. Care must 
+ be taken not to perform setup logic that requires access to GL functions before initialization is complete.
+
+ */
+
 @interface CCAppController : NSObject
 
-//for Mac we pass these properties from the AppDelegate to allow configuration
+#if __CC_PLATFORM_MAC
+
+/// -----------------------------------------------------------------------
+/// @name Mac Specific
+/// -----------------------------------------------------------------------
+
+/**
+*  The application window (set from .xib)
+*/
 @property (weak) NSWindow *window;
+
+/**
+ *  The GLView (set from .xib)
+ */
 @property (weak) CCGLView *glView;
 
+#endif
 
-@property(nonatomic, strong) NSDictionary *cocosConfig;
-
+/**
+ *  The name of the first scene to be displayed - by default this is "MainScene.ccb"
+ */
 @property(nonatomic, copy) NSString *firstSceneName;
 
+/**
+ *  Setup and configure cocos for the current platform. This method should be invoked from the entry point of the application.
+ */
 - (void)setupApplication;
 @end

--- a/cocos2d/Platforms/CCAppController.h
+++ b/cocos2d/Platforms/CCAppController.h
@@ -11,6 +11,7 @@
 
 @class NSWindow;
 @class CCGLView;
+@class CCScene;
 
 /**
  *  
@@ -32,6 +33,10 @@
 
 @interface CCAppController : NSObject
 
+/**
+*  The view in which the cocos nodes and scene graph are rendered
+*/
+@property (weak) CC_VIEW<CCView> *glView;
 
 /// -----------------------------------------------------------------------
 /// @name Mac Specific
@@ -43,9 +48,9 @@
 @property (weak) NSWindow *window;
 
 /**
- *  The GLView (set from .xib)
- */
-@property (weak) CC_VIEW<CCView> *glView;
+*  Configuration options that are used to setup cocos2d on Mac
+*/
+- (NSDictionary *)macConfig;
 
 /**
  *  The application window size to be displayed on mac.
@@ -55,6 +60,26 @@
  */
 - (CGSize)defaultWindowSize;
 
+
+/// -----------------------------------------------------------------------
+/// @name iOS Specific
+/// -----------------------------------------------------------------------
+
+/**
+*  Configuration options that are used to setup cocos2d on iOS
+*  By default this reads from "configCocos2d.plist" in the Published-iOS directory
+*/
+- (NSDictionary *)iosConfig;
+
+/// -----------------------------------------------------------------------
+/// @name Android Specific
+/// -----------------------------------------------------------------------
+
+/**
+*  Configuration options that are used to setup cocos2d on Android
+*  By default this reads from "configCocos2d.plist" in the Published-Android directory
+*/
+- (NSDictionary *)androidConfig;
 
 /// -----------------------------------------------------------------------
 /// @name Application Setup
@@ -71,5 +96,12 @@
 *  the application.
  */
 - (void)setupApplication;
+
+/**
+    Instantiate and return the first scene in the application
+    Only override this if you wish to load something other than a `.ccb` file
+    (i.e. a programaticaly created CCScene instance)
+ */
+- (CCScene *)startScene;
 
 @end

--- a/cocos2d/Platforms/CCAppController.h
+++ b/cocos2d/Platforms/CCAppController.h
@@ -31,7 +31,6 @@
 
 @interface CCAppController : NSObject
 
-#if __CC_PLATFORM_MAC
 
 /// -----------------------------------------------------------------------
 /// @name Mac Specific
@@ -47,15 +46,29 @@
  */
 @property (weak) CCGLView *glView;
 
-#endif
+/**
+ *  The application window size to be displayed on mac.
+    Default value (480.0f, 320.0f)
+ *
+ *  @return CGSize
+ */
+- (CGSize)defaultWindowSize;
+
+
+/// -----------------------------------------------------------------------
+/// @name Application Setup
+/// -----------------------------------------------------------------------
+
 
 /**
- *  The name of the first scene to be displayed - by default this is "MainScene.ccb"
+ *  The name of the first scene to be displayed - by default this is "MainScene"
  */
 @property(nonatomic, copy) NSString *firstSceneName;
 
 /**
- *  Setup and configure cocos for the current platform. This method should be invoked from the entry point of the application.
+ *  Setup and configure cocos for the current platform. This method should be invoked from the entry point of
+*  the application.
  */
 - (void)setupApplication;
+
 @end

--- a/cocos2d/Platforms/CCAppController.h
+++ b/cocos2d/Platforms/CCAppController.h
@@ -1,0 +1,25 @@
+//
+//  CCAppController.h
+//  cocos2d
+//
+//  Created by Donald Hutchison on 13/01/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@class NSWindow;
+@class CCGLView;
+@interface CCAppController : NSObject
+
+//for Mac we pass these properties from the AppDelegate to allow configuration
+@property (weak) NSWindow *window;
+@property (weak) CCGLView *glView;
+
+
+@property(nonatomic, strong) NSDictionary *cocosConfig;
+
+@property(nonatomic, copy) NSString *firstSceneName;
+
+- (void)setupApplication;
+@end

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -74,11 +74,10 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
  */
 - (CCScene *)startScene
 {
-    
+    NSAssert(_glView.director, @"Require a valid director to decode the CCB file!");
+
     [CCDirector pushCurrentDirector:_glView.director];
-
     CCScene *scene = [CCBReader loadAsScene:self.firstSceneName];
-
     [CCDirector popCurrentDirector];
 
     return scene;
@@ -115,15 +114,15 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 {
     CCAppDelegate *appDelegate = [UIApplication sharedApplication].delegate;
     [appDelegate constructWindow];
-    
+
     _glView = [appDelegate constructView:config withBounds:appDelegate.window.bounds];
-    
+
     CCDirector *director = _glView.director;
     NSAssert(director, @"CCView failed to construct a director.");
     [self configureDirector:director withConfig:config withView:_glView];
-    
+
     [CCDirector pushCurrentDirector:director];
-    
+
     if([config[CCSetupScreenMode] isEqual:CCScreenModeFixed]){
         [self setupFixedScreenMode:config director:director];
     } else {
@@ -139,7 +138,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
     [appDelegate.window makeKeyAndVisible];
     [appDelegate forceOrientation];
-    
+
     [CCDirector popCurrentDirector];
 }
 
@@ -252,6 +251,8 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
     activity.cocos2dSetupConfig = config;
     [activity applyRequestedOrientation:config];
     [activity constructViewWithConfig:config andDensity:metrics.density];
+    
+    _glView = activity.glView;
     [activity scheduleInRunLoop];
 
     [[CCPackageManager sharedManager] loadPackages];
@@ -259,8 +260,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)performAndroidGLConfiguration
 {
-    CCActivity *activity = [CCActivity currentActivity];
-    [self configureDirector:[CCDirector currentDirector] withConfig:_cocosConfig withView:activity.glView];
+    [self configureDirector:_glView.director withConfig:_cocosConfig withView:_glView];
 
     [self runStartSceneAndroid];
 }
@@ -283,7 +283,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)setupFlexibleScreenMode:(NSDictionary*)config
 {
-    CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector currentDirector];
+    CCDirectorAndroid *director = (CCDirectorAndroid*)_glView.director;
 
     NSInteger device = [CCDeviceInfo runningDevice];
     BOOL tablet = device == CCDeviceiPad || device == CCDeviceiPadRetinaDisplay;
@@ -304,7 +304,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)setupFixedScreenMode:(NSDictionary*)config
 {
-    CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector currentDirector];
+    CCDirectorAndroid *director = (CCDirectorAndroid*)_glView.director;
 
     CGSize size = [CCDirector currentDirector].viewSizeInPixels;
     CGSize fixed = [config[CCScreenModeFixedDimensions] CGSizeValue];
@@ -327,7 +327,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)runStartSceneAndroid
 {
-    CCDirectorAndroid *androidDirector = (CCDirectorAndroid*)[CCDirector currentDirector];
+    CCDirector *androidDirector = _glView.director;
 
     [androidDirector presentScene:[self startScene]];
     [androidDirector setAnimationInterval:1.0/60.0];

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -13,7 +13,6 @@
 #import "CCBReader.h"
 #import "CCDeviceInfo.h"
 #import "CCAppDelegate.h"
-#import "CCTexture.h"
 #import "OALSimpleAudio.h"
 #import "CCPackageManager.h"
 #import "CCFileUtils.h"
@@ -108,7 +107,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
     CCAppDelegate *appDelegate = [UIApplication sharedApplication].delegate;
     [appDelegate constructWindow];
 
-    CCDirector *director = [CCDirector sharedDirector];
+    CCDirector *director = [CCDirector currentDirector];
 
     CC_VIEW <CCDirectorView> *ccview = [appDelegate constructView:config withBounds:appDelegate.window.bounds];
     [self configureDirector:director withConfig:config withView:ccview];
@@ -118,11 +117,6 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
     } else {
         [self setupFlexibleScreenMode:config director:director];
     }
-
-    // Default texture format for PNG/BMP/TIFF/JPEG/GIF images
-    // It can be RGBA8888, RGBA4444, RGB5_A1, RGB565
-    // You can change this setting at any time.
-    [CCTexture setDefaultAlphaPixelFormat:CCTexturePixelFormat_RGBA8888];
 
     // Initialise OpenAL
     [OALSimpleAudio sharedInstance];
@@ -173,7 +167,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)setupFixedScreenMode:(NSDictionary *)config director:(CCDirectorIOS *)director
 {
-    CGSize size = [CCDirector sharedDirector].viewSizeInPixels;
+    CGSize size = [CCDirector currentDirector].viewSizeInPixels;
     CGSize fixed = [config[CCScreenModeFixedDimensions] CGSizeValue];
 
     if([config[CCSetupScreenOrientation] isEqualToString:CCScreenOrientationPortrait]){
@@ -252,7 +246,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 - (void)performAndroidGLConfiguration
 {
     CCActivity *activity = [CCActivity currentActivity];
-    [self configureDirector:[CCDirector sharedDirector] withConfig:_cocosConfig withView:activity.glView];
+    [self configureDirector:[CCDirector currentDirector] withConfig:_cocosConfig withView:activity.glView];
 
     [self runStartSceneAndroid];
 }
@@ -276,7 +270,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)setupFlexibleScreenMode:(NSDictionary*)config
 {
-    CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector sharedDirector];
+    CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector currentDirector];
 
     NSInteger device = [[CCConfiguration sharedConfiguration] runningDevice];
     BOOL tablet = device == CCDeviceiPad || device == CCDeviceiPadRetinaDisplay;
@@ -297,9 +291,9 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)setupFixedScreenMode:(NSDictionary*)config
 {
-    CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector sharedDirector];
+    CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector currentDirector];
 
-    CGSize size = [CCDirector sharedDirector].viewSizeInPixels;
+    CGSize size = [CCDirector currentDirector].viewSizeInPixels;
     CGSize fixed = [config[CCScreenModeFixedDimensions] CGSizeValue];
 
     if([config[CCSetupScreenOrientation] isEqualToString:CCScreenOrientationPortrait])
@@ -320,7 +314,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)runStartSceneAndroid
 {
-    CCDirectorAndroid *androidDirector = (CCDirectorAndroid*)[CCDirector sharedDirector];
+    CCDirectorAndroid *androidDirector = (CCDirectorAndroid*)[CCDirector currentDirector];
 
     [androidDirector runWithScene:[self startScene]];
     [androidDirector setAnimationInterval:1.0/60.0];
@@ -360,7 +354,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)applyConfigurationToCocos:(NSDictionary*)config
 {
-    CCDirectorMac *director = (CCDirectorMac*) [CCDirector sharedDirector];
+    CCDirectorMac *director = (CCDirectorMac*) [CCDirector currentDirector];
 
     CGSize defaultWindowSize = [config[CCMacDefaultWindowSize] CGSizeValue];
     [self.window setFrame:CGRectMake(0.0f, 0.0f, defaultWindowSize.width, defaultWindowSize.height) display:true animate:false];
@@ -380,7 +374,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)runStartSceneMac
 {
-    CCDirectorMac *director = (CCDirectorMac*) [CCDirector sharedDirector];
+    CCDirectorMac *director = (CCDirectorMac*) [CCDirector currentDirector];
     [director runWithScene:[self startScene]];
 }
 

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -63,9 +63,11 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 #elif __CC_PLATFORM_MAC
     [self setupMac];
 #else
-
+/*
+    Explicitly erroring out here as trying to configure under an unrecognised platform will cause spectacular failures
+*/
+#error "Unrecognised platform - CCAppController only supports application configuration on iOS, Mac or Android!"
 #endif
-
 }
 
 

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -85,18 +85,6 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 #pragma mark iOS setup
 
-#if __CC_PLATFORM_IOS
-
-- (void)setupIOS
-{
-    _cocosConfig = [self iosConfig];
-
-    [CCBReader configureCCFileUtils];
-
-    [self applyConfigurationToCocos:_cocosConfig];
-    [self setFirstScene];
-}
-
 - (NSDictionary*)iosConfig
 {
     NSString *configPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"Published-iOS"];
@@ -108,6 +96,18 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
     config[CCScreenModeFixedDimensions] = [NSValue valueWithCGSize:CGSizeMake(586, 384)];
 
     return config;
+}
+
+#if __CC_PLATFORM_IOS
+
+- (void)setupIOS
+{
+    _cocosConfig = [self iosConfig];
+
+    [CCBReader configureCCFileUtils];
+
+    [self applyConfigurationToCocos:_cocosConfig];
+    [self setFirstScene];
 }
 
 - (void)applyConfigurationToCocos:(NSDictionary*)config
@@ -210,6 +210,18 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 #pragma mark Android setup
 
+- (NSDictionary*)androidConfig
+{
+    NSString* configPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"Published-Android"];
+
+    configPath = [configPath stringByAppendingPathComponent:@"configCocos2d.plist"];
+    NSMutableDictionary *config = [NSMutableDictionary dictionaryWithContentsOfFile:configPath];
+
+    config[CCScreenModeFixedDimensions] = [NSValue valueWithCGSize:CGSizeMake(586, 384)];
+
+    return config;
+}
+
 #if __CC_PLATFORM_ANDROID
 
 - (void)setupAndroid
@@ -231,17 +243,6 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 }
 
-- (NSDictionary*)androidConfig
-{
-    NSString* configPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"Published-Android"];
-
-    configPath = [configPath stringByAppendingPathComponent:@"configCocos2d.plist"];
-    NSMutableDictionary *config = [NSMutableDictionary dictionaryWithContentsOfFile:configPath];
-
-    config[CCScreenModeFixedDimensions] = [NSValue valueWithCGSize:CGSizeMake(586, 384)];
-
-    return config;
-}
 
 - (void)performAndroidNonGLConfiguration:(NSDictionary*)config
 {
@@ -345,6 +346,15 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
     return CGSizeMake(480.0f, 320.0f);
 }
 
+- (NSDictionary*)macConfig
+{
+    NSMutableDictionary *macConfig = [NSMutableDictionary dictionary];
+
+    macConfig[CCMacDefaultWindowSize] = [NSValue valueWithCGSize:[self defaultWindowSize]];
+
+    return macConfig;
+}
+
 #if __CC_PLATFORM_MAC
 
 -(void)setupMac
@@ -355,14 +365,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
     [self runStartSceneMac];
 }
 
-- (NSDictionary*)macConfig
-{
-    NSMutableDictionary *macConfig = [NSMutableDictionary dictionary];
-    
-    macConfig[CCMacDefaultWindowSize] = [NSValue valueWithCGSize:[self defaultWindowSize]];
-    
-    return macConfig;
-}
+
 
 - (void)applyConfigurationToCocos:(NSDictionary*)config
 {

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -70,7 +70,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 
 /*
-    The first scene to start the application with, can be overridden in subclass
+    Instantiate and return the first scene
  */
 - (CCScene *)startScene
 {
@@ -366,15 +366,14 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)applyConfigurationToCocos:(NSDictionary*)config
 {
-    CCDirectorMac *director = (CCDirectorMac*) [CCDirector currentDirector];
-
+    CCDirectorMac *director = (CCDirectorMac*) _glView.director;
     CGSize defaultWindowSize = [config[CCMacDefaultWindowSize] CGSizeValue];
+    
     [self.window setFrame:CGRectMake(0.0f, 0.0f, defaultWindowSize.width, defaultWindowSize.height) display:true animate:false];
     [self.glView setFrame:self.window.frame];
-
-    // connect the OpenGL view with the director
-    [director setView:self.glView];
-
+    
+    [director reshapeProjection:CC_SIZE_SCALE(defaultWindowSize, director.contentScaleFactor)];
+    
     // Enable "moving" mouse event. Default no.
     [self.window setAcceptsMouseMovedEvents:NO];
 
@@ -386,7 +385,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (void)runStartSceneMac
 {
-    CCDirectorMac *director = (CCDirectorMac*) [CCDirector currentDirector];
+    CCDirectorMac *director = (CCDirectorMac*) _glView.director;
     [director presentScene:[self startScene]];
 }
 

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -11,6 +11,13 @@
 #import "CCAppController.h"
 #import "CCScene.h"
 #import "CCBReader.h"
+#import "CCDeviceInfo.h"
+#import "CCAppDelegate.h"
+#import "CCTexture.h"
+#import "OALSimpleAudio.h"
+#import "CCPackageManager.h"
+#import "CCFileUtils.h"
+#import "ccUtils.h"
 
 #if __CC_PLATFORM_ANDROID
 

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -25,6 +25,10 @@
 
 #endif
 
+#if __CC_PLATFORM_MAC
+#import "CCDirectorMac.h"
+#endif
+
 static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 {
     int scale = 1;
@@ -36,6 +40,17 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 @implementation CCAppController
 {
     NSDictionary *_cocosConfig;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        _firstSceneName = @"MainScene";
+    }
+
+    return self;
 }
 
 - (void)setupApplication
@@ -316,6 +331,14 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 #pragma mark Mac setup
 
+/*
+    Override to change mac window size
+*/
+-(CGSize)defaultWindowSize
+{
+    return CGSizeMake(480.0f, 320.0f);
+}
+
 #if __CC_PLATFORM_MAC
 
 -(void)setupMac
@@ -324,14 +347,6 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
     [CCBReader configureCCFileUtils];
     [self applyConfigurationToCocos:_cocosConfig];
     [self runStartSceneMac];
-}
-
-/*
-    Override to change mac window size
-*/
--(CGSize)defaultWindowSize
-{
-    return CGSizeMake(480.0f, 320.0f);
 }
 
 - (NSDictionary*)macConfig

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -1,0 +1,367 @@
+//
+//  CCAppController.m
+//  cocos2d
+//
+//  Created by Donald Hutchison on 13/01/15.
+//
+//
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+#import "CCAppController.h"
+#import "CCScene.h"
+#import "CCBReader.h"
+
+#if __CC_PLATFORM_ANDROID
+
+#import "CCActivity.h"
+
+#endif
+
+static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
+{
+    int scale = 1;
+    while(fixedSize*scale < size) scale *= 2;
+
+    return scale;
+}
+
+@implementation CCAppController
+{
+    NSDictionary *_cocosConfig;
+}
+
+- (void)setupApplication
+{
+#if __CC_PLATFORM_IOS
+    [self setupIOS];
+#elif __CC_PLATFORM_ANDROID
+    [self setupAndroid];
+#elif __CC_PLATFORM_MAC
+    [self setupMac];
+#else
+
+#endif
+
+}
+
+
+/*
+    The first scene to start the application with, can be overridden in subclass
+ */
+- (CCScene *)startScene
+{
+    return [CCBReader loadAsScene:self.firstSceneName];
+}
+
+#pragma mark iOS setup
+
+#if __CC_PLATFORM_IOS
+
+- (void)setupIOS
+{
+    _cocosConfig = [self iosConfig];
+
+    [CCBReader configureCCFileUtils];
+
+    [self applyConfigurationToCocos:_cocosConfig];
+    [self setFirstScene];
+}
+
+- (NSDictionary*)iosConfig
+{
+    NSString *configPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"Published-iOS"];
+    configPath = [configPath stringByAppendingPathComponent:@"configCocos2d.plist"];
+
+    NSMutableDictionary *config = [NSMutableDictionary dictionaryWithContentsOfFile:configPath];
+
+    // Fixed size. As wide as iPhone 5 at 2x and as high as the iPad at 2x.
+    config[CCScreenModeFixedDimensions] = [NSValue valueWithCGSize:CGSizeMake(586, 384)];
+
+    return config;
+}
+
+- (void)applyConfigurationToCocos:(NSDictionary*)config
+{
+    CCAppDelegate *appDelegate = [UIApplication sharedApplication].delegate;
+    [appDelegate constructWindow];
+
+    CCDirector *director = [CCDirector sharedDirector];
+
+    CC_VIEW <CCDirectorView> *ccview = [appDelegate constructView:config withBounds:appDelegate.window.bounds];
+    [self configureDirector:director withConfig:config withView:ccview];
+
+    if([config[CCSetupScreenMode] isEqual:CCScreenModeFixed]){
+        [self setupFixedScreenMode:config director:director];
+    } else {
+        [self setupFlexibleScreenMode:config director:director];
+    }
+
+    // Default texture format for PNG/BMP/TIFF/JPEG/GIF images
+    // It can be RGBA8888, RGBA4444, RGB5_A1, RGB565
+    // You can change this setting at any time.
+    [CCTexture setDefaultAlphaPixelFormat:CCTexturePixelFormat_RGBA8888];
+
+    // Initialise OpenAL
+    [OALSimpleAudio sharedInstance];
+
+    [appDelegate constructNavController:config];
+
+    [[CCPackageManager sharedManager] loadPackages];
+
+    [appDelegate.window makeKeyAndVisible];
+    [appDelegate forceOrientation];
+}
+
+- (void)configureDirector:(CCDirector *)director withConfig:(NSDictionary *)config withView:(CC_VIEW <CCDirectorView> *)ccview
+{
+    CCDirectorIOS*directorIOS = (CCDirectorIOS*) director;
+    directorIOS.wantsFullScreenLayout = YES;
+
+    // Display FSP and SPF
+    [directorIOS setDisplayStats:[config[CCSetupShowDebugStats] boolValue]];
+
+    // set FPS at 60
+    NSTimeInterval animationInterval = [(config[CCSetupAnimationInterval] ?: @(1.0/60.0)) doubleValue];
+    [directorIOS setAnimationInterval:animationInterval];
+
+    directorIOS.fixedUpdateInterval = [(config[CCSetupFixedUpdateInterval] ?: @(1.0/60.0)) doubleValue];
+
+    // attach the openglView to the director
+    [directorIOS setView:ccview];
+}
+
+- (void)setupFlexibleScreenMode:(NSDictionary *)config director:(CCDirector *)director
+{
+    // Setup tablet scaling if it was requested.
+    if(	UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&	[config[CCSetupTabletScale2X] boolValue] )
+    {
+        // Set the director to use 2 points per pixel.
+        director.contentScaleFactor *= 2.0;
+
+        // Set the UI scale factor to show things at "native" size.
+        director.UIScaleFactor = 0.5;
+
+        // Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
+        [[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
+    }
+
+    [director setProjection:CCDirectorProjection2D];
+}
+
+- (void)setupFixedScreenMode:(NSDictionary *)config director:(CCDirectorIOS *)director
+{
+    CGSize size = [CCDirector sharedDirector].viewSizeInPixels;
+    CGSize fixed = [config[CCScreenModeFixedDimensions] CGSizeValue];
+
+    if([config[CCSetupScreenOrientation] isEqualToString:CCScreenOrientationPortrait]){
+        CC_SWAP(fixed.width, fixed.height);
+    }
+
+    // Find the minimal power-of-two scale that covers both the width and height.
+    CGFloat scaleFactor = MIN(FindPOTScale(size.width, fixed.width), FindPOTScale(size.height, fixed.height));
+
+    director.contentScaleFactor = scaleFactor;
+    director.UIScaleFactor = (float)(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 1.0 : 0.5);
+
+    // Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
+    [[CCFileUtils sharedFileUtils] setiPadContentScaleFactor: 2.0];
+
+    director.designSize = fixed;
+    [director setProjection:CCDirectorProjectionCustom];
+}
+
+- (void)setFirstScene
+{
+    CCAppDelegate *appDelegate = [UIApplication sharedApplication].delegate;
+    appDelegate.startScene = [self startScene];
+}
+
+#endif
+
+#pragma mark Android setup
+
+#if __CC_PLATFORM_ANDROID
+
+- (void)setupAndroid
+{
+    _cocosConfig = [self androidConfig];
+    [CCBReader configureCCFileUtils];
+
+    [self performAndroidNonGLConfiguration:_cocosConfig];
+
+    /*
+        Unlike iOS, GL is not initialized on Android before the application is constructed.
+        We must explicitly hang off of Android's `surfaceCreated` callback, at which point
+        we can continue with configuring cocos's GL dependant properties.
+    */
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                          selector:@selector(performAndroidGLConfiguration)
+                                          name:@"GL_INITIALIZED"
+                                          object:nil];
+
+}
+
+- (NSDictionary*)androidConfig
+{
+    NSString* configPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"Published-Android"];
+
+    configPath = [configPath stringByAppendingPathComponent:@"configCocos2d.plist"];
+    NSMutableDictionary *config = [NSMutableDictionary dictionaryWithContentsOfFile:configPath];
+
+    config[CCScreenModeFixedDimensions] = [NSValue valueWithCGSize:CGSizeMake(586, 384)];
+
+    return config;
+}
+
+- (void)performAndroidNonGLConfiguration:(NSDictionary*)config
+{
+    CCActivity *activity = [CCActivity currentActivity];
+    AndroidDisplayMetrics* metrics = [activity getDisplayMetrics];
+
+    activity.cocos2dSetupConfig = config;
+    [activity applyRequestedOrientation:config];
+    [activity constructViewWithConfig:config andDensity:metrics.density];
+    [activity scheduleInRunLoop];
+
+    [[CCPackageManager sharedManager] loadPackages];
+}
+
+- (void)performAndroidGLConfiguration
+{
+    CCActivity *activity = [CCActivity currentActivity];
+    [self configureDirector:[CCDirector sharedDirector] withConfig:_cocosConfig withView:activity.glView];
+
+    [self runStartSceneAndroid];
+}
+
+- (void)configureDirector:(CCDirector*)director withConfig:(NSDictionary *)config withView:(CCGLView*)view
+{
+    CCDirectorAndroid *androidDirector = (CCDirectorAndroid*)director;
+    director.delegate = [CCActivity currentActivity];
+    [CCTexture setDefaultAlphaPixelFormat:CCTexturePixelFormat_RGBA8888];
+    [director setView:view];
+
+    if([config[CCSetupScreenMode] isEqual:CCScreenModeFixed])
+    {
+        [self setupFixedScreenMode:config];
+    }
+    else
+    {
+        [self setupFlexibleScreenMode:config];
+    }
+}
+
+- (void)setupFlexibleScreenMode:(NSDictionary*)config
+{
+    CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector sharedDirector];
+
+    NSInteger device = [[CCConfiguration sharedConfiguration] runningDevice];
+    BOOL tablet = device == CCDeviceiPad || device == CCDeviceiPadRetinaDisplay;
+
+    if(tablet && [config[CCSetupTabletScale2X] boolValue])
+    {
+        // Set the UI scale factor to show things at "native" size.
+        director.UIScaleFactor = 0.5;
+
+        // Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
+        [[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
+    }
+
+    director.contentScaleFactor *= 1.83;
+
+    [director setProjection:CCDirectorProjection2D];
+}
+
+- (void)setupFixedScreenMode:(NSDictionary*)config
+{
+    CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector sharedDirector];
+
+    CGSize size = [CCDirector sharedDirector].viewSizeInPixels;
+    CGSize fixed = [config[CCScreenModeFixedDimensions] CGSizeValue];
+
+    if([config[CCSetupScreenOrientation] isEqualToString:CCScreenOrientationPortrait])
+    {
+        CC_SWAP(fixed.width, fixed.height);
+    }
+
+    CGFloat scaleFactor = MAX(size.width/ fixed.width, size.height/ fixed.height);
+
+    director.contentScaleFactor = scaleFactor;
+    director.UIScaleFactor = 1;
+
+    [[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
+
+    director.designSize = fixed;
+    [director setProjection:CCDirectorProjectionCustom];
+}
+
+- (void)runStartSceneAndroid
+{
+    CCDirectorAndroid *androidDirector = (CCDirectorAndroid*)[CCDirector sharedDirector];
+
+    [androidDirector runWithScene:[self startScene]];
+    [androidDirector setAnimationInterval:1.0/60.0];
+    [androidDirector startAnimation];
+}
+
+#endif
+
+#pragma mark Mac setup
+
+#if __CC_PLATFORM_MAC
+
+-(void)setupMac
+{
+    _cocosConfig = [self macConfig];
+    [CCBReader configureCCFileUtils];
+    [self applyConfigurationToCocos:_cocosConfig];
+    [self runStartSceneMac];
+}
+
+/*
+    Override to change mac window size
+*/
+-(CGSize)defaultWindowSize
+{
+    return CGSizeMake(480.0f, 320.0f);
+}
+
+- (NSDictionary*)macConfig
+{
+    NSMutableDictionary *macConfig = [NSMutableDictionary dictionary];
+    
+    macConfig[CCMacDefaultWindowSize] = [NSValue valueWithCGSize:[self defaultWindowSize]];
+    
+    return macConfig;
+}
+
+- (void)applyConfigurationToCocos:(NSDictionary*)config
+{
+    CCDirectorMac *director = (CCDirectorMac*) [CCDirector sharedDirector];
+
+    CGSize defaultWindowSize = [config[CCMacDefaultWindowSize] CGSizeValue];
+    [self.window setFrame:CGRectMake(0.0f, 0.0f, defaultWindowSize.width, defaultWindowSize.height) display:true animate:false];
+    [self.glView setFrame:self.window.frame];
+
+    // connect the OpenGL view with the director
+    [director setView:self.glView];
+
+    // Enable "moving" mouse event. Default no.
+    [self.window setAcceptsMouseMovedEvents:NO];
+
+    // Center main window
+    [self.window center];
+
+    [[CCPackageManager sharedManager] loadPackages];
+}
+
+- (void)runStartSceneMac
+{
+    CCDirectorMac *director = (CCDirectorMac*) [CCDirector sharedDirector];
+    [director runWithScene:[self startScene]];
+}
+
+#endif
+
+@end

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -375,7 +375,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 - (void)runStartSceneMac
 {
     CCDirectorMac *director = (CCDirectorMac*) [CCDirector currentDirector];
-    [director runWithScene:[self startScene]];
+    [director presentScene:[self startScene]];
 }
 
 #endif

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -21,6 +21,7 @@
 #if __CC_PLATFORM_ANDROID
 
 #import "CCActivity.h"
+#import "CCDirectorAndroid.h"
 
 #endif
 
@@ -255,7 +256,6 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 {
     CCDirectorAndroid *androidDirector = (CCDirectorAndroid*)director;
     director.delegate = [CCActivity currentActivity];
-    [CCTexture setDefaultAlphaPixelFormat:CCTexturePixelFormat_RGBA8888];
     [director setView:view];
 
     if([config[CCSetupScreenMode] isEqual:CCScreenModeFixed])
@@ -272,7 +272,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 {
     CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector currentDirector];
 
-    NSInteger device = [[CCConfiguration sharedConfiguration] runningDevice];
+    NSInteger device = [CCDeviceInfo runningDevice];
     BOOL tablet = device == CCDeviceiPad || device == CCDeviceiPadRetinaDisplay;
 
     if(tablet && [config[CCSetupTabletScale2X] boolValue])
@@ -316,9 +316,8 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 {
     CCDirectorAndroid *androidDirector = (CCDirectorAndroid*)[CCDirector currentDirector];
 
-    [androidDirector runWithScene:[self startScene]];
+    [androidDirector presentScene:[self startScene]];
     [androidDirector setAnimationInterval:1.0/60.0];
-    [androidDirector startAnimation];
 }
 
 #endif

--- a/cocos2d/Platforms/Mac/CCDirectorMac.m
+++ b/cocos2d/Platforms/Mac/CCDirectorMac.m
@@ -279,33 +279,7 @@
 
 
 		case CCDirectorProjection3D: {
-//			float zeye = [self getZEye];
-//
-//			kmGLMatrixMode(KM_GL_PROJECTION);
-//			kmGLLoadIdentity();
-//
-//			kmMat4 matrixPerspective, matrixLookup;
-//
-//			// issue #1334
-//			kmMat4PerspectiveProjection( &matrixPerspective, 60, (GLfloat)size.width/size.height, 0.1f, MAX(zeye*2,1500) );
-////			kmMat4PerspectiveProjection( &matrixPerspective, 60, (GLfloat)size.width/size.height, 0.1f, 1500);
-//
-//
-//			kmGLMultMatrix(&matrixPerspective);
-//
-//
-//			kmGLMatrixMode(KM_GL_MODELVIEW);
-//			kmGLLoadIdentity();
-//			kmVec3 eye, center, up;
-//
-//			float eyeZ = size.height * zeye / size.height;
-//
-//			kmVec3Fill( &eye, size.width/2, size.height/2, eyeZ );
-//			kmVec3Fill( &center, size.width/2, size.height/2, 0 );
-//			kmVec3Fill( &up, 0, 1, 0);
-//			kmMat4LookAt(&matrixLookup, &eye, &center, &up);
-//			kmGLMultMatrix(&matrixLookup);
-//			break;
+
 		}
 
 		case CCDirectorProjectionCustom:

--- a/cocos2d/Platforms/iOS/CCAppDelegate.h
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.h
@@ -27,7 +27,6 @@
 #if __CC_PLATFORM_IOS
 
 #import <Foundation/Foundation.h>
-
 #import <UIKit/UIKit.h>
 
 #import "CCDirectorIOS.h"
@@ -76,11 +75,10 @@
 // -----------------------------------------------------------------------
 
 /**
- *  Override this method to return the very first scene that Cocos2D should present.
  *
- *  @return The first scene of your app. It will be presented automatically.
+ *  @note The first scene of your app. It will be presented automatically.
  */
-- (CCScene*) startScene;
+@property (nonatomic) CCScene *startScene;
 
 // -----------------------------------------------------------------------
 /** @name Cocos2d Setup */
@@ -112,6 +110,13 @@
  */
 - (void) setupCocos2dWithOptions:(NSDictionary*)config;
 
+- (void)constructNavController:(NSDictionary *)config;
+
+- (void)constructWindow;
+
+- (void)forceOrientation;
+
+- (CC_VIEW <CCDirectorView> *)constructView:(NSDictionary *)config withBounds:(CGRect)bounds;
 @end
 
 #endif

--- a/cocos2d/Platforms/iOS/CCAppDelegate.h
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.h
@@ -30,7 +30,7 @@
 #import <UIKit/UIKit.h>
 
 #import "CCDirectorIOS.h"
-
+#import "CCDirectorView.h"
 @class CCAppDelegate;
 @class CCScene;
 

--- a/cocos2d/Platforms/iOS/CCAppDelegate.h
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.h
@@ -116,7 +116,7 @@
 
 - (void)forceOrientation;
 
-- (CC_VIEW <CCDirectorView> *)constructView:(NSDictionary *)config withBounds:(CGRect)bounds;
+- (CC_VIEW <CCView> *)constructView:(NSDictionary *)config withBounds:(CGRect)bounds;
 @end
 
 #endif

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -175,7 +175,7 @@
 #endif
 }
 
-- (CC_VIEW <CCDirectorView> *)constructView:(NSDictionary *)config withBounds:(CGRect)bounds
+- (CC_VIEW <CCView> *)constructView:(NSDictionary *)config withBounds:(CGRect)bounds
 {
     // CCView creation
     // viewWithFrame: size of the OpenGL view. For full screen use [_window bounds]
@@ -190,7 +190,7 @@
     //  - Possible values: YES, NO
     // numberOfSamples: Only valid if multisampling is enabled
     //  - Possible values: 0 to glGetIntegerv(GL_MAX_SAMPLES_APPLE)
-    CC_VIEW<CCDirectorView> *ccview = nil;
+    CC_VIEW<CCView> *ccview = nil;
     switch([CCDeviceInfo graphicsAPI]){
         case CCGraphicsAPIGL:
         {

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -30,11 +30,11 @@
 #import "ccUtils.h"
 
 #import "CCAppDelegate.h"
-#import "CCDeviceInfo.h"
 #import "CCTexture.h"
 #import "CCFileUtils.h"
 #import "OALSimpleAudio.h"
 #import "CCPackageManager.h"
+#import "CCDeviceInfo.h"
 
 #import "CCDirector_Private.h"
 
@@ -42,8 +42,6 @@
 #import "CCMetalView.h"
 #endif
 
-// Fixed size. As wide as iPhone 5 at 2x and as high as the iPad at 2x.
-const CGSize FIXED_SIZE = {568, 384};
 
 @interface CCNavigationController ()
 {
@@ -138,147 +136,24 @@ const CGSize FIXED_SIZE = {568, 384};
 	return UIInterfaceOrientationMaskAll;
 }
 
-- (CCScene*) startScene
+- (void)constructNavController:(NSDictionary *)config
 {
-    NSAssert(NO, @"Override CCAppDelegate and implement the startScene method");
-    return NULL;
+    // Create a Navigation Controller with the Director
+    navController_ = [[CCNavigationController alloc] initWithRootViewController:[CCDirector currentDirector]];
+    navController_.navigationBarHidden = YES;
+    navController_.appDelegate = self;
+    navController_.screenOrientation = (config[CCSetupScreenOrientation] ?: CCScreenOrientationLandscape);
+
+    // for rotation and other messages
+    [[CCDirector currentDirector] setDelegate:navController_];
+
+    // set the Navigation Controller as the root view controller
+    [window_ setRootViewController:navController_];
 }
 
-static CGFloat
-FindPOTScale(CGFloat size, CGFloat fixedSize)
+- (void)constructWindow
 {
-	int scale = 1;
-	while(fixedSize*scale < size) scale *= 2;
-	
-	return scale;
-}
-
-- (void) setupCocos2dWithOptions:(NSDictionary*)config
-{
-	// Create the main window
-	window_ = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-	CGRect bounds = [window_ bounds];
-    
-	// CCView creation
-	// viewWithFrame: size of the OpenGL view. For full screen use [_window bounds]
-	//  - Possible values: any CGRect
-	// pixelFormat: Format of the render buffer. Use RGBA8 for better color precision (eg: gradients). But it takes more memory and it is slower
-	//	- Possible values: kEAGLColorFormatRGBA8, kEAGLColorFormatRGB565
-	// depthFormat: Use stencil if you plan to use CCClippingNode. Use Depth if you plan to use 3D effects, like CCCamera or CCNode#vertexZ
-	//  - Possible values: 0, GL_DEPTH_COMPONENT24_OES, GL_DEPTH24_STENCIL8_OES
-	// sharegroup: OpenGL sharegroup. Useful if you want to share the same OpenGL context between different threads
-	//  - Possible values: nil, or any valid EAGLSharegroup group
-	// multiSampling: Whether or not to enable multisampling
-	//  - Possible values: YES, NO
-	// numberOfSamples: Only valid if multisampling is enabled
-	//  - Possible values: 0 to glGetIntegerv(GL_MAX_SAMPLES_APPLE)
-	CC_VIEW<CCView> *ccview = nil;
-	switch([CCDeviceInfo graphicsAPI]){
-		case CCGraphicsAPIGL:
-        {
-			ccview = [CCViewiOSGL
-				viewWithFrame:bounds
-				pixelFormat:config[CCSetupPixelFormat] ?: kEAGLColorFormatRGBA8
-				depthFormat:[config[CCSetupDepthFormat] unsignedIntValue]
-				preserveBackbuffer:[config[CCSetupPreserveBackbuffer] boolValue]
-				sharegroup:nil
-				multiSampling:[config[CCSetupMultiSampling] boolValue]
-				numberOfSamples:[config[CCSetupNumberOfSamples] unsignedIntValue]
-			];
-        }
-			break;
-#if __CC_METAL_SUPPORTED_AND_ENABLED
-		case CCGraphicsAPIMetal:
-			// TODO support MSAA, depth buffers, etc.
-			ccview = [[CCMetalView alloc] initWithFrame:bounds];
-			break;
-#endif
-		default: NSAssert(NO, @"Internal error: Graphics API not set up.");
-	}
-	
-    CCDirector *director = ccview.director;
-    NSAssert(director, @"The CCView failed to create a director.");
-	director.wantsFullScreenLayout = YES;
-    
-#warning TODO temporary
-    [CCDirector pushCurrentDirector:director];
-	
-	// Display FSP and SPF
-	[director setDisplayStats:[config[CCSetupShowDebugStats] boolValue]];
-	
-	// set FPS at 60
-	NSTimeInterval animationInterval = [(config[CCSetupAnimationInterval] ?: @(1.0/60.0)) doubleValue];
-	[director setAnimationInterval:animationInterval];
-	
-	director.fixedUpdateInterval = [(config[CCSetupFixedUpdateInterval] ?: @(1.0/60.0)) doubleValue];
-	
-	if([config[CCSetupScreenMode] isEqual:CCScreenModeFixed]){
-        [self setupFixedScreenMode:config director:director];
-    } else {
-        [self setupFlexibleScreenMode:config director:director];
-    }
-	
-    // Initialise OpenAL
-    [OALSimpleAudio sharedInstance];
-	
-	// Create a Navigation Controller with the Director
-	navController_ = [[CCNavigationController alloc] initWithRootViewController:director];
-	navController_.navigationBarHidden = YES;
-	navController_.appDelegate = self;
-	navController_.screenOrientation = (config[CCSetupScreenOrientation] ?: CCScreenOrientationLandscape);
-    
-	// for rotation and other messages
-	[director setDelegate:navController_];
-	
-	// set the Navigation Controller as the root view controller
-	[window_ setRootViewController:navController_];
-    
-    [[CCPackageManager sharedManager] loadPackages];
-	
-	[window_ makeKeyAndVisible];
-    
-    [self forceOrientation];
-    [CCDirector popCurrentDirector];
-}
-
-- (void)setupFlexibleScreenMode:(NSDictionary *)config director:(CCDirector *)director
-{
-    // Setup tablet scaling if it was requested.
-    if(	UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&	[config[CCSetupTabletScale2X] boolValue] )
-    {
-        // Set the director to use 2 points per pixel.
-        director.contentScaleFactor *= 2.0;
-
-        // Set the UI scale factor to show things at "native" size.
-        director.UIScaleFactor = 0.5;
-
-        // Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
-        [[CCFileUtils sharedFileUtils] setiPadContentScaleFactor:2.0];
-    }
-
-    [director setProjection:CCDirectorProjection2D];
-}
-
-- (void)setupFixedScreenMode:(NSDictionary *)config director:(CCDirector *)director
-{
-    CGSize size = [CCDirector currentDirector].viewSizeInPixels;
-    CGSize fixed = FIXED_SIZE;
-
-    if([config[CCSetupScreenOrientation] isEqualToString:CCScreenOrientationPortrait]){
-			CC_SWAP(fixed.width, fixed.height);
-		}
-
-    // Find the minimal power-of-two scale that covers both the width and height.
-    CGFloat scaleFactor = MIN(FindPOTScale(size.width, fixed.width), FindPOTScale(size.height, fixed.height));
-
-    director.contentScaleFactor = scaleFactor;
-    director.UIScaleFactor = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 1.0 : 0.5);
-
-    // Let CCFileUtils know that "-ipad" textures should be treated as having a contentScale of 2.0.
-    [[CCFileUtils sharedFileUtils] setiPadContentScaleFactor: 2.0];
-
-    director.designSize = fixed;
-    [director setProjection:CCDirectorProjectionCustom];
+    window_ = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 }
 
 // iOS8 hack around orientation bug
@@ -299,6 +174,51 @@ FindPOTScale(CGFloat size, CGFloat fixedSize)
     }
 #endif
 }
+
+- (CC_VIEW <CCDirectorView> *)constructView:(NSDictionary *)config withBounds:(CGRect)bounds
+{
+    // CCView creation
+    // viewWithFrame: size of the OpenGL view. For full screen use [_window bounds]
+    //  - Possible values: any CGRect
+    // pixelFormat: Format of the render buffer. Use RGBA8 for better color precision (eg: gradients). But it takes more memory and it is slower
+    //	- Possible values: kEAGLColorFormatRGBA8, kEAGLColorFormatRGB565
+    // depthFormat: Use stencil if you plan to use CCClippingNode. Use Depth if you plan to use 3D effects, like CCCamera or CCNode#vertexZ
+    //  - Possible values: 0, GL_DEPTH_COMPONENT24_OES, GL_DEPTH24_STENCIL8_OES
+    // sharegroup: OpenGL sharegroup. Useful if you want to share the same OpenGL context between different threads
+    //  - Possible values: nil, or any valid EAGLSharegroup group
+    // multiSampling: Whether or not to enable multisampling
+    //  - Possible values: YES, NO
+    // numberOfSamples: Only valid if multisampling is enabled
+    //  - Possible values: 0 to glGetIntegerv(GL_MAX_SAMPLES_APPLE)
+    CC_VIEW<CCDirectorView> *ccview = nil;
+    switch([CCDeviceInfo graphicsAPI]){
+        case CCGraphicsAPIGL:
+        {
+            ccview = [CCViewiOSGL
+                    viewWithFrame:bounds
+                      pixelFormat:config[CCSetupPixelFormat] ?: kEAGLColorFormatRGBA8
+                      depthFormat:[config[CCSetupDepthFormat] unsignedIntValue]
+               preserveBackbuffer:[config[CCSetupPreserveBackbuffer] boolValue]
+                       sharegroup:nil
+                    multiSampling:[config[CCSetupMultiSampling] boolValue]
+                  numberOfSamples:[config[CCSetupNumberOfSamples] unsignedIntValue]
+            ];
+        }
+            break;
+#if __CC_METAL_SUPPORTED_AND_ENABLED
+		case CCGraphicsAPIMetal:
+			// TODO support MSAA, depth buffers, etc.
+			ccview = [[CCMetalView alloc] initWithFrame:bounds];
+			break;
+#endif
+        default: NSAssert(NO, @"Internal error: Graphics API not set up.");
+    }
+
+    return ccview;
+}
+
+
+#pragma mark UIApplicationDelegate Protocol
 
 // getting a call, pause the game
 -(void) applicationWillResignActive:(UIApplication *)application

--- a/cocos2d/Platforms/iOS/CCAppDelegate.m
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.m
@@ -27,12 +27,9 @@
 #if __CC_PLATFORM_IOS
 
 #import "ccTypes.h"
-#import "ccUtils.h"
 
 #import "CCAppDelegate.h"
 #import "CCTexture.h"
-#import "CCFileUtils.h"
-#import "OALSimpleAudio.h"
 #import "CCPackageManager.h"
 #import "CCDeviceInfo.h"
 
@@ -105,19 +102,12 @@
 	
 	return GLKMatrix4MakeOrtho(offset.x, sizePoint.width + offset.x, offset.y, sizePoint.height + offset.y, -1024, 1024);
 }
-
-// This is needed for iOS4 and iOS5 in order to ensure
-// that the 1st scene has the correct dimensions
-// This is not needed on iOS6 and could be added to the application:didFinish...
-
-#warning don't believe the lies above! This is the main entry point to your first scene for iOS!
+    
 -(void) directorDidReshapeProjection:(CCDirector*)director
 {
     if(director.runningScene == nil) {
-        [CCDirector pushCurrentDirector:director];
         CCScene * scene = [_appDelegate startScene];
-        [CCDirector popCurrentDirector];
-        
+
         // Add the first scene to the stack. The director will draw it immediately into the framebuffer. (Animation is started automatically when the view is displayed.)
         // and add the scene to the stack. The director will run it when it automatically when the view is displayed.
         [director presentScene: scene];


### PR DESCRIPTION
This pull request is designed to make the startup and initialization of cocos consistent across platforms for SpriteBuilder generated applications. This only really affects projects which use cocos/SpriteBuilder's application template classes e.g. `CCAppDelegate` - applications with custom setup logic should remain unaffected. It addresses the issue https://github.com/spritebuilder/SpriteBuilder/issues/912 

The most significant change is that all cocos related configuration (setting of `contentScaleFactor`, application of `cocosConfig2d.plist` values) is done outside of any platform specific files like `CCActivity`. These platform level classes call out to a common `CCAppController` instance which invokes base functionality to setup everything in a common manner. This can best be described by the handy-dandy pseudo UML diagram below.

![untitled diagram](https://cloud.githubusercontent.com/assets/85586/6042125/9eaeebb6-ac82-11e4-9932-955b2794d3ec.png)

The main benefits are 
- Clear separation of platform internals and cocos specific config
- A single entry point is presented to the user for the launching of application specific logic (previously the first default point of user control was `MainScene` which exists in the scene lifecycle and is not application persistent)
- Configuration is encapsulated in a single class

_Note_ - due to the way `CCGLView` (android) behaves, configuration has to be done in two stages - before and after GL initialization. Unlike the other platforms, there is no available GL context on android at the start of exectution. This would require changing the initialization / configuration functionality of the `CCGLView` and may be done in a further review.
