### PR TITLE
CCLightNode - Fix lighting inconsistency between SB and device / sim

### DIFF
--- a/cocos2d/CCLightNode.m
+++ b/cocos2d/CCLightNode.m
@@ -45,14 +45,7 @@
         _cutoffRadius = 0.0f;
         _halfRadius = 0.5f;
         
-        if (type == CCLightDirectional)
-        {
-            _depth = 1.0f;
-        }
-        else
-        {
-            _depth = 100.0f;
-        }
+        _depth = 100.0f;
     }
     
     return self;


### PR DESCRIPTION
Always set the light's depth value to 100 regardless of the light type.
The type dependent logic didn't play well with SB.
