### PR TITLE
CCActionRepeat update - treat CCTime as double

### DIFF
--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -336,8 +336,7 @@
 	{
 		while (dt > _nextDt && _total < _times)
 		{
-
-			[_innerAction update:1.0f];
+			[_innerAction update:1.0];
 			_total++;
 
 			[_innerAction stop];
@@ -346,7 +345,7 @@
 		}
 		
 		// fix for issue #1288, incorrect end value of repeat
-		if(dt >= 1.0f && _total < _times) 
+		if(dt >= 1.0 && _total < _times) 
 		{
 			_total++;
 		}
@@ -356,7 +355,7 @@
 		{
 			if (_total == _times)
 			{
-				[_innerAction update:1];
+				[_innerAction update:1.0];
 				[_innerAction stop];
 			}
 			else
@@ -368,7 +367,7 @@
 	}
 	else
 	{
-		[_innerAction update:fmodf(dt * _times,1.0f)];
+		[_innerAction update:fmod(dt * _times, 1.0)];
 	}
 }
 


### PR DESCRIPTION
CCTime is a double on all builds - this updates CCActionRepeats update method to treat it so - mainly change fmodf to fmod but also a couple of other comparisons and explicit uses of .0f removed.
