### PR TITLE
fix value parsing problem with fnt file

### DIFF
--- a/cocos2d/CCLabelBMFont.m
+++ b/cocos2d/CCLabelBMFont.m
@@ -365,7 +365,6 @@ void FNTConfigRemoveCache( void )
     
 	// Character ID
 	propertyValue = [nse nextObject];
-	propertyValue = [propertyValue substringToIndex: [propertyValue rangeOfString: @" "].location];
 	characterDefinition->charID = [propertyValue intValue];
     
 	// Character x


### PR DESCRIPTION
This line of code `propertyValue = [propertyValue substringToIndex: [propertyValue rangeOfString: @" "].location];` is not needed and will fail when a tab instead of space is before `charID`, which may be the case when you are using [**littera**](http://kvazars.com/littera/) to generate your fnt file.
