### PR TITLE
Fixing a memory leak when CCColor:CGColor was called

### DIFF
--- a/cocos2d/Support/CCColor.m
+++ b/cocos2d/Support/CCColor.m
@@ -178,10 +178,14 @@
 
 - (CGColorRef) CGColor
 {
-    CGFloat components[4] = {(CGFloat)_r, (CGFloat)_g, (CGFloat)_b, (CGFloat)_a};
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
-    _color = CGColorCreate(colorspace, components);
-    CGColorSpaceRelease(colorspace);
+    if (_color == NULL)
+    {
+        CGFloat components[4] = {(CGFloat)_r, (CGFloat)_g, (CGFloat)_b, (CGFloat)_a};
+        CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
+        _color = CGColorCreate(colorspace, components);
+        CGColorSpaceRelease(colorspace);
+    }
+    
     return _color;
 }
 


### PR DESCRIPTION
If the CGColor method of a CCColor was called more than once it would leak as the existing _color member was not freed.

The Instruments leak associated it with this line in NSAttributedString+CCAdditions.m / NSMutableAttributedStringFixPlatformSpecificAttributes :
    BOOL colorChanged = NSMutableAttributedStringSetDefaultAttribute(string, foregroundColorAttributeName, (__bridge id)defaultColor.CGColor);

when called from CCLabelTTF updateTexture which caused some confusion in finding it. Your mileage may vary depending on how you access CCColor CGColor but I was getting ~30 leaks of CGColor objects within 20 seconds of app startup. CCLabelTTF seems to be the main user - outline colour and shadow colour setup also call it.
