### PR TITLE
Removed a warning from XCode 6.3

### DIFF
--- a/cocos2d/CCLightNode.m
+++ b/cocos2d/CCLightNode.m
@@ -15,6 +15,8 @@
 
 @implementation CCLightNode
 
+@dynamic color; // Stops a warning that the superclass defines it, but we like our own extra documentation so want the re-definition
+
 -(id)init
 {
     return [self initWithType:CCLightPoint groups:nil color:[CCColor whiteColor] intensity:1.0f];


### PR DESCRIPTION
For consideration - really the redefine of the property should be removed, but it expands/enhances the documentation and this @dynamic will remove the warning.
