### PR TITLE
FIX: changed CCTableView's dataSource property from 'strong' to 'weak'

### DIFF
--- a/cocos2d-ui/CCTableView.h
+++ b/cocos2d-ui/CCTableView.h
@@ -156,7 +156,7 @@
  
  @note Assigning a new or different data source immediately calls reloadData.
  */
-@property (nonatomic,strong) id <CCTableViewDataSource> dataSource;
+@property (nonatomic,weak) id <CCTableViewDataSource> dataSource;
 
 /** Removes all cells from memory and requests a new set of cells from the dataSource.
  Assigning a different dataSource and changing the rowHeight will cause reloadData to run.


### PR DESCRIPTION
This prevents retain-cycle that normally occurs when using a SpriteBuilder Scene (CCNode that's 0th child of CCScene generated via loading from CCBReader) as the dataSource of a CCTableView
