### PR TITLE
Expose various CCNS methods across platforms.

### DIFF
--- a/cocos2d/Platforms/CCNS.h
+++ b/cocos2d/Platforms/CCNS.h
@@ -26,11 +26,9 @@
 
 #import "ccTypes.h"
 
-#if __CC_PLATFORM_ANDROID || __CC_PLATFORM_IOS
-
-#if 1
-//#ifndef __CC_CG_STRING_UTILS
+#ifndef __CC_CG_STRING_UTILS
 #define __CC_CG_STRING_UTILS
+
 
 static inline NSString *CCNSStringFromCGPoint(CGPoint point);
 static inline NSString *CCNSStringFromCGSize(CGSize size);
@@ -102,6 +100,8 @@ static inline NSString *CCNSStringFromCGSize(CGSize size)
     return [NSString stringWithFormat:@"{%g, %g}", size.width, size.height];
 }
 
+#if __CC_PLATFORM_ANDROID || __CC_PLATFORM_IOS
+
 #define CCRectFromString(__r__)		CCCGRectFromString(__r__)
 #define CCPointFromString(__p__)	CCCGPointFromString(__p__)
 #define CCSizeFromString(__s__)		CCCGSizeFromString(__s__)
@@ -109,7 +109,6 @@ static inline NSString *CCNSStringFromCGSize(CGSize size)
 #define CCNSRectToCGRect
 #define CCNSPointToCGPoint
 
-#endif
 
 #elif __CC_PLATFORM_MAC
 
@@ -119,6 +118,7 @@ static inline NSString *CCNSStringFromCGSize(CGSize size)
 #define CCNSSizeToCGSize			NSSizeToCGSize
 #define CCNSRectToCGRect			NSRectToCGRect
 #define CCNSPointToCGPoint			NSPointToCGPoint
+
 #endif
 
-
+#endif //__CC_CG_STRING_UTILS


### PR DESCRIPTION
This pull request is designed to allow cocos2d to compile on mac, as the `CCNSStringFromCGPoint` is being used across platforms as of https://github.com/cocos2d/cocos2d-swift/commit/78ed94651d7504c7d5f3dc1165d9854481f8dbf8, despite the unavailability of the method on Mac. This prevents applications which rely on cocos2d (i.e. SpriteBuilder) from compiling.

Also changed here is the correct use of the header guards and removal of a weird `#if 1` statement.
