### PR TITLE
Fix for narrow labels.

### DIFF
--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -323,7 +323,6 @@
                 [self insertLineBreakAtCharacter:fc];
                 [prevCharacter setControlFollowing:SoftLineBreakFollows];
             }
-            expectingWordBoundary = NO;
             lineLHS = 0.0f;
         }
         if ([fc controlFollowing] & WordBreakFollows)


### PR DESCRIPTION
A bug in the word-wrapping logic manifests on very narrow labels:

http://forum.cocos2d-spritebuilder.org/t/found-two-new-bugs-in-new-cocos2d-3-4-and-spritebuilder/16712/20
