### PR TITLE
Removing properties already defined in superclass

### DIFF
--- a/cocos2d/CCLabelBMFont.h
+++ b/cocos2d/CCLabelBMFont.h
@@ -152,14 +152,6 @@
  @see CCTextAlignment */
 @property (nonatomic,assign,readonly) CCTextAlignment alignment;
 
-/** The opacity of the text, in the range 0.0 (fully transparent) to 1.0 (fully opaque). */
-@property (nonatomic,readwrite) CGFloat opacity;
-
-/** The color of the text.
- @see CCColor */
-@property (nonatomic,strong) CCColor* color;
-
-
 /// -----------------------------------------------------------------------
 /// @name Size and Alignment
 /// -----------------------------------------------------------------------


### PR DESCRIPTION
Properties 'opacity' and 'color' are already defined in the superclass CCNode (shows up as a warning in XCode 6.3)

![screen shot 2015-04-10 at 16 18 47](https://cloud.githubusercontent.com/assets/715058/7090831/a1dc0708-df9d-11e4-81f6-188ab75445f1.png)
