### PR TITLE
Fix duped chars on anchor change

### DIFF
--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -1095,7 +1095,7 @@ void FNTConfigRemoveCache( void )
 	if( ! CGPointEqualToPoint(point, self.anchorPoint) )
     {
 		[super setAnchorPoint:point];
-		[self createFontChars];
+		[self updateLabel];
 	}
 }
 


### PR DESCRIPTION
This fixes the issue quoted in https://github.com/cocos2d/cocos2d-spritebuilder/pull/1253

Instead of reverting those changes this one liner fixes the reported problem.
