### PR TITLE
Removing the setting of _userObject to nil

### DIFF
--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -203,8 +203,6 @@ static NSUInteger globalOrderOfArrival = 1;
     
     // CCAnimationManager Cleanup (Set by SpriteBuilder)
     [_animationManager performSelector:@selector(cleanup)];
-    
-    _userObject = nil;
 }
 
 - (NSString*) description


### PR DESCRIPTION
In the cleanup method the _userObject property was being set to nil - appears to be a leftover from some earlier AnimationManager code from the commit history. _userObject should be left alone by the core engine, as by definition it is something for user code to do whatever it wants with.
