### PR TITLE
Check for BGRA8888 support on android

### DIFF
--- a/cocos2d/CCConfiguration.m
+++ b/cocos2d/CCConfiguration.m
@@ -291,6 +291,8 @@ static char * glExtensions;
 		_supportsBGRA8888 = bgra8a | bgra8b;
 #elif __CC_PLATFORM_MAC
 		_supportsBGRA8888 = [self checkForGLExtension:@"GL_EXT_bgra"];
+#elif __CC_PLATFORM_ANDROID
+    _supportsBGRA8888 = [self checkForGLExtension:@"GL_EXT_texture_format_BGRA8888"];
 #endif
 			_supportsDiscardFramebuffer = [self checkForGLExtension:@"GL_EXT_discard_framebuffer"];
 

--- a/cocos2d/CCTexture.m
+++ b/cocos2d/CCTexture.m
@@ -108,6 +108,11 @@ static const MTLPixelFormat MetalPixelFormats[] = {
 
 #endif
 
+#if __CC_PLATFORM_ANDROID
+  #ifndef GL_BGRA
+  #define GL_BGRA                                                 0x80E1
+  #endif
+#endif
 
 //CLASS IMPLEMENTATIONS:
 


### PR DESCRIPTION
Check the android device to see if it support BGRA8888 extensions. Also adds a missing constant definition for the GL_BGRA type on android.
