### PR TITLE
CCEffectLighting - Fix alpha blending issues

### DIFF
--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -112,10 +112,10 @@ static float conditionShininess(float shininess);
     
     NSMutableString *effectBody = [[NSMutableString alloc] init];
     [effectBody appendString:CC_GLSL(
-                                     vec4 lightColor;
-                                     vec4 lightSpecularColor;
-                                     vec4 diffuseSum = u_globalAmbientColor;
-                                     vec4 specularSum = vec4(0,0,0,0);
+                                     vec3 lightColor;
+                                     vec3 lightSpecularColor;
+                                     vec3 diffuseSum = u_globalAmbientColor.rgb;
+                                     vec3 specularSum = vec3(0,0,0);
                                      
                                      vec3 worldSpaceLightDir;
                                      vec3 halfAngleDir;
@@ -161,10 +161,10 @@ static float conditionShininess(float shininess);
         if (light.type == CCLightDirectional)
         {
             [effectBody appendFormat:@"worldSpaceLightDir = v_worldSpaceLightDir%lu.xyz;\n", (unsigned long)lightIndex];
-            [effectBody appendFormat:@"lightColor = u_lightColor%lu;\n", (unsigned long)lightIndex];
+            [effectBody appendFormat:@"lightColor = u_lightColor%lu.rgb;\n", (unsigned long)lightIndex];
             if (needsSpecular)
             {
-                [effectBody appendFormat:@"lightSpecularColor = u_lightSpecularColor%lu;\n", (unsigned long)lightIndex];
+                [effectBody appendFormat:@"lightSpecularColor = u_lightSpecularColor%lu.rgb;\n", (unsigned long)lightIndex];
             }
         }
         else
@@ -177,10 +177,10 @@ static float conditionShininess(float shininess);
             [effectBody appendFormat:@"falloffSelect = step(u_lightFalloff%lu.x, lightDist);\n", (unsigned long)lightIndex];
             [effectBody appendFormat:@"falloffTerm = (1.0 - falloffSelect) * falloffTermA + falloffSelect * falloffTermB;\n"];
 
-            [effectBody appendFormat:@"lightColor = u_lightColor%lu * falloffTerm;\n", (unsigned long)lightIndex];
+            [effectBody appendFormat:@"lightColor = u_lightColor%lu.rgb * falloffTerm;\n", (unsigned long)lightIndex];
             if (needsSpecular)
             {
-                [effectBody appendFormat:@"lightSpecularColor = u_lightSpecularColor%lu * falloffTerm;\n", (unsigned long)lightIndex];
+                [effectBody appendFormat:@"lightSpecularColor = u_lightSpecularColor%lu.rgb * falloffTerm;\n", (unsigned long)lightIndex];
             }
         }
         [effectBody appendString:@"diffuseTerm = max(0.0, dot(worldSpaceNormal, worldSpaceLightDir));\n"];
@@ -193,12 +193,12 @@ static float conditionShininess(float shininess);
             [effectBody appendString:@"specularSum += lightSpecularColor * pow(specularTerm, u_specularExponent);\n"];
         }
     }
-    [effectBody appendString:@"vec4 resultColor = diffuseSum * inputValue;\n"];
+    [effectBody appendString:@"vec3 resultColor = diffuseSum * inputValue.rgb;\n"];
     if (needsSpecular)
     {
-        [effectBody appendString:@"resultColor += specularSum * u_specularColor;\n"];
+        [effectBody appendString:@"resultColor += specularSum * u_specularColor.rgb * inputValue.a;\n"];
     }
-    [effectBody appendString:@"return vec4(resultColor.xyz, inputValue.a);\n"];
+    [effectBody appendString:@"return vec4(resultColor, inputValue.a);\n"];
     
     CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"lightingEffectFrag" body:effectBody inputs:@[input] returnType:@"vec4"];
     return @[fragmentFunction];


### PR DESCRIPTION
- Ensure that lighting only affects the RGB channels and does not change alpha.
- When adding the specular term to the final result color, multiply it by the input color's
  alpha value so everything stays in the premultiplied alpha space.
