### PR TITLE
Bugfix/fix warnings

### DIFF
--- a/cocos2d-ui/CCBReader/CCAnimationManager.m
+++ b/cocos2d-ui/CCBReader/CCAnimationManager.m
@@ -195,7 +195,7 @@ static NSInteger ccbAnimationManagerID = 0;
     return NULL;
 }
 
-- (CCActionInterval*)actionFromKeyframe0:(CCBKeyframe*)kf0 andKeyframe1:(CCBKeyframe*)kf1 propertyName:(NSString*)name node:(CCNode*)node {
+- (CCAction*)actionFromKeyframe0:(CCBKeyframe*)kf0 andKeyframe1:(CCBKeyframe*)kf1 propertyName:(NSString*)name node:(CCNode*)node {
     float duration = kf1.time - kf0.time;
     
     if(kf0 && kf0.easingType==kCCBKeyframeEasingInstant) {
@@ -275,7 +275,7 @@ static NSInteger ccbAnimationManagerID = 0;
         kf1.time = tweenDuration;
         kf1.easingType = kCCBKeyframeEasingLinear;
         
-        CCActionInterval* tweenAction = [self actionFromKeyframe0:NULL andKeyframe1:kf1 propertyName:name node:node];
+        CCAction* tweenAction = [self actionFromKeyframe0:NULL andKeyframe1:kf1 propertyName:name node:node];
         tweenAction.name = _animationManagerId;
         [tweenAction startWithTarget:node];
         [_currentActions addObject:tweenAction];
@@ -326,9 +326,16 @@ static NSInteger ccbAnimationManagerID = 0;
     }
 }
 
-- (CCActionInterval*)easeAction:(CCActionInterval*) action easingType:(int)easingType easingOpt:(float) easingOpt
+- (CCAction*)easeAction:(CCAction*) action easingType:(int)easingType easingOpt:(float) easingOpt
 {
     if ([action isKindOfClass:[CCActionSequence class]]) return action;
+    
+    CCActionInterval*intervalAction = (CCActionInterval*)action;
+    if(!intervalAction)
+    {
+        NSLog(@"CCBReader: Incorrect action type %@ for easing - must be a CCActionInterval subclass", action);
+        return nil;
+    }
     
     if (easingType == kCCBKeyframeEasingLinear)
     {
@@ -336,55 +343,55 @@ static NSInteger ccbAnimationManagerID = 0;
     }
     else if (easingType == kCCBKeyframeEasingInstant)
     {
-        return [CCActionEaseInstant actionWithAction:action];
+        return [CCActionEaseInstant actionWithAction:intervalAction];
     }
     else if (easingType == kCCBKeyframeEasingCubicIn)
     {
-        return [CCActionEaseIn actionWithAction:action rate:easingOpt];
+        return [CCActionEaseIn actionWithAction:intervalAction rate:easingOpt];
     }
     else if (easingType == kCCBKeyframeEasingCubicOut)
     {
-        return [CCActionEaseOut actionWithAction:action rate:easingOpt];
+        return [CCActionEaseOut actionWithAction:intervalAction rate:easingOpt];
     }
     else if (easingType == kCCBKeyframeEasingCubicInOut)
     {
-        return [CCActionEaseInOut actionWithAction:action rate:easingOpt];
+        return [CCActionEaseInOut actionWithAction:intervalAction rate:easingOpt];
     }
     else if (easingType == kCCBKeyframeEasingBackIn)
     {
-        return [CCActionEaseBackIn actionWithAction:action];
+        return [CCActionEaseBackIn actionWithAction:intervalAction];
     }
     else if (easingType == kCCBKeyframeEasingBackOut)
     {
-        return [CCActionEaseBackOut actionWithAction:action];
+        return [CCActionEaseBackOut actionWithAction:intervalAction];
     }
     else if (easingType == kCCBKeyframeEasingBackInOut)
     {
-        return [CCActionEaseBackInOut actionWithAction:action];
+        return [CCActionEaseBackInOut actionWithAction:intervalAction];
     }
     else if (easingType == kCCBKeyframeEasingBounceIn)
     {
-        return [CCActionEaseBounceIn actionWithAction:action];
+        return [CCActionEaseBounceIn actionWithAction:intervalAction];
     }
     else if (easingType == kCCBKeyframeEasingBounceOut)
     {
-        return [CCActionEaseBounceOut actionWithAction:action];
+        return [CCActionEaseBounceOut actionWithAction:intervalAction];
     }
     else if (easingType == kCCBKeyframeEasingBounceInOut)
     {
-        return [CCActionEaseBounceInOut actionWithAction:action];
+        return [CCActionEaseBounceInOut actionWithAction:intervalAction];
     }
     else if (easingType == kCCBKeyframeEasingElasticIn)
     {
-        return [CCActionEaseElasticIn actionWithAction:action period:easingOpt];
+        return [CCActionEaseElasticIn actionWithAction:intervalAction period:easingOpt];
     }
     else if (easingType == kCCBKeyframeEasingElasticOut)
     {
-        return [CCActionEaseElasticOut actionWithAction:action period:easingOpt];
+        return [CCActionEaseElasticOut actionWithAction:intervalAction period:easingOpt];
     }
     else if (easingType == kCCBKeyframeEasingElasticInOut)
     {
-        return [CCActionEaseElasticInOut actionWithAction:action period:easingOpt];
+        return [CCActionEaseElasticInOut actionWithAction:intervalAction period:easingOpt];
     }
     else
     {
@@ -869,7 +876,7 @@ static NSInteger ccbAnimationManagerID = 0;
     // Build Animation Actions
     NSMutableArray* actions = [[NSMutableArray alloc] init];
     
-    CCActionInterval* action = [self actionFromKeyframe0:startKF andKeyframe1:endKF propertyName:seqProp.name node:node];
+    CCAction* action = [self actionFromKeyframe0:startKF andKeyframe1:endKF propertyName:seqProp.name node:node];
     
     if (action) {
         

--- a/cocos2d-ui/Platform/Android/java/CCEditText.m
+++ b/cocos2d-ui/Platform/Android/java/CCEditText.m
@@ -15,6 +15,12 @@
     CCEditTextCompletionBlock _completionBlock;
 }
 
+-(id)initWithContext:(AndroidContext *)context
+{
+    self = [super initWithContext:context];
+    return self;
+}
+
 - (BOOL)onKeyPreIme:(int32_t)keyCode keyEvent:(AndroidKeyEvent *)event {
     if (keyCode == AndroidKeyEventKeycodeBack || [event action] == AndroidKeyEventActionUp) {
         if (_completionBlock != nil) {

--- a/cocos2d/CCDirector.h
+++ b/cocos2d/CCDirector.h
@@ -220,8 +220,6 @@ typedef NS_ENUM(NSUInteger, CCDirectorProjection) {
 
 /** @returns The director for the currently active CCView */
 +(CCDirector*)currentDirector;
-+(CCDirector*)sharedDirector __attribute__((deprecated));
-
 
 /** @name Accessing OpenGL Thread */
 

--- a/cocos2d/CCDirector.h
+++ b/cocos2d/CCDirector.h
@@ -255,7 +255,7 @@ typedef NS_ENUM(NSUInteger, CCDirectorProjection) {
 
 /// View used by the director for rendering. The CC_VIEW macro equals UIView on iOS, NSOpenGLView on OS X and CCView on Android.
 /// @see CCView
-@property(nonatomic, weak) CC_VIEW<CCView> *view;
+@property(nonatomic, retain) CC_VIEW<CCView> *view;
 /** Sets an OpenGL projection
  @see CCDirectorProjection
  @see projectionMatrix */

--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -52,6 +52,7 @@
 #import "CCFileUtils.h"
 #import "CCImage.h"
 #import "ccUtils.h"
+#import "CCDeprecated.h"
 
 #if __CC_PLATFORM_IOS
 #import "Platforms/iOS/CCDirectorIOS.h"

--- a/cocos2d/Platforms/Android/CCActivity.h
+++ b/cocos2d/Platforms/Android/CCActivity.h
@@ -23,7 +23,7 @@
 @interface CCActivity : GLActivity <AndroidSurfaceHolderCallback, CCDirectorDelegate>
 @property (readonly, nonatomic) AndroidAbsoluteLayout *layout;
 @property (nonatomic, strong) NSDictionary *cocos2dSetupConfig;
-@property (nonatomic, strong) CCGLView *glView;
+@property (nonatomic, strong) CCGLView<CCView> *glView;
 @property (nonatomic, strong) NSString *startScene;
 + (instancetype)currentActivity;
 

--- a/cocos2d/Platforms/Android/CCActivity.m
+++ b/cocos2d/Platforms/Android/CCActivity.m
@@ -13,6 +13,7 @@
 #import <android/native_window.h>
 #import <bridge/runtime.h>
 #import <AndroidKit/AndroidLooper.h>
+#import <AndroidKit/AndroidAbsoluteLayout.h>
 
 #import "cocos2d.h"
 #import "CCBReader.h"
@@ -291,7 +292,7 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
     {
         [self performSelector:@selector(setupView:) onThread:_thread withObject:holder waitUntilDone:YES modes:@[NSDefaultRunLoopMode]];
         CCDirectorAndroid *director = (CCDirectorAndroid*)[CCDirector currentDirector];
-        [director performSelector:@selector(startAnimation) onThread:_thread withObject:nil waitUntilDone:YES modes:@[NSDefaultRunLoopMode]];
+        [director performSelector:@selector(startRunLoop) onThread:_thread withObject:nil waitUntilDone:YES modes:@[NSDefaultRunLoopMode]];
     }
 #endif
 }
@@ -307,7 +308,7 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
 
 - (void)handleDestroy
 {
-    [[CCDirector currentDirector] stopAnimation];
+    [[CCDirector currentDirector] stopRunLoop];
 }
 
 - (BOOL)onKeyDown:(int32_t)keyCode keyEvent:(AndroidKeyEvent *)event

--- a/cocos2d/Platforms/Android/CCDirectorAndroid.m
+++ b/cocos2d/Platforms/Android/CCDirectorAndroid.m
@@ -94,7 +94,7 @@
 	[super end];
 }
 
--(void) setView:(CCGLView *)view
+-(void) setView:(CCGLView<CCView> *)view
 {
 		[super setView:view];
 		if( view ) {

--- a/cocos2d/Platforms/Android/CCGLView.h
+++ b/cocos2d/Platforms/Android/CCGLView.h
@@ -42,7 +42,7 @@ enum CCAndroidScreenMode {
 };
 
 BRIDGE_CLASS("com.apportable.GLView")
-@interface CCGLView : GLView <CCDirectorView>
+@interface CCGLView : GLView <CCView>
 
 - (id)initWithContext:(AndroidContext *)context screenMode:(enum CCAndroidScreenMode)screenMode scaleFactor:(float)scaleFactor;
 

--- a/cocos2d/Platforms/Android/CCMathUtilsAndroid.h
+++ b/cocos2d/Platforms/Android/CCMathUtilsAndroid.h
@@ -24,8 +24,8 @@
 extern "C" {
 #endif
     
-    static inline float CCMathDegreesToRadians(float degrees) { return degrees * (M_PI / 180); };
-    static inline float CCMathRadiansToDegrees(float radians) { return radians * (180 / M_PI); };
+    static inline float CCMathDegreesToRadians(float degrees) { return (float)(degrees * (M_PI / 180)); };
+    static inline float CCMathRadiansToDegrees(float radians) { return (float)(radians * (180 / M_PI)); };
     
     GLKVector3 CCMathProject(GLKVector3 object, GLKMatrix4 model, GLKMatrix4 projection, int *viewport);
     GLKVector3 CCMathUnproject(GLKVector3 window, GLKMatrix4 model, GLKMatrix4 projection, int *viewport, bool *success);

--- a/cocos2d/Platforms/Android/CCQuaternion.h
+++ b/cocos2d/Platforms/Android/CCQuaternion.h
@@ -156,9 +156,9 @@ extern "C" {
                                   *(float32x4_t *)&quaternion);
         float32x2_t v2 = vpadd_f32(vget_low_f32(v), vget_high_f32(v));
         v2 = vpadd_f32(v2, v2);
-        return sqrt(vget_lane_f32(v2, 0));
+        return (float)sqrt(vget_lane_f32(v2, 0));
 #else
-        return sqrt(quaternion.q[0] * quaternion.q[0] +
+        return (float)sqrt(quaternion.q[0] * quaternion.q[0] +
                     quaternion.q[1] * quaternion.q[1] +
                     quaternion.q[2] * quaternion.q[2] +
                     quaternion.q[3] * quaternion.q[3]);

--- a/cocos2d/Platforms/Android/CCVector2.h
+++ b/cocos2d/Platforms/Android/CCVector2.h
@@ -333,9 +333,9 @@ extern "C" {
         float32x2_t v = vmul_f32(*(float32x2_t *)&vector,
                                  *(float32x2_t *)&vector);
         v = vpadd_f32(v, v);
-        return sqrt(vget_lane_f32(v, 0));
+        return (float)sqrt(vget_lane_f32(v, 0));
 #else
-        return sqrt(vector.v[0] * vector.v[0] + vector.v[1] * vector.v[1]);
+        return (float)sqrt(vector.v[0] * vector.v[0] + vector.v[1] * vector.v[1]);
 #endif
     }
     

--- a/cocos2d/Platforms/Android/CCVector4.h
+++ b/cocos2d/Platforms/Android/CCVector4.h
@@ -382,9 +382,9 @@ extern "C" {
                                   *(float32x4_t *)&vector);
         float32x2_t v2 = vpadd_f32(vget_low_f32(v), vget_high_f32(v));
         v2 = vpadd_f32(v2, v2);
-        return sqrt(vget_lane_f32(v2, 0));
+        return (float)sqrt(vget_lane_f32(v2, 0));
 #else
-        return sqrt(vector.v[0] * vector.v[0] +
+        return (float)sqrt(vector.v[0] * vector.v[0] +
                     vector.v[1] * vector.v[1] +
                     vector.v[2] * vector.v[2] +
                     vector.v[3] * vector.v[3]);

--- a/cocos2d/Platforms/CCAppController.h
+++ b/cocos2d/Platforms/CCAppController.h
@@ -31,12 +31,43 @@
 
  */
 
+
+
 @interface CCAppController : NSObject
 
 /**
 *  The view in which the cocos nodes and scene graph are rendered
 */
 @property (nonatomic, weak) CC_VIEW<CCView> *glView;
+
+// -----------------------------------------------------------------------
+/** @name Cocos2d Setup */
+// -----------------------------------------------------------------------
+
+/**
+ *  This method is called from the `applicaton:didFinishLaunchingWithOptions:` UIApplicationDelegate method.
+ *  It will configure Cocos2D with the options that you provide. You can leave out any of the options to have Cocos2D use default values.
+ *  Some of the settings can be changed at runtime, for instance the debug stats.
+ *
+ *  Currently supported keys for the configuration dictionary are:
+ *
+ *  - `CCSetupPixelFormat`: NSString with the pixel format, normally `kEAGLColorFormatRGBA8` or `kEAGLColorFormatRGB565`. The RGB565 option is faster and recommended, unless color vibrancy is noticably impaired or you need the alpha channel.
+ *  - `CCSetupScreenMode`: NSString value that accepts either `CCScreenModeFlexible` or `CCScreenModeFixed`.
+ *  - `CCSetupScreenOrientation`: NSString value that accepts `CCScreenOrientationLandscape`, `CCScreenOrientationPortrait`, or `CCScreenOrientationAll`.
+ *  - `CCSetupAnimationInterval`: NSNumber with double. Specifies the desired interval between animation frames. Supported values are `1.0/60.0` (default, 60 fps) and `1.0/30.0` (30 fps).
+ *  - `CCSetupFixedUpdateInterval`: NSNumber with double. Specifies the desired interval between fixed updates. Should be smaller than `CCSetupAnimationInterval`. Defaults to `1.0/60.0` (60 Hz).
+ *  - `CCSetupShowDebugStats`: NSNumber with bool. Specifies if the stats (FPS, frame time and draw call count) should be rendered. Defaults to NO.
+ *  - `CCSetupTabletScale2X`: NSNumber with bool. If true, the iPad will be setup to act like it has a 512x384 points "logical" screen size with a "Retina" pixel resolution of 1024x768.
+ *      This makes it much easier to make universal iOS games. This is the default mode for SpriteBuilder projects. This value is ignored when using the fixed screen mode.
+ *
+ *  - `CCSetupDepthFormat`: NSNumber with integer. Specifies the desired depth buffer format. Values are 0 (no depth buffering), `GL_DEPTH24_STENCIL8_OES` (8-Bit depth buffer) and `GL_DEPTH_COMPONENT24_OES` (24-bit depth buffer).
+ *      Depth buffering is only needed in rare cases and comes at the expense of performance and additional memory usage.
+ *  - `CCSetupPreserveBackbuffer`: NSNumber with bool. Specifies whether backbuffer will be preserved. Defaults to NO.
+ *  - `CCSetupMultiSampling`: NSNumber with bool. Specifies whether multisampling (fullscreen anti-aliasing) is enabled. Defaults to NO.
+ *  - `CCSetupNumberOfSamples`: NSNumber with integer. Specifies number of samples when multisampling is enabled. Ignored if multisampling is not enabled.
+ *
+ *  @param config Dictionary with setup options for Cocos2D.
+ */
 
 /// -----------------------------------------------------------------------
 /// @name Mac Specific
@@ -69,6 +100,7 @@
 *  Configuration options that are used to setup cocos2d on iOS
 *  By default this reads from "configCocos2d.plist" in the Published-iOS directory
 */
+
 - (NSDictionary *)iosConfig;
 
 /// -----------------------------------------------------------------------

--- a/cocos2d/Platforms/CCAppController.h
+++ b/cocos2d/Platforms/CCAppController.h
@@ -36,7 +36,7 @@
 /**
 *  The view in which the cocos nodes and scene graph are rendered
 */
-@property (weak) CC_VIEW<CCView> *glView;
+@property (nonatomic, weak) CC_VIEW<CCView> *glView;
 
 /// -----------------------------------------------------------------------
 /// @name Mac Specific
@@ -45,7 +45,7 @@
 /**
 *  The application window (set from .xib)
 */
-@property (weak) NSWindow *window;
+@property (nonatomic, weak) NSWindow *window;
 
 /**
 *  Configuration options that are used to setup cocos2d on Mac

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -271,7 +271,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
     [self runStartSceneAndroid];
 }
 
-- (void)configureDirector:(CCDirector*)director withConfig:(NSDictionary *)config withView:(CCGLView*)view
+- (void)configureDirector:(CCDirector*)director withConfig:(NSDictionary *)config withView:(CCGLView<CCView>*)view
 {
     CCDirectorAndroid *androidDirector = (CCDirectorAndroid*)director;
     director.delegate = [CCActivity currentActivity];

--- a/cocos2d/Platforms/CCAppController.m
+++ b/cocos2d/Platforms/CCAppController.m
@@ -115,7 +115,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 {
     _cocosConfig = [self iosConfig];
 
-    CCAppDelegate *appDelegate = [UIApplication sharedApplication].delegate;
+    CCAppDelegate *appDelegate = (CCAppDelegate*)[UIApplication sharedApplication].delegate;
     [appDelegate constructWindow];
 
     _glView = [appDelegate constructView:_cocosConfig withBounds:appDelegate.window.bounds];
@@ -188,7 +188,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
     [director setProjection:CCDirectorProjection2D];
 }
 
-- (void)setupFixedScreenMode:(NSDictionary *)config director:(CCDirectorIOS *)director
+- (void)setupFixedScreenMode:(NSDictionary *)config director:(CCDirector *)director
 {
     CGSize size = [CCDirector currentDirector].viewSizeInPixels;
     CGSize fixed = [config[CCScreenModeFixedDimensions] CGSizeValue];

--- a/cocos2d/Platforms/iOS/CCAppDelegate.h
+++ b/cocos2d/Platforms/iOS/CCAppDelegate.h
@@ -80,35 +80,6 @@
  */
 @property (nonatomic) CCScene *startScene;
 
-// -----------------------------------------------------------------------
-/** @name Cocos2d Setup */
-// -----------------------------------------------------------------------
-
-/**
- *  This method is called from the `applicaton:didFinishLaunchingWithOptions:` UIApplicationDelegate method. 
- *  It will configure Cocos2D with the options that you provide. You can leave out any of the options to have Cocos2D use default values.
- *  Some of the settings can be changed at runtime, for instance the debug stats.
- *
- *  Currently supported keys for the configuration dictionary are:
- *
- *  - `CCSetupPixelFormat`: NSString with the pixel format, normally `kEAGLColorFormatRGBA8` or `kEAGLColorFormatRGB565`. The RGB565 option is faster and recommended, unless color vibrancy is noticably impaired or you need the alpha channel.
- *  - `CCSetupScreenMode`: NSString value that accepts either `CCScreenModeFlexible` or `CCScreenModeFixed`.
- *  - `CCSetupScreenOrientation`: NSString value that accepts `CCScreenOrientationLandscape`, `CCScreenOrientationPortrait`, or `CCScreenOrientationAll`.
- *  - `CCSetupAnimationInterval`: NSNumber with double. Specifies the desired interval between animation frames. Supported values are `1.0/60.0` (default, 60 fps) and `1.0/30.0` (30 fps).
- *  - `CCSetupFixedUpdateInterval`: NSNumber with double. Specifies the desired interval between fixed updates. Should be smaller than `CCSetupAnimationInterval`. Defaults to `1.0/60.0` (60 Hz).
- *  - `CCSetupShowDebugStats`: NSNumber with bool. Specifies if the stats (FPS, frame time and draw call count) should be rendered. Defaults to NO.
- *  - `CCSetupTabletScale2X`: NSNumber with bool. If true, the iPad will be setup to act like it has a 512x384 points "logical" screen size with a "Retina" pixel resolution of 1024x768. 
- *      This makes it much easier to make universal iOS games. This is the default mode for SpriteBuilder projects. This value is ignored when using the fixed screen mode.
- *
- *  - `CCSetupDepthFormat`: NSNumber with integer. Specifies the desired depth buffer format. Values are 0 (no depth buffering), `GL_DEPTH24_STENCIL8_OES` (8-Bit depth buffer) and `GL_DEPTH_COMPONENT24_OES` (24-bit depth buffer).
- *      Depth buffering is only needed in rare cases and comes at the expense of performance and additional memory usage.
- *  - `CCSetupPreserveBackbuffer`: NSNumber with bool. Specifies whether backbuffer will be preserved. Defaults to NO.
- *  - `CCSetupMultiSampling`: NSNumber with bool. Specifies whether multisampling (fullscreen anti-aliasing) is enabled. Defaults to NO.
- *  - `CCSetupNumberOfSamples`: NSNumber with integer. Specifies number of samples when multisampling is enabled. Ignored if multisampling is not enabled.
- *
- *  @param config Dictionary with setup options for Cocos2D.
- */
-- (void) setupCocos2dWithOptions:(NSDictionary*)config;
 
 - (void)constructNavController:(NSDictionary *)config;
 

--- a/cocos2d/Support/ccUtils.h
+++ b/cocos2d/Support/ccUtils.h
@@ -98,7 +98,7 @@ static inline CGSize CC_SIZE_SCALE(CGSize size, CGFloat scale){
 
     
 static inline NSData* CC_DECODE_BASE64(NSString* base64){
-        NSData* result;
+        NSData* result = nil;
 #if __CC_PLATFORM_IOS || __CC_PLATFORM_MAC
         result = [[NSData alloc] initWithBase64Encoding:base64];
 #elif __CC_PLATFORM_ANDROID

--- a/cocos2d/Support/ccUtils.h
+++ b/cocos2d/Support/ccUtils.h
@@ -99,10 +99,13 @@ static inline CGSize CC_SIZE_SCALE(CGSize size, CGFloat scale){
     
 static inline NSData* CC_DECODE_BASE64(NSString* base64){
         NSData* result = nil;
-#if __CC_PLATFORM_IOS || __CC_PLATFORM_MAC
+#if __CC_PLATFORM_IOS
         result = [[NSData alloc] initWithBase64Encoding:base64];
+#elif __CC_PLATFORM_MAC
+        result = [[NSData alloc] initWithBase64EncodedString:base64 options:0];
 #elif __CC_PLATFORM_ANDROID
 //        result = [NSData decodeWithStr:base64 flags:0];
+#warning "Base64 decoding not implemented on android."
 #endif
         return result;
     


### PR DESCRIPTION
This review fixes various warnings throughout the framework, mostly by changing away from deprecated apis, explicitly casting return types, using the same type signature as inherited from UIAppController (see the `+@property(nonatomic, retain) CC_VIEW<CCView> *view` change) and by updating the ObjectAL submodule to point to a ref with similar fixes.

The tests run on all applicable platforms and it is possible to publish and run spritebuilder projects with this ref.
