### PR TITLE
Develop

### DIFF
--- a/cocos2d/Platforms/Android/CCActivity.m
+++ b/cocos2d/Platforms/Android/CCActivity.m
@@ -11,7 +11,6 @@
 #if __CC_PLATFORM_ANDROID
 
 #import <android/native_window.h>
-#import <bridge/runtime.h>
 #import <AndroidKit/AndroidLooper.h>
 #import <AndroidKit/AndroidAbsoluteLayout.h>
 

--- a/cocos2d/Platforms/Android/CCActivity.m
+++ b/cocos2d/Platforms/Android/CCActivity.m
@@ -90,6 +90,16 @@ static CGFloat FindLinearScale(CGFloat size, CGFloat fixedSize)
     if (_running) {
         return;
     }
+    if ([[self class] instanceMethodForSelector:_cmd] == [[CCActivity class] instanceMethodForSelector:_cmd]) {
+        // 20150402 : Warn about backwards-incompatibility with previous SBAndroid startup codepath.
+        // What you should do if you hit this:
+        //    * Comment the NSAssert and see if everything "just works" =)
+        //      --OR--
+        //    * Make sure your CCActivity subclass implements -run method (and calls [super run] first thing)
+        //    * -[CCAppController setupApplication] ultimately needs to be invoked once on startup (usually from your subclassed -run)
+        //    * (You may wish to generate a new test project from SpriteBuilder as a reference to trace the startup codepath)
+        NSAssert(NO, @"Your CCActivity subclass appears to use an old startup codepath which may result in a black screen");
+    }
     NSSetUncaughtExceptionHandler(&handler);
     currentActivity = self;
     _running = YES;

--- a/cocos2d/Platforms/Android/CCGLView.h
+++ b/cocos2d/Platforms/Android/CCGLView.h
@@ -12,7 +12,6 @@
 
 #import <CoreGraphics/CGGeometry.h>
 #import <android/native_window.h>
-#import <bridge/runtime.h>
 #import <GLActivityKit/GLView.h>
 #import "../../Platforms/CCGL.h"
 #import "CCView.h"

--- a/cocos2d/Platforms/Android/CCGLView.m
+++ b/cocos2d/Platforms/Android/CCGLView.m
@@ -11,7 +11,6 @@
 #if __CC_PLATFORM_ANDROID
 
 #import <android/native_window.h>
-#import <bridge/runtime.h>
 #import "CCTouchEvent.h"
 #import "CCTouch.h"
 #import "CCActivity.h"

--- a/cocos2d/cocos2d.h
+++ b/cocos2d/cocos2d.h
@@ -178,7 +178,6 @@
 #import "Platforms/Android/CCDirectorAndroid.h"
 
 #import <android/native_window.h>
-#import <bridge/runtime.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Two commits:
1. Excise BridgeKit references
2. Warn about backward incompatibility in CCActivity subclass on SBAndroid

The latter was necessary to build/run git@github.com:apportable/BridgeKitSample.spritebuilder.git against latest SpriteBuilder and cocos2d develop branch
