### PR TITLE
Fixing GPU error on the value set to clear stencil

### DIFF
--- a/cocos2d/CCClippingNode.m
+++ b/cocos2d/CCClippingNode.m
@@ -225,7 +225,7 @@ SetProgram(CCNode *n, CCShader *p, NSNumber *alpha) {
 			//     never draw it into the frame buffer
 			//     if not in inverted mode: set the current layer value to 0 in the stencil buffer
 			//     if in inverted mode: set the current layer value to 1 in the stencil buffer
-			glClearStencil(_inverted ? ~0 : 0);
+			glClearStencil(_inverted ? mask_layer : 0);
 			glClear(GL_STENCIL_BUFFER_BIT);
 			
 			///////////////////////////////////


### PR DESCRIPTION
If the CCClipping node has inverted property set then the ~0 passed to glClearStencil will cause the GPU analyze trace to report an error. It doesn't appear to have any negative impact, but on the basis of better safe than sorry this change sets a specific correct value.

Example error report images:

![screen shot 2015-03-06 at 10 45 40](https://cloud.githubusercontent.com/assets/715058/6524337/59cffc1c-c3f0-11e4-9f8b-ad25fd478c71.png)

![screen shot 2015-03-06 at 10 46 26](https://cloud.githubusercontent.com/assets/715058/6524344/62476aec-c3f0-11e4-9340-b7eac8efacd6.png)

![screen shot 2015-03-06 at 10 46 43](https://cloud.githubusercontent.com/assets/715058/6524349/673ee48a-c3f0-11e4-8302-36d3ad58f862.png)
