### PR TITLE
Check tagged variants of default untagged resources.

### DIFF
--- a/cocos2d/Support/CCFileLocator.m
+++ b/cocos2d/Support/CCFileLocator.m
@@ -304,6 +304,10 @@ NSString * const CCFILELOCATOR_SEARCH_OPTION_NOTRACE = @"CCFILELOCATOR_SEARCH_OP
         // Then the untagged variant.
         if(block(filename, self.untaggedContentScale, NO)) return;
         
+                
+        // Then the tagged version of the untagged variant (because that feature wasn't implemented)
+        if(block([self contentScaleFilenameWithBasefilename:filename contentScale:self.untaggedContentScale], self.untaggedContentScale, YES)) return;
+
         // Then the lower-res tagged variants.
         while(true)
         {


### PR DESCRIPTION
This is a dirty hack required for the current version of spritebuilder to detect 4x resolution files. Currently the "untagged" resolution support has not been implemented in the app and so we require this workaround for newly generated projects to detect resources.

Whether this is suitable for cocos2d develop is a decision I don't feel qualified to make. I've sent an email regarding priorities for feature development moving fowards, but as it stands SpriteBuilder develop cannot load resources without this.
