### PR TITLE
removeAction doesn't work

### DIFF
--- a/cocos2d/CCScheduler.m
+++ b/cocos2d/CCScheduler.m
@@ -726,7 +726,7 @@ CompareTimers(const void *a, const void *b, void *context)
 -(void)removeAction:(CCAction*) action fromTarget:(NSObject<CCSchedulableTarget> *)target;
 {
     CCScheduledTarget *scheduledTarget = [self scheduledTargetForTarget:target insert:YES];
-    [scheduledTarget.actions removeObject:target];
+    [scheduledTarget.actions removeObject:action];
 }
 
 -(void)removeAllActionsFromTarget:(NSObject<CCSchedulableTarget> *)target


### PR DESCRIPTION
Due to a typo, [CCScheduler removeAction:] wasn't working. It was trying to remove the target from the list of actions. Oops, my bad.
