### PR TITLE
ccb -> sb file compatibility

### DIFF
--- a/cocos2d-ui/CCBReader/CCBLocalizationManager.m
+++ b/cocos2d-ui/CCBReader/CCBLocalizationManager.m
@@ -46,7 +46,7 @@
     self = [super init];
     if (!self) return NULL;
     
-    [self loadStringsFile:@"Strings.ccbLang"];
+    [self loadStringsFile:@"Strings.sbLang"];
     
     return self;
 }
@@ -56,6 +56,13 @@
     NSError *err = nil;
     
     CCFile *file = [[CCFileLocator sharedFileLocator] fileNamed:plistFile error:&err];
+
+    //Compatibility for ccb -> sb renaming
+    if(err)
+    {
+        file = [[CCFileLocator sharedFileLocator] fileNamed:@"Strings.ccbLang" error:&err];
+    }
+
     NSAssert(err == nil, @"Error finding %@: %@", plistFile, err);
     
     NSDictionary *ser = [file loadPlist:&err];

--- a/cocos2d-ui/CCBReader/CCBReader.m
+++ b/cocos2d-ui/CCBReader/CCBReader.m
@@ -55,6 +55,8 @@
 #define DEBUG_READER_PROPERTIES 0
 #endif
 
+static const  NSString * const CCBI_PREFIX = @".ccbi";
+static const  NSString * const SBI_PREFIX = @".sbi";
 
 @interface CCBFile : CCNode
 {
@@ -852,7 +854,7 @@ static inline float readFloat(CCBReader *self)
 
 #if DEBUG
         // Special case: scroll view missing content node
-        if (!d && [ccbFileName isEqualToString:@".ccbi"] && [NSStringFromClass([node class]) isEqualToString:@"CCScrollView"])
+        if (!d && [ccbFileName isEqualToString:CCBI_PREFIX] && [NSStringFromClass([node class]) isEqualToString:@"CCScrollView"])
         {
             NSLog(@"*** [PROPERTY] ERROR HINT: Did you forget to set the content node for your CCScrollView?");
         }
@@ -1848,7 +1850,7 @@ SelectorNameForProperty(objc_property_t property)
 - (CCNode*) nodeGraphFromFile:(NSString*)ccbFileName owner:(id)o parentSize:(CGSize)parentSize
 {
     // Add ccbi suffix
-    if (![ccbFileName hasSuffix:@".ccbi"]) ccbFileName = [ccbFileName stringByAppendingString:@".ccbi"];
+    if (![ccbFileName hasSuffix:SBI_PREFIX] || ![ccbFileName hasSuffix:CCBI_PREFIX]) ccbFileName = [ccbFileName stringByAppendingString:SBI_PREFIX];
     
     NSError *err = nil;
     


### PR DESCRIPTION
This PR is designed to allow the `CCBReader` and `CCBLocalizationManager` classes to operate on the `sb` files created by the latest incarnation of SpriteBuilder.

As a compatibility measure, `ccb` files will still be handled if explicitly passed in, but the default is set to expect the `sb` / `sbi` variants as produced by spritebuilder develop.
