### PR TITLE
Metal fixes for latest develop

### DIFF
--- a/cocos2d-ui-tests/tests/CCRendererTest.m
+++ b/cocos2d-ui-tests/tests/CCRendererTest.m
@@ -267,7 +267,7 @@
 	CCShader *shader = nil;
 	
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		shader = [[CCShader alloc] initWithFragmentShaderSource:CC_METAL(
 			fragment half4 ShaderMain(
 				const CCFragData in [[stage_in]],

--- a/cocos2d-ui-tests/tests/TextureTest.m
+++ b/cocos2d-ui-tests/tests/TextureTest.m
@@ -307,7 +307,7 @@
     
     sprite.shaderUniforms[@"cube"] = sprite.texture;
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		sprite.shader = [[CCShader alloc] initWithFragmentShaderSource:CC_METAL(
 			fragment half4 ShaderMain(
 				const CCFragData in [[stage_in]],

--- a/cocos2d/CCDeprecated.m
+++ b/cocos2d/CCDeprecated.m
@@ -221,7 +221,7 @@ CGAffineTransformFromGLKMatrix4(GLKMatrix4 m)
 	if(_antialiased != antialiased){
 		CCRenderDispatch(NO, ^{
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-			if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+			if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 				CCMetalContext *context = [CCMetalContext currentContext];
 				
 				MTLSamplerDescriptor *samplerDesc = [MTLSamplerDescriptor new];

--- a/cocos2d/CCDrawNode.m
+++ b/cocos2d/CCDrawNode.m
@@ -35,7 +35,7 @@
 
 #import "CCRenderer.h"
 #import "CCColor.h"
-#import "CCDeviceInfo.h"
+#import "CCSetup.h"
 
 // Vertex shader that performs the modelview-projection multiplication on the GPU.
 // Faster for draw nodes that draw many vertexes, but can't be batched.
@@ -83,7 +83,7 @@ CCShader *CCDRAWNODE_BATCH_SHADER = nil;
 +(void)initialize
 {
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		id<MTLLibrary> library = [CCMetalContext currentContext].library;
 		NSAssert(library, @"Metal shader library not found.");
 		

--- a/cocos2d/CCRenderTexture.m
+++ b/cocos2d/CCRenderTexture.m
@@ -208,7 +208,7 @@ FlipY(GLKMatrix4 projection)
 -(GLKMatrix4)projection
 {
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		return FlipY(_projection);
 	} else
 #endif
@@ -220,7 +220,7 @@ FlipY(GLKMatrix4 projection)
 -(void)setProjection:(GLKMatrix4)projection
 {
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		_projection = FlipY(projection);
 	} else
 #endif

--- a/cocos2d/CCRenderer.m
+++ b/cocos2d/CCRenderer.m
@@ -54,7 +54,7 @@
 
 void CCRENDERER_DEBUG_PUSH_GROUP_MARKER(NSString *label){
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		[[CCMetalContext currentContext].currentRenderCommandEncoder pushDebugGroup:label];
 	} else
 #endif
@@ -65,7 +65,7 @@ void CCRENDERER_DEBUG_PUSH_GROUP_MARKER(NSString *label){
 
 void CCRENDERER_DEBUG_POP_GROUP_MARKER(void){
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		[[CCMetalContext currentContext].currentRenderCommandEncoder popDebugGroup];
 	} else
 #endif
@@ -76,7 +76,7 @@ void CCRENDERER_DEBUG_POP_GROUP_MARKER(void){
 
 void CCRENDERER_DEBUG_INSERT_EVENT_MARKER(NSString *label){
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		[[CCMetalContext currentContext].currentRenderCommandEncoder insertDebugSignpost:label];
 	} else
 #endif
@@ -87,7 +87,7 @@ void CCRENDERER_DEBUG_INSERT_EVENT_MARKER(NSString *label){
 
 void CCRENDERER_DEBUG_CHECK_ERRORS(void){
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 	} else
 #endif
 	{

--- a/cocos2d/CCShader.m
+++ b/cocos2d/CCShader.m
@@ -211,7 +211,7 @@ CompileShaderSources(GLenum type, NSArray *sources)
 	NSString *shaderName = (NSString *)key;
 	
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		id<MTLLibrary> library = [CCMetalContext currentContext].library;
 		
 		NSString *fragmentName = [shaderName stringByAppendingString:@"FS"];
@@ -670,7 +670,7 @@ MetalUniformSettersForFunctions(id<MTLFunction> vertexFunction, id<MTLFunction> 
 -(instancetype)initWithVertexShaderSource:(NSString *)vertexSource fragmentShaderSource:(NSString *)fragmentSource
 {
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		return [self initWithMetalVertexShaderSource:vertexSource fragmentShaderSource:fragmentSource];
 	}
 #endif
@@ -699,7 +699,7 @@ MetalUniformSettersForFunctions(id<MTLFunction> vertexFunction, id<MTLFunction> 
 -(instancetype)initWithRawVertexShaderSource:(NSString *)vertexSource rawFragmentShaderSource:(NSString *)fragmentSource
 {
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-    if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+    if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
         return [self initWithMetalVertexShaderSource:vertexSource fragmentShaderSource:fragmentSource];
     }
 #endif
@@ -723,7 +723,7 @@ MetalUniformSettersForFunctions(id<MTLFunction> vertexFunction, id<MTLFunction> 
 -(instancetype)copyWithZone:(NSZone *)zone
 {
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		return [[CCShader allocWithZone:zone] initWithMetalVertexFunction:_vertexFunction fragmentFunction:_fragmentFunction];
 	} else
 #endif
@@ -747,7 +747,7 @@ static CCShader *CC_SHADER_POS_TEX_COLOR_ALPHA_TEST = nil;
 	CC_SHADER_CACHE = [[CCShaderCache alloc] init];
 	
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		id<MTLLibrary> library = [CCMetalContext currentContext].library;
 		NSAssert(library, @"Metal shader library not found.");
 		

--- a/cocos2d/CCTexture+PVR.m
+++ b/cocos2d/CCTexture+PVR.m
@@ -2,6 +2,7 @@
 
 #import "ccMacros.h"
 #import "CCDeviceInfo.h"
+#import "CCSetup.h"
 #import "ccUtils.h"
 #import "CCGL.h"
 #import "CCRenderDispatch.h"
@@ -394,7 +395,7 @@ ReadPVRData(NSInputStream *stream, struct PVRInfo info, PVRDataBlock block)
             [self setupTexture:info.type rendertexture:NO sizeInPixels:info.size options:options];
             
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-            if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+            if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
                 // TODO add support for PVRTC
                 NSAssert(info.format == &PVRTableFormats[0], @"Metal only supports RGBA8 PVR files.");
                 

--- a/cocos2d/CCTexture.m
+++ b/cocos2d/CCTexture.m
@@ -139,7 +139,7 @@ static CCTexture *CCTextureNone = nil;
 	CCTextureNone->_contentScale = 1.0;
 	
 #if __CC_METAL_SUPPORTED_AND_ENABLED
-	if([CCDeviceInfo sharedDeviceInfo].graphicsAPI == CCGraphicsAPIMetal){
+	if([CCSetup sharedSetup].graphicsAPI == CCGraphicsAPIMetal){
 		CCMetalContext *context = [CCMetalContext currentContext];
 		NSAssert(context, @"Metal context is nil.");
 		

--- a/cocos2d/Platforms/CCSetup.m
+++ b/cocos2d/Platforms/CCSetup.m
@@ -466,7 +466,11 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 -(CCGraphicsAPI)graphicsAPI
 {
     if(_graphicsAPI == CCGraphicsAPIInvalid){
+#if __CC_METAL_SUPPORTED_AND_ENABLED
+        self.graphicsAPI = CCGraphicsAPIMetal;
+#else
         self.graphicsAPI = CCGraphicsAPIGL;
+#endif
     }
     
     return _graphicsAPI;

--- a/cocos2d/Platforms/iOS/CCMetalSupport.m
+++ b/cocos2d/Platforms/iOS/CCMetalSupport.m
@@ -29,6 +29,7 @@
 #import "CCMetalView.h"
 #import "CCTexture_Private.h"
 #import "CCShader_Private.h"
+#import "CCSetup_Private.h"
 
 #import "CCDeviceInfo.h"
 

--- a/cocos2d/Platforms/iOS/CCMetalView.m
+++ b/cocos2d/Platforms/iOS/CCMetalView.m
@@ -2,6 +2,7 @@
 
 #if __CC_METAL_SUPPORTED_AND_ENABLED
 
+#import <UIKit/UIKit.h>
 #import <QuartzCore/CAMetalLayer.h>
 #import <Metal/Metal.h>
 
@@ -61,15 +62,26 @@
         
         self.opaque = YES;
         self.backgroundColor = nil;
-        self.contentScaleFactor = [UIScreen mainScreen].scale;
+        
+        // Default to the screen's native scale.
+        UIScreen *screen = [UIScreen mainScreen];
+        if([screen respondsToSelector:@selector(nativeScale)]){
+            self.contentScaleFactor = screen.nativeScale;
+        } else {
+            self.contentScaleFactor = screen.scale;
+        }
         
         self.multipleTouchEnabled = YES;
         
-        _director = [[CCDirectorDisplayLink alloc] init];
-        _director.view = self;
+        _director = [[CCDirectorDisplayLink alloc] initWithView:self];
 	}
 
 	return self;
+}
+
+-(CGSize)sizeInPixels
+{
+    return CC_SIZE_SCALE(self.bounds.size, self.contentScaleFactor);
 }
 
 - (void) dealloc
@@ -87,7 +99,6 @@
 	_layerSizeDidUpdate = YES;
 
 	_surfaceSize = CC_SIZE_SCALE(self.bounds.size, self.contentScaleFactor);
-	[_director reshapeProjection:_surfaceSize];
 }
 
 -(void)beginFrame

--- a/iOS/AppDelegate.m
+++ b/iOS/AppDelegate.m
@@ -30,6 +30,9 @@
 #import "MainMenu.h"
 #import "CCPackageConstants.h"
 
+#if __CC_METAL_SUPPORTED_AND_ENABLED
+#import "CCMetalView.h"
+#endif
 
 @interface AppDelegate : NSObject
 @end
@@ -72,7 +75,27 @@
     ];
 
     _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-    _view = [[CCViewiOSGL alloc] initWithFrame:_window.bounds pixelFormat:kEAGLColorFormatRGBA8 depthFormat:GL_DEPTH24_STENCIL8_OES preserveBackbuffer:NO sharegroup:nil multiSampling:NO numberOfSamples:0];
+    
+    switch([CCSetup sharedSetup].graphicsAPI){
+        case CCGraphicsAPIGL:
+        {
+            _view = [[CCViewiOSGL alloc] initWithFrame:_window.bounds
+                                           pixelFormat:kEAGLColorFormatRGBA8
+                                           depthFormat:GL_DEPTH24_STENCIL8_OES
+                                    preserveBackbuffer:NO
+                                            sharegroup:nil
+                                         multiSampling:NO
+                                       numberOfSamples:0];
+            break;
+        }
+#if __CC_METAL_SUPPORTED_AND_ENABLED
+        case CCGraphicsAPIMetal:
+            // TODO support MSAA, depth buffers, etc.
+            _view = [[CCMetalView alloc] initWithFrame:_window.bounds];
+            break;
+#endif
+        default: NSAssert(NO, @"Internal error: Graphics API not set up.");
+    }
     
     UIViewController *viewController = [[UIViewController alloc] init];
     viewController.view = _view;


### PR DESCRIPTION
- graphicsAPI moved from CCDeviceInfo to CCSetup
- Set the graphics API to Metal when Metal is supported and enabled
- Fix initialization of CCMetalView
- Create CCMetalView instead of CCViewiOSGL if the graphics API is Metal
