### PR TITLE
Build fix and warning fix

### DIFF
--- a/cocos2d-ui-tests/tests/CCEffectsTest.m
+++ b/cocos2d-ui-tests/tests/CCEffectsTest.m
@@ -408,7 +408,7 @@
         root.contentSizeType = CCSizeTypePoints;
         root.contentSize = CGSizeMake(200.0f, 200.0f);
         
-        CCLabelTTF *label = [CCLabelTTF labelWithString:title fontName:@"HelveticaNeue-Light" fontSize:12 * [CCDirector sharedDirector].UIScaleFactor];
+        CCLabelTTF *label = [CCLabelTTF labelWithString:title fontName:@"HelveticaNeue-Light" fontSize:12 * [CCDirector currentDirector].UIScaleFactor];
         label.color = [CCColor whiteColor];
         label.positionType = CCPositionTypeNormalized;
         label.position = ccp(0.5f, 1.0f);

--- a/cocos2d/CCTransition.h
+++ b/cocos2d/CCTransition.h
@@ -28,6 +28,8 @@
 #import "CCScene.h"
 #import "CCTexture.h"
 
+@class CCRenderTexture;
+
 /**
  *  Defines the direction that a directional transition will move. Used by CCTransition.
  *


### PR DESCRIPTION
- Fix build breakage by forward declaring CCRenderTexture in CCTransition.h
- Fix build warning by changing a misplaced sharedDirector to currentDirector CCEffectsTest
