### PR TITLE
NSString should accept nil value

### DIFF
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -170,8 +170,7 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
 
 - (void) setString:(NSString*)str
 {
-	NSAssert( str, @"Invalid string" );
-    [self _setAttributedString:[[NSAttributedString alloc] initWithString:str]];
+    [self _setAttributedString:[[NSAttributedString alloc] initWithString:str?str:@""]];
 }
 
 -(NSString*) string


### PR DESCRIPTION
The string property of CCLabelTTF should accept being set to nil,
rather than crash, as this is the expected behaviour of an NSString.
