### PR TITLE
Remove static analyzer warnings about fontName

### DIFF
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -975,14 +975,16 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
                 return nil;
             }
             CTFontDescriptorRef descriptor = CFArrayGetValueAtIndex(descriptors, 0);
-            fontName = (__bridge NSString *)CTFontDescriptorCopyAttribute(descriptor, kCTFontNameAttribute);
+            CFTypeRef cfFontName = CTFontDescriptorCopyAttribute(descriptor, kCTFontNameAttribute);
+            fontName = [(__bridge NSString *)cfFontName copy];
+            CFRelease(cfFontName);
             CFRelease(descriptors);
-            
         } else {
             CGDataProviderRef fontDataProvider = CGDataProviderCreateWithURL((__bridge CFURLRef)fontURL);
             CGFontRef loadedFont = CGFontCreateWithDataProvider(fontDataProvider);
-            fontName = (__bridge NSString *)CGFontCopyPostScriptName(loadedFont);
-            
+            CFStringRef cfFontName = CGFontCopyPostScriptName(loadedFont);
+            fontName = [(__bridge NSString *)cfFontName copy];
+            CFRelease(cfFontName);
             CGFontRelease(loadedFont);
             CGDataProviderRelease(fontDataProvider);
         }


### PR DESCRIPTION
Before the above change a static analyzer build gives warnings due to this method 'Potential memory leak of an object' due to the fontName being a +1 retain count from the CFFontCopyPostScript name and the method name not being one that indicates it is handing over ownership of the object.

![screen shot 2015-04-03 at 17 00 23](https://cloud.githubusercontent.com/assets/715058/6984706/898eceee-da23-11e4-9022-23b75577c784.png)
