### PR TITLE
CCEffectLighting - Add overall lighting intensity control

### DIFF
--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -366,25 +366,26 @@
     setupBlock(ccp(0.75f, 0.5f), CCLightDirectional, 0.5f, @"Directional Light\nPosition does not matter, orientation does.");
 }
 
--(void)setupLightingEffectIntensityTest
+-(void)setupLightingEffectContributionTest
 {
-    self.subTitle = @"Lighting Intensity Test";
+    self.subTitle = @"Lighting Contribution Test";
     
     [self.contentNode.scene.lights flushGroupNames];
   
     NSString *normalMapImage = @"Images/powered_normals.png";
     NSString *diffuseImage = @"Images/powered.png";
     
-    void (^setupBlock)(CGPoint position, float lightingIntensity, NSString *title) = ^void(CGPoint position, float lightingIntensity, NSString *title)
+    void (^setupBlock)(CGPoint position, float lightingContribution, float diffuseAndSpecularIntensity, NSString *title) = ^void(CGPoint position, float lightingContribution, float diffuseAndSpecularIntensity, NSString *title)
     {
         CCLightNode *light = [[CCLightNode alloc] init];
         light.type = CCLightPoint;
         light.groups = @[title];
         light.positionType = CCPositionTypeNormalized;
-        light.position = ccp(0.7f, 0.85f);
+        light.position = ccp(0.75f, 0.8f);
         light.anchorPoint = ccp(0.5f, 0.5f);
-        light.intensity = 1.0f;
+        light.intensity = diffuseAndSpecularIntensity;
         light.ambientIntensity = 0.2f;
+        light.specularIntensity = diffuseAndSpecularIntensity;
         light.cutoffRadius = 0.0f;
         light.depth = 50.0f;
         
@@ -393,21 +394,21 @@
         CCEffectLighting *lightingEffect = [[CCEffectLighting alloc] init];
         lightingEffect.groups = @[title];
         lightingEffect.shininess = 0.1f;
-        lightingEffect.intensity = lightingIntensity;
+        lightingEffect.contribution = lightingContribution;
         
         CCSprite *sprite = [CCSprite spriteWithImageNamed:diffuseImage];
         sprite.positionType = CCPositionTypeNormalized;
         sprite.position = ccp(0.5f, 0.5f);
         sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:normalMapImage];
         sprite.effect = lightingEffect;
-        sprite.scale = 0.5f;
+        sprite.scale = 0.25f;
         
         CCNode *root = [[CCNode alloc] init];
         root.positionType = CCPositionTypeNormalized;
         root.position = position;
         root.anchorPoint = ccp(0.5f, 0.5f);
         root.contentSizeType = CCSizeTypePoints;
-        root.contentSize = CGSizeMake(200.0f, 200.0f);
+        root.contentSize = CGSizeMake(200.0f, 120.0f);
         
         CCLabelTTF *label = [CCLabelTTF labelWithString:title fontName:@"HelveticaNeue-Light" fontSize:12 * [CCDirector sharedDirector].UIScaleFactor];
         label.color = [CCColor whiteColor];
@@ -427,12 +428,23 @@
     const float step = (1.0f - 2.0f * border) / steps;
     float xPos = border;
     
-    setupBlock(ccp(xPos, 0.5f), 0.0f, @"Intensity = 0.0\nNo lighting"); xPos += step;
-    setupBlock(ccp(xPos, 0.5f), 0.2f, @"Intensity = 0.2\n20% lighting"); xPos += step;
-    setupBlock(ccp(xPos, 0.5f), 0.4f, @"Intensity = 0.4\n40% lighting"); xPos += step;
-    setupBlock(ccp(xPos, 0.5f), 0.6f, @"Intensity = 0.6\n60% lighting"); xPos += step;
-    setupBlock(ccp(xPos, 0.5f), 0.8f, @"Intensity = 0.8\n80% lighting"); xPos += step;
-    setupBlock(ccp(xPos, 0.5f), 1.0f, @"Intensity = 1.0\nFull lighting");
+    setupBlock(ccp(xPos, 0.65f), 0.0f, 1.0f, @"Contribution = 0.0\nNo lighting");
+    setupBlock(ccp(xPos, 0.25f), 0.0f, 0.0f, @"Ambient Only\nContribution = 0.0\nNo lighting"); xPos += step;
+
+    setupBlock(ccp(xPos, 0.65f), 0.2f, 1.0f, @"Contribution = 0.2\n20% lighting");
+    setupBlock(ccp(xPos, 0.25f), 0.2f, 0.0f, @"Ambient Only\nContribution = 0.2\n20% lighting"); xPos += step;
+
+    setupBlock(ccp(xPos, 0.65f), 0.4f, 1.0f, @"Contribution = 0.4\n40% lighting");
+    setupBlock(ccp(xPos, 0.25f), 0.4f, 0.0f, @"Ambient Only\nContribution = 0.4\n40% lighting"); xPos += step;
+
+    setupBlock(ccp(xPos, 0.65f), 0.6f, 1.0f, @"Contribution = 0.6\n60% lighting");
+    setupBlock(ccp(xPos, 0.25f), 0.6f, 0.0f, @"Ambient Only\nContribution = 0.6\n60% lighting"); xPos += step;
+
+    setupBlock(ccp(xPos, 0.65f), 0.8f, 1.0f, @"Contribution = 0.8\n80% lighting");
+    setupBlock(ccp(xPos, 0.25f), 0.8f, 0.0f, @"Ambient Only\nContribution = 0.8\n80% lighting"); xPos += step;
+
+    setupBlock(ccp(xPos, 0.65f), 1.0f, 1.0f, @"Contribution = 1.0\nFull lighting");
+    setupBlock(ccp(xPos, 0.25f), 1.0f, 0.0f, @"Ambient Only\nContribution = 1.0\nFull lighting"); xPos += step;
 }
 
 -(void)setupLightingRenderTextureTest

--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -366,6 +366,75 @@
     setupBlock(ccp(0.75f, 0.5f), CCLightDirectional, 0.5f, @"Directional Light\nPosition does not matter, orientation does.");
 }
 
+-(void)setupLightingEffectIntensityTest
+{
+    self.subTitle = @"Lighting Intensity Test";
+    
+    [self.contentNode.scene.lights flushGroupNames];
+  
+    NSString *normalMapImage = @"Images/powered_normals.png";
+    NSString *diffuseImage = @"Images/powered.png";
+    
+    void (^setupBlock)(CGPoint position, float lightingIntensity, NSString *title) = ^void(CGPoint position, float lightingIntensity, NSString *title)
+    {
+        CCLightNode *light = [[CCLightNode alloc] init];
+        light.type = CCLightPoint;
+        light.groups = @[title];
+        light.positionType = CCPositionTypeNormalized;
+        light.position = ccp(0.7f, 0.85f);
+        light.anchorPoint = ccp(0.5f, 0.5f);
+        light.intensity = 1.0f;
+        light.ambientIntensity = 0.2f;
+        light.cutoffRadius = 0.0f;
+        light.depth = 50.0f;
+        
+        CCSprite *lightSprite = [CCSprite spriteWithImageNamed:@"Images/snow.png"];
+        
+        CCEffectLighting *lightingEffect = [[CCEffectLighting alloc] init];
+        lightingEffect.groups = @[title];
+        lightingEffect.shininess = 0.1f;
+        lightingEffect.intensity = lightingIntensity;
+        
+        CCSprite *sprite = [CCSprite spriteWithImageNamed:diffuseImage];
+        sprite.positionType = CCPositionTypeNormalized;
+        sprite.position = ccp(0.5f, 0.5f);
+        sprite.normalMapSpriteFrame = [CCSpriteFrame frameWithImageNamed:normalMapImage];
+        sprite.effect = lightingEffect;
+        sprite.scale = 0.5f;
+        
+        CCNode *root = [[CCNode alloc] init];
+        root.positionType = CCPositionTypeNormalized;
+        root.position = position;
+        root.anchorPoint = ccp(0.5f, 0.5f);
+        root.contentSizeType = CCSizeTypePoints;
+        root.contentSize = CGSizeMake(200.0f, 200.0f);
+        
+        CCLabelTTF *label = [CCLabelTTF labelWithString:title fontName:@"HelveticaNeue-Light" fontSize:12 * [CCDirector sharedDirector].UIScaleFactor];
+        label.color = [CCColor whiteColor];
+        label.positionType = CCPositionTypeNormalized;
+        label.position = ccp(0.5f, 1.0f);
+        label.horizontalAlignment = CCTextAlignmentCenter;
+        
+        [self.contentNode addChild:root];
+        [root addChild:label];
+        [root addChild:sprite];
+        [root addChild:light];
+        [light addChild:lightSprite];
+    };
+    
+    const int steps = 5;
+    const float border = 0.10f;
+    const float step = (1.0f - 2.0f * border) / steps;
+    float xPos = border;
+    
+    setupBlock(ccp(xPos, 0.5f), 0.0f, @"Intensity = 0.0\nNo lighting"); xPos += step;
+    setupBlock(ccp(xPos, 0.5f), 0.2f, @"Intensity = 0.2\n20% lighting"); xPos += step;
+    setupBlock(ccp(xPos, 0.5f), 0.4f, @"Intensity = 0.4\n40% lighting"); xPos += step;
+    setupBlock(ccp(xPos, 0.5f), 0.6f, @"Intensity = 0.6\n60% lighting"); xPos += step;
+    setupBlock(ccp(xPos, 0.5f), 0.8f, @"Intensity = 0.8\n80% lighting"); xPos += step;
+    setupBlock(ccp(xPos, 0.5f), 1.0f, @"Intensity = 1.0\nFull lighting");
+}
+
 -(void)setupLightingRenderTextureTest
 {
     self.subTitle = @"Lighting + Render Texture Test";

--- a/cocos2d/CCEffectLighting.h
+++ b/cocos2d/CCEffectLighting.h
@@ -41,13 +41,13 @@
  *  @param groups         The light groups this effect belongs to.
  *  @param specularColor  The specular color of this effect.
  *  @param shininess      The overall shininess of the effect.
- *  @param intensity      The overall contribution of lighting to the affected node.
+ *  @param contribution   The overall contribution of lighting to the affected node.
  *
  *  @return The CCEffectLighting object.
  *  @since v3.4 and later
  *  @see CCColor
  */
-+(instancetype)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess intensity:(float)intensity;
++(instancetype)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess contribution:(float)contribution;
 
 /**
  *  Initializes a CCEffectLighting object.
@@ -76,13 +76,13 @@
  *  @param groups         The light groups this effect belongs to.
  *  @param specularColor  The specular color of this effect.
  *  @param shininess      The overall shininess of the effect.
- *  @param intensity      The overall contribution of lighting to the affected node.
+ *  @param contribution   The overall contribution of lighting to the affected node.
  *
  *  @return The CCEffectLighting object.
  *  @since v3.4 and later
  *  @see CCColor
  */
--(id)initWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess intensity:(float)intensity;
+-(id)initWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess contribution:(float)contribution;
 
 /// -----------------------------------------------------------------------
 /// @name Lighting Properties
@@ -115,12 +115,12 @@
 @property (nonatomic, assign) float shininess;
 
 /**
- *  The overall intensity of the lighting effect's contributtion to the affected node. 
+ *  The overall contribution of the lighting effect to the affected node's final color.
  *  This value is in the range [0..1] where 0 results in no lighting and 1 results in 
  *  full lighting.
  *  @since v3.4 and later
  */
-@property (nonatomic, assign) float intensity;
+@property (nonatomic, assign) float contribution;
 
 @end
 

--- a/cocos2d/CCEffectLighting.h
+++ b/cocos2d/CCEffectLighting.h
@@ -36,6 +36,20 @@
 +(instancetype)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess;
 
 /**
+ *  Creates and initializes a CCEffectLighting object with the supplied parameters.
+ *
+ *  @param groups         The light groups this effect belongs to.
+ *  @param specularColor  The specular color of this effect.
+ *  @param shininess      The overall shininess of the effect.
+ *  @param intensity      The overall contribution of lighting to the affected node.
+ *
+ *  @return The CCEffectLighting object.
+ *  @since v3.4 and later
+ *  @see CCColor
+ */
++(instancetype)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess intensity:(float)intensity;
+
+/**
  *  Initializes a CCEffectLighting object.
  *
  *  @return The CCEffectLighting object.
@@ -55,6 +69,20 @@
  *  @see CCColor
  */
 -(id)initWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess;
+
+/**
+ *  Initializes a CCEffectLighting object with the supplied parameters.
+ *
+ *  @param groups         The light groups this effect belongs to.
+ *  @param specularColor  The specular color of this effect.
+ *  @param shininess      The overall shininess of the effect.
+ *  @param intensity      The overall contribution of lighting to the affected node.
+ *
+ *  @return The CCEffectLighting object.
+ *  @since v3.4 and later
+ *  @see CCColor
+ */
+-(id)initWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess intensity:(float)intensity;
 
 /// -----------------------------------------------------------------------
 /// @name Lighting Properties
@@ -85,6 +113,14 @@
  *  @since v3.4 and later
  */
 @property (nonatomic, assign) float shininess;
+
+/**
+ *  The overall intensity of the lighting effect's contributtion to the affected node. 
+ *  This value is in the range [0..1] where 0 results in no lighting and 1 results in 
+ *  full lighting.
+ *  @since v3.4 and later
+ */
+@property (nonatomic, assign) float intensity;
 
 @end
 

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -34,10 +34,12 @@ static const NSUInteger CCEffectLightingMaxLightCount = 8;
 static CCLightKey CCLightKeyMake(NSArray *lights);
 static BOOL CCLightKeyCompare(CCLightKey a, CCLightKey b);
 static float conditionShininess(float shininess);
+static float conditionIntensity(float intensity);
 
 
 @interface CCEffectLighting ()
 @property (nonatomic, strong) NSNumber *conditionedShininess;
+@property (nonatomic, strong) NSNumber *conditionedIntensity;
 @property (nonatomic, assign) CCLightGroupMask groupMask;
 @property (nonatomic, assign) BOOL groupMaskDirty;
 @property (nonatomic, copy) NSArray *closestLights;
@@ -93,6 +95,8 @@ static float conditionShininess(float shininess);
         [fragUniforms addObject:[CCEffectUniform uniform:@"float" name:@"u_specularExponent" value:[NSNumber numberWithFloat:5.0f]]];
         [fragUniforms addObject:[CCEffectUniform uniform:@"vec4" name:@"u_specularColor" value:[NSValue valueWithGLKVector4:GLKVector4Make(1.0f, 1.0f, 1.0f, 1.0f)]]];
     }
+    
+    [fragUniforms addObject:[CCEffectUniform uniform:@"float" name:@"u_overallIntensity" value:[NSNumber numberWithFloat:1.0f]]];
     
     NSArray *fragFunctions = [CCEffectLightingImpl buildFragmentFunctionsWithLights:interface.closestLights normalMap:interface.needsNormalMap specular:interface.needsSpecular];
     NSArray *vertFunctions = [CCEffectLightingImpl buildVertexFunctionsWithLights:interface.closestLights];
@@ -193,10 +197,10 @@ static float conditionShininess(float shininess);
             [effectBody appendString:@"specularSum += lightSpecularColor * pow(specularTerm, u_specularExponent);\n"];
         }
     }
-    [effectBody appendString:@"vec3 resultColor = diffuseSum * inputValue.rgb;\n"];
+    [effectBody appendString:@"vec3 resultColor = clamp(diffuseSum + vec3(1.0 - u_overallIntensity), vec3(0), vec3(1)) * inputValue.rgb;\n"];
     if (needsSpecular)
     {
-        [effectBody appendString:@"resultColor += specularSum * u_specularColor.rgb * inputValue.a;\n"];
+        [effectBody appendString:@"resultColor += specularSum * u_overallIntensity * u_specularColor.rgb * inputValue.a;\n"];
     }
     [effectBody appendString:@"return vec4(resultColor, inputValue.a);\n"];
     
@@ -338,6 +342,8 @@ static float conditionShininess(float shininess);
             passInputs.shaderUniforms[pass.uniformTranslationTable[@"u_specularColor"]] = [NSValue valueWithGLKVector4:weakInterface.specularColor.glkVector4];
         }
         
+        passInputs.shaderUniforms[pass.uniformTranslationTable[@"u_overallIntensity"]] = weakInterface.conditionedIntensity;
+        
     } copy]];
     
     return @[pass0];
@@ -355,6 +361,11 @@ static float conditionShininess(float shininess);
 
 -(id)initWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess
 {
+    return [self initWithGroups:groups specularColor:specularColor shininess:shininess intensity:1.0f];
+}
+
+-(id)initWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess intensity:(float)intensity
+{
     if((self = [super init]))
     {
         self.effectImpl = [[CCEffectLightingImpl alloc] initWithInterface:self];
@@ -365,6 +376,7 @@ static float conditionShininess(float shininess);
         _specularColor = specularColor;
         _shininess = shininess;
         _conditionedShininess = [NSNumber numberWithFloat:conditionShininess(shininess)];
+        _conditionedIntensity = [NSNumber numberWithFloat:conditionIntensity(intensity)];
     }
     return self;
 }
@@ -373,6 +385,11 @@ static float conditionShininess(float shininess);
 +(instancetype)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess
 {
     return [[self alloc] initWithGroups:groups specularColor:specularColor shininess:shininess];
+}
+
++(instancetype)effectWithGroups:(NSArray *)groups specularColor:(CCColor *)specularColor shininess:(float)shininess intensity:(float)intensity
+{
+    return [[self alloc] initWithGroups:groups specularColor:specularColor shininess:shininess intensity:intensity];
 }
 
 - (CCEffectPrepareResult)prepareForRenderingWithSprite:(CCSprite *)sprite
@@ -427,6 +444,12 @@ static float conditionShininess(float shininess);
     _conditionedShininess = [NSNumber numberWithFloat:conditionShininess(shininess)];
 }
 
+-(void)setIntensity:(float)intensity
+{
+    _intensity = intensity;
+    _conditionedIntensity = [NSNumber numberWithFloat:conditionIntensity(intensity)];
+}
+
 @end
 
 
@@ -463,5 +486,11 @@ float conditionShininess(float shininess)
     NSCAssert((shininess >= 0.0f) && (shininess <= 1.0f), @"Supplied shininess out of range [0..1].");
     shininess = clampf(shininess, 0.0f, 1.0f);
     return ((shininess * 99.0f) + 1.0f);
+}
+
+float conditionIntensity(float intensity)
+{
+    NSCAssert((intensity >= 0.0f) && (intensity <= 1.0f), @"Supplied intensity out of range [0..1].");
+    return clampf(intensity, 0.0f, 1.0f);
 }
 


### PR DESCRIPTION
The property ranges from [0..1]. If the value is 0, lighting has no effect on
the affected sprite. If the value is 1, lighting contributes fully to the affected
sprite. Values in between allow addition of some lighting to a sprite.
