### PR TITLE
Change description to show 'Name = <name>'

### DIFF
--- a/cocos2d/CCSprite.m
+++ b/cocos2d/CCSprite.m
@@ -212,7 +212,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %p | Rect = (%.2f,%.2f,%.2f,%.2f) | tag = %@ >",
+	return [NSString stringWithFormat:@"<%@ = %p | Rect = (%.2f,%.2f,%.2f,%.2f) | Name = %@ >",
 		[self class], self, _textureRect.origin.x, _textureRect.origin.y, _textureRect.size.width, _textureRect.size.height, _name
 	];
 }

--- a/cocos2d/CCSpriteBatchNode.m
+++ b/cocos2d/CCSpriteBatchNode.m
@@ -78,7 +78,7 @@
 
 - (NSString*) description
 {
-	return [NSString stringWithFormat:@"<%@ = %p | Tag = %@>", [self class], self, _name ];
+	return [NSString stringWithFormat:@"<%@ = %p | Name = %@>", [self class], self, _name ];
 }
 
 @end


### PR DESCRIPTION
CCSprite + CCSpriteBatchNode 'description' was showing 'tag = <name>' change it to show 'Name = <name>' to match CCNode
