### PR TITLE
CCEffectColorChannelOffset - Fix color channel offset alpha

### DIFF
--- a/cocos2d/CCEffectColorChannelOffset.m
+++ b/cocos2d/CCEffectColorChannelOffset.m
@@ -63,7 +63,7 @@
                                    float blueInBounds = step(0.0, min(blueCompare.x, blueCompare.y));
                                    vec4 blueSample = inputValue * texture2D(cc_PreviousPassTexture, blueSamplePos) * blueInBounds;
                                    
-                                   return vec4(redSample.r, greenSample.g, blueSample.b, (redSample.a + greenSample.a + blueSample.a) / 3.0);
+                                   return vec4(redSample.r, greenSample.g, blueSample.b, max(max(redSample.a, greenSample.a), blueSample.a));
                                    );
     
     CCEffectFunction* fragmentFunction = [[CCEffectFunction alloc] initWithName:@"colorChannelOffsetEffect" body:effectBody inputs:@[input] returnType:@"vec4"];


### PR DESCRIPTION
Instead of averaging the alpha of the red, green, and blue sample points,
compute the max of them. This makes the combined alpha image for the
offset RGB channels into the union of the offset alpha channels which yields
the expected visual result.
