### PR TITLE
Rename CCBReader to CCSBReader

### DIFF
--- a/cocos2d-ui/CCBReader/CCAnimationManager.m
+++ b/cocos2d-ui/CCBReader/CCAnimationManager.m
@@ -34,7 +34,7 @@
 #import "CCBKeyframe.h"
 #import "CCBSequence.h"
 #import "CCBSequenceProperty.h"
-#import "CCBReader.h"
+#import "CCSBReader.h"
 #import "CCBKeyframe.h"
 #import "OALSimpleAudio.h"
 #import "CCActionInterval.h"
@@ -261,7 +261,7 @@ static NSInteger ccbAnimationManagerID = 0;
             return [CCBActionTweenColor actionWithDuration:duration key:name from:kf0.value to:kf1.value];
         }
     } else {
-        CCLOG(@"CCBReader: Failed to create animation for property: %@", name);
+        CCLOG(@"CCSBReader: Failed to create animation for property: %@", name);
     }
               
     return NULL;
@@ -333,7 +333,7 @@ static NSInteger ccbAnimationManagerID = 0;
     CCActionInterval*intervalAction = (CCActionInterval*)action;
     if(!intervalAction)
     {
-        NSLog(@"CCBReader: Incorrect action type %@ for easing - must be a CCActionInterval subclass", action);
+        NSLog(@"CCSBReader: Incorrect action type %@ for easing - must be a CCActionInterval subclass", action);
         return nil;
     }
     
@@ -395,7 +395,7 @@ static NSInteger ccbAnimationManagerID = 0;
     }
     else
     {
-        NSLog(@"CCBReader: Unkown easing type %d", easingType);
+        NSLog(@"CCSBReader: Unkown easing type %d", easingType);
         return action;
     }
 }

--- a/cocos2d-ui/CCBReader/CCBLocalizationManager.m
+++ b/cocos2d-ui/CCBReader/CCBLocalizationManager.m
@@ -23,7 +23,7 @@
  */
 
 #import "CCBLocalizationManager.h"
-#import "CCBReader.h"
+#import "CCSBReader.h"
 #import "CCFileLocator.h"
 #import "CCFile.h"
 

--- a/cocos2d-ui/CCBReader/CCBReader_Private.h
+++ b/cocos2d-ui/CCBReader/CCBReader_Private.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import "CCBReader.h"
+#import "CCSBReader.h"
 
 #define kCCBVersion 11
 

--- a/cocos2d-ui/CCBReader/CCBuilderReader.h
+++ b/cocos2d-ui/CCBReader/CCBuilderReader.h
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  */
 
-#import "CCBReader.h"
+#import "CCSBReader.h"
 #import "CCBAnimationManager.h"
 #import "CCAnimationManager.h"
 #import "CCBLocalizationManager.h"

--- a/cocos2d-ui/CCBReader/CCSBReader.h
+++ b/cocos2d-ui/CCBReader/CCSBReader.h
@@ -30,20 +30,20 @@
 #import "CCAnimationManager.h"
 
 /**
- The CCBReader loads SpriteBuilder (CCB) documents.
+ The CCSBReader loads SpriteBuilder (CCB) documents.
  
  For the most part you'll just use one of these two methods:
  
     // load a CCB document as a CCNode instance
-    CCNode* myNode = [CCBReader load:@"MyNode"];
+    CCNode* myNode = [CCSBReader load:@"MyNode"];
 
     // load a CCB document of type "Sprite" as a CCSprite instance
-    CCSprite* mySprite = (CCSprite*)[CCBReader load:@"MySprite"];
+    CCSprite* mySprite = (CCSprite*)[CCSBReader load:@"MySprite"];
 
     // load a CCB document wrapped in a CCScene instance
-    CCScene* scene = [CCBReader loadAsScene:@"MyNode"];
+    CCScene* scene = [CCSBReader loadAsScene:@"MyNode"];
  
- You can optionally pass an owner object to the CCBReader load methods. This owner object then gets assigned all of the SpriteBuilder document's member variables that are marked to be set to the "Owner".
+ You can optionally pass an owner object to the CCSBReader load methods. This owner object then gets assigned all of the SpriteBuilder document's member variables that are marked to be set to the "Owner".
  In all other cases owner is nil and assigning variables to Owner discards their assignment.
  
  When a SpriteBuilder document was loaded, all nodes created from the document will receive the didLoadFromCCB message, if implemented as follows:
@@ -62,7 +62,7 @@
  
  Nodes created from a SpriteBuilder document will also have a valid CCAnimationManager instance assigned to their [CCNode animationManager] property.
  */
-@interface CCBReader : NSObject
+@interface CCSBReader : NSObject
 {
     NSData* data;
     unsigned char* bytes;
@@ -95,11 +95,11 @@
 /// -----------------------------------------------------------------------
 
 /**
- *  Creates a new CCBReader. You don't normally need to do this because you can directly use most methods, ie `[CCBReader load:@"MyNode"];`.
+ *  Creates a new CCSBReader. You don't normally need to do this because you can directly use most methods, ie `[CCSBReader load:@"MyNode"];`.
  *
- *  @return A new CCBReader.
+ *  @return A new CCSBReader.
  */
-+ (CCBReader*) reader;
++ (CCSBReader *) reader;
 
 /// -----------------------------------------------------------------------
 /// @name Loading SpriteBuilder documents

--- a/cocos2d-ui/CCBReader/CCSBReader.m
+++ b/cocos2d-ui/CCBReader/CCSBReader.m
@@ -67,7 +67,7 @@ static const  NSString * const SBI_PREFIX = @".sbi";
 @end
 
 
-@interface CCBReader()
+@interface CCSBReader ()
 {
 
 }
@@ -78,7 +78,7 @@ static const  NSString * const SBI_PREFIX = @".sbi";
 @end
 
 
-@implementation CCBReader
+@implementation CCSBReader
 
 @synthesize animationManager;
 
@@ -111,19 +111,19 @@ static const  NSString * const SBI_PREFIX = @".sbi";
     bytes = NULL;
 }
 
-static inline unsigned char readByte(CCBReader *self)
+static inline unsigned char readByte(CCSBReader *self)
 {
     unsigned char byte = self->bytes[self->currentByte];
     self->currentByte++;
     return byte;
 }
 
-static inline BOOL readBool(CCBReader *self)
+static inline BOOL readBool(CCSBReader *self)
 {
     return (BOOL)readByte(self);
 }
 
-static inline NSString *readUTF8(CCBReader *self)
+static inline NSString *readUTF8(CCSBReader *self)
 {
     int b0 = readByte(self);
     int b1 = readByte(self);
@@ -137,7 +137,7 @@ static inline NSString *readUTF8(CCBReader *self)
     return str;
 }
 
-static inline void alignBits(CCBReader *self)
+static inline void alignBits(CCSBReader *self)
 {
     if (self->currentBit)
     {
@@ -164,7 +164,7 @@ done:
 }
 
 
-static inline int readIntWithSign(CCBReader *self, BOOL pSigned)
+static inline int readIntWithSign(CCSBReader *self, BOOL pSigned)
 {
     unsigned int value = 0;
     self->currentByte += readVariableLengthIntFromArray(self->bytes + self->currentByte, &value);
@@ -192,7 +192,7 @@ static inline int readIntWithSign(CCBReader *self, BOOL pSigned)
 //DEPRICATED
 //DEPRICATED
 //DEPRICATED
-static inline int readIntWithSignOLD(CCBReader *self, BOOL sign)
+static inline int readIntWithSignOLD(CCSBReader *self, BOOL sign)
 {
     // Good luck groking this!
     // The basic idea is to do as little bit reading as possible and use everything in a byte contexts and avoid loops; espc ones that iterate 8 * bytes-read
@@ -298,7 +298,7 @@ static inline int readIntWithSignOLD(CCBReader *self, BOOL sign)
 
 
 
-static inline float readFloat(CCBReader *self)
+static inline float readFloat(CCSBReader *self)
 {
     unsigned char type = readByte(self);
     
@@ -815,7 +815,7 @@ static inline float readFloat(CCBReader *self)
                     }
                     else
                     {
-                        NSLog(@"CCBReader: Failed to set selector/target block for \"%@\" for target %@",selectorName,target);
+                        NSLog(@"CCSBReader: Failed to set selector/target block for \"%@\" for target %@",selectorName,target);
                     }
 
 #if DEBUG_READER_PROPERTIES
@@ -824,7 +824,7 @@ static inline float readFloat(CCBReader *self)
                 }
                 else
                 {
-                    NSLog(@"CCBReader: Failed to find target for block");
+                    NSLog(@"CCSBReader: Failed to find target for block");
                 }
             }
         }
@@ -863,7 +863,7 @@ static inline float readFloat(CCBReader *self)
         NSAssert(d,@"[PROPERTY] %@ - kCCBPropTypeCCBFile - Failed to find ccb file: \"%@\", node class name: \"%@\", name: \"%@\", in ccb file: \"%@\"",
                  name, ccbFileName, [node class], [node name], _currentCCBFile);
 
-        CCBReader* reader = [[CCBReader alloc] init];
+        CCSBReader * reader = [[CCSBReader alloc] init];
         reader.animationManager.rootContainerSize = parent.contentSize;
         
         // Setup byte array & owner
@@ -956,7 +956,7 @@ static inline float readFloat(CCBReader *self)
 		Class nodeClass = NSClassFromString(className);
 		if (nodeClass == nil)
 		{
-			NSAssert(nil, @"CCBReader: Could not create class named: %@", className);
+			NSAssert(nil, @"CCSBReader: Could not create class named: %@", className);
 			return nil;
 		}
 		
@@ -1133,7 +1133,7 @@ static inline float readFloat(CCBReader *self)
 			return;
 		
 		CCNode * mappedNode = nodeMapping[@(uuid)];
-		NSAssert(mappedNode != nil, @"CCBReader: Failed to find node UUID:%i", uuid);
+		NSAssert(mappedNode != nil, @"CCSBReader: Failed to find node UUID:%i", uuid);
 		[node setValue:mappedNode forKey:name];
 		
 	}
@@ -1300,7 +1300,7 @@ static inline float readFloat(CCBReader *self)
     Class nodeClass = NSClassFromString(nodeClassName);
     if (nodeClass == nil)
     {
-		NSAssert(nil, @"CCBReader: Could not create class named: %@", nodeClassName);
+		NSAssert(nil, @"CCSBReader: Could not create class named: %@", nodeClassName);
         return nil;
     }
 	
@@ -1488,7 +1488,7 @@ SelectorNameForProperty(objc_property_t property)
                 }
                 else
                 {
-                    NSLog(@"CCBReader: Couldn't find member variable: %@", memberVarAssignmentName);
+                    NSLog(@"CCSBReader: Couldn't find member variable: %@", memberVarAssignmentName);
                 }
             }
         }
@@ -1758,7 +1758,7 @@ SelectorNameForProperty(objc_property_t property)
     int version = readIntWithSignOLD(self, NO);
     if (version != kCCBVersion)
     {
-		[NSException raise:NSInternalInconsistencyException format:@"CCBReader: Incompatible ccbi file version (file: %d reader: %d)",version,kCCBVersion];
+		[NSException raise:NSInternalInconsistencyException format:@"CCSBReader: Incompatible ccbi file version (file: %d reader: %d)",version,kCCBVersion];
         return NO;
     }
     
@@ -1801,7 +1801,7 @@ SelectorNameForProperty(objc_property_t property)
 {
     for (CCNode* child in nodeGraph.children)
     {
-        [CCBReader callDidLoadFromCCBForNodeGraph:child];
+        [CCSBReader callDidLoadFromCCBForNodeGraph:child];
     }
     
     if ([nodeGraph respondsToSelector:@selector(didLoadFromCCB)])
@@ -1842,7 +1842,7 @@ SelectorNameForProperty(objc_property_t property)
     }
     
     // Call didLoadFromCCB
-    [CCBReader callDidLoadFromCCBForNodeGraph:nodeGraph];
+    [CCSBReader callDidLoadFromCCBForNodeGraph:nodeGraph];
 
     return nodeGraph;
 }
@@ -1883,34 +1883,34 @@ SelectorNameForProperty(objc_property_t property)
 	[CCFileLocator sharedFileLocator].searchPaths = array;
 }
 
-+ (CCBReader*) reader
++ (CCSBReader *) reader
 {
-    return [[CCBReader alloc] init];
+    return [[CCSBReader alloc] init];
 }
 
 + (CCNode*) load:(NSString*) file owner:(id)owner
 {
-    return [CCBReader load:file owner:owner parentSize:[CCDirector currentDirector].designSize];
+    return [CCSBReader load:file owner:owner parentSize:[CCDirector currentDirector].designSize];
 }
 
 + (CCNode*) nodeGraphFromData:(NSData*) data owner:(id)owner parentSize:(CGSize)parentSize
 {
-    return [[CCBReader reader] loadWithData:data owner:owner];
+    return [[CCSBReader reader] loadWithData:data owner:owner];
 }
 
 + (CCNode*) load:(NSString*) file owner:(id)owner parentSize:(CGSize)parentSize
 {
-    return [[CCBReader reader] nodeGraphFromFile:file owner:owner parentSize:parentSize];
+    return [[CCSBReader reader] nodeGraphFromFile:file owner:owner parentSize:parentSize];
 }
 
 + (CCNode*) load:(NSString*) file
 {
-    return [CCBReader load:file owner:NULL];
+    return [CCSBReader load:file owner:NULL];
 }
 
 + (CCScene*) loadAsScene:(NSString *)file owner:(id)owner
 {
-    return [CCBReader sceneWithNodeGraphFromFile:file owner:owner parentSize:[CCDirector currentDirector].designSize];
+    return [CCSBReader sceneWithNodeGraphFromFile:file owner:owner parentSize:[CCDirector currentDirector].designSize];
 }
 
 -(CCScene*) createScene
@@ -1920,7 +1920,7 @@ SelectorNameForProperty(objc_property_t property)
 
 + (CCScene*) sceneWithNodeGraphFromFile:(NSString *)file owner:(id)owner parentSize:(CGSize)parentSize
 {
-    CCNode* node = [CCBReader load:file owner:owner parentSize:parentSize];
+    CCNode* node = [CCSBReader load:file owner:owner parentSize:parentSize];
     CCScene* scene = [CCScene node];
     [scene addChild:node];
     return scene;
@@ -1928,7 +1928,7 @@ SelectorNameForProperty(objc_property_t property)
 
 + (CCScene*) loadAsScene:(NSString*) file
 {
-    return [CCBReader loadAsScene:file owner:NULL]; 
+    return [CCSBReader loadAsScene:file owner:NULL];
 }
 
 + (NSString*) ccbDirectoryPath

--- a/cocos2d-ui/CCBReader/CCSBReader.m
+++ b/cocos2d-ui/CCBReader/CCSBReader.m
@@ -55,8 +55,8 @@
 #define DEBUG_READER_PROPERTIES 0
 #endif
 
-static const  NSString * const CCBI_PREFIX = @".ccbi";
-static const  NSString * const SBI_PREFIX = @".sbi";
+static NSString * const CCBI_PREFIX = @".ccbi";
+static NSString * const SBI_PREFIX = @".sbi";
 
 @interface CCBFile : CCNode
 {

--- a/cocos2d-ui/cocos2d-ui.h
+++ b/cocos2d-ui/cocos2d-ui.h
@@ -30,5 +30,5 @@
 #import "CCTextField.h"
 #import "CCSlider.h"
 
-// CCBReader
+// CCSBReader
 #import "CCBuilderReader.h"

--- a/cocos2d.xcodeproj/project.pbxproj
+++ b/cocos2d.xcodeproj/project.pbxproj
@@ -264,7 +264,7 @@
 		7A59476B19E3731800F65F90 /* CCBAnimationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = D24160FB1958F6EE003673BD /* CCBAnimationManager.h */; };
 		7A59476D19E3731800F65F90 /* CCBKeyframe.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273021822F4AA0054849B /* CCBKeyframe.h */; };
 		7A59476F19E3731900F65F90 /* CCBLocalizationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273041822F4AA0054849B /* CCBLocalizationManager.h */; };
-		7A59477119E3731A00F65F90 /* CCBReader.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273061822F4AA0054849B /* CCBReader.h */; };
+		7A59477119E3731A00F65F90 /* CCSBReader.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273061822F4AA0054849B /* CCSBReader.h */; };
 		7A59477319E3731B00F65F90 /* CCBSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273081822F4AA0054849B /* CCBSequence.h */; };
 		7A59477519E3731C00F65F90 /* CCBSequenceProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D2730A1822F4AA0054849B /* CCBSequenceProperty.h */; };
 		7A59477719E3731C00F65F90 /* CCBuilderReader.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D2730C1822F4AA0054849B /* CCBuilderReader.h */; };
@@ -378,7 +378,7 @@
 		7A5948B719E375BA00F65F90 /* CCBAnimationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D24160FC1958F6EE003673BD /* CCBAnimationManager.m */; };
 		7A5948B919E375BA00F65F90 /* CCBKeyframe.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273031822F4AA0054849B /* CCBKeyframe.m */; };
 		7A5948BB19E375BA00F65F90 /* CCBLocalizationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273051822F4AA0054849B /* CCBLocalizationManager.m */; };
-		7A5948BD19E375BB00F65F90 /* CCBReader.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273071822F4AA0054849B /* CCBReader.m */; };
+		7A5948BD19E375BB00F65F90 /* CCSBReader.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273071822F4AA0054849B /* CCSBReader.m */; };
 		7A5948BF19E375BB00F65F90 /* CCBsequence.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273091822F4AA0054849B /* CCBsequence.m */; };
 		7A5948C119E375BB00F65F90 /* CCBSequenceProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D2730B1822F4AA0054849B /* CCBSequenceProperty.m */; };
 		7A5948C719E375BC00F65F90 /* CCControl.m in Sources */ = {isa = PBXBuildFile; fileRef = B78AE45D17E7AF1C0028BE0B /* CCControl.m */; };
@@ -543,8 +543,8 @@
 		B7D273101822F4AA0054849B /* CCBKeyframe.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273031822F4AA0054849B /* CCBKeyframe.m */; };
 		B7D273111822F4AA0054849B /* CCBLocalizationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273041822F4AA0054849B /* CCBLocalizationManager.h */; };
 		B7D273121822F4AA0054849B /* CCBLocalizationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273051822F4AA0054849B /* CCBLocalizationManager.m */; };
-		B7D273131822F4AA0054849B /* CCBReader.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273061822F4AA0054849B /* CCBReader.h */; };
-		B7D273141822F4AA0054849B /* CCBReader.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273071822F4AA0054849B /* CCBReader.m */; };
+		B7D273131822F4AA0054849B /* CCSBReader.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273061822F4AA0054849B /* CCSBReader.h */; };
+		B7D273141822F4AA0054849B /* CCSBReader.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273071822F4AA0054849B /* CCSBReader.m */; };
 		B7D273151822F4AA0054849B /* CCBSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273081822F4AA0054849B /* CCBSequence.h */; };
 		B7D273161822F4AA0054849B /* CCBsequence.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273091822F4AA0054849B /* CCBsequence.m */; };
 		B7D273171822F4AA0054849B /* CCBSequenceProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D2730A1822F4AA0054849B /* CCBSequenceProperty.h */; };
@@ -751,7 +751,7 @@
 		D2FEB647194F6C9E00FC0574 /* CCEffect_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D272031718FC89A000B100FF /* CCEffect_Private.h */; };
 		D2FEB648194F6C9E00FC0574 /* CCEffectStack.h in Headers */ = {isa = PBXBuildFile; fileRef = D272032018FC89A000B100FF /* CCEffectStack.h */; };
 		D2FEB64A194F6C9E00FC0574 /* CCTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E260D618171D2000A0E872 /* CCTextField.h */; };
-		D2FEB64B194F6C9E00FC0574 /* CCBReader.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273061822F4AA0054849B /* CCBReader.h */; };
+		D2FEB64B194F6C9E00FC0574 /* CCSBReader.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D273061822F4AA0054849B /* CCSBReader.h */; };
 		D2FEB64C194F6C9E00FC0574 /* CCEffectPixellate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF3761F191C594A00C6D27A /* CCEffectPixellate.h */; };
 		D2FEB64E194F6C9E00FC0574 /* CCTiledMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 509D0816101E4FCE007E1749 /* CCTiledMap.h */; };
 		D2FEB652194F6C9E00FC0574 /* CCTMXXMLParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 50CFAC371023660000175934 /* CCTMXXMLParser.h */; };
@@ -841,7 +841,7 @@
 		D2FEB6DD194F6C9E00FC0574 /* CCTiledMapObjectGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 50D2AC9410E90DFA0068ECEB /* CCTiledMapObjectGroup.m */; };
 		D2FEB6DE194F6C9E00FC0574 /* CGPointExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 503798C50F912C2000986724 /* CGPointExtension.m */; };
 		D2FEB6DF194F6C9E00FC0574 /* CCParticleSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 50D413250F9A3FE00040C3C8 /* CCParticleSystem.m */; };
-		D2FEB6E3194F6C9E00FC0574 /* CCBReader.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273071822F4AA0054849B /* CCBReader.m */; };
+		D2FEB6E3194F6C9E00FC0574 /* CCSBReader.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D273071822F4AA0054849B /* CCSBReader.m */; };
 		D2FEB6EA194F6C9E00FC0574 /* CCEffectStack.m in Sources */ = {isa = PBXBuildFile; fileRef = D272032118FC89A000B100FF /* CCEffectStack.m */; };
 		D2FEB6EC194F6C9E00FC0574 /* CCRenderTexture.m in Sources */ = {isa = PBXBuildFile; fileRef = 50316AA510291280003ACFE7 /* CCRenderTexture.m */; };
 		D2FEB6ED194F6C9E00FC0574 /* CCMotionStreak.m in Sources */ = {isa = PBXBuildFile; fileRef = 50316AD31029A126003ACFE7 /* CCMotionStreak.m */; };
@@ -1434,8 +1434,8 @@
 		B7D273031822F4AA0054849B /* CCBKeyframe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CCBKeyframe.m; path = "cocos2d-ui/CCBReader/CCBKeyframe.m"; sourceTree = "<group>"; };
 		B7D273041822F4AA0054849B /* CCBLocalizationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CCBLocalizationManager.h; path = "cocos2d-ui/CCBReader/CCBLocalizationManager.h"; sourceTree = "<group>"; };
 		B7D273051822F4AA0054849B /* CCBLocalizationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CCBLocalizationManager.m; path = "cocos2d-ui/CCBReader/CCBLocalizationManager.m"; sourceTree = "<group>"; };
-		B7D273061822F4AA0054849B /* CCBReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CCBReader.h; path = "cocos2d-ui/CCBReader/CCBReader.h"; sourceTree = "<group>"; };
-		B7D273071822F4AA0054849B /* CCBReader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CCBReader.m; path = "cocos2d-ui/CCBReader/CCBReader.m"; sourceTree = "<group>"; };
+		B7D273061822F4AA0054849B /* CCSBReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CCSBReader.h; path = "cocos2d-ui/CCBReader/CCSBReader.h"; sourceTree = "<group>"; };
+		B7D273071822F4AA0054849B /* CCSBReader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CCSBReader.m; path = "cocos2d-ui/CCBReader/CCSBReader.m"; sourceTree = "<group>"; };
 		B7D273081822F4AA0054849B /* CCBSequence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CCBSequence.h; path = "cocos2d-ui/CCBReader/CCBSequence.h"; sourceTree = "<group>"; };
 		B7D273091822F4AA0054849B /* CCBsequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CCBsequence.m; path = "cocos2d-ui/CCBReader/CCBsequence.m"; sourceTree = "<group>"; };
 		B7D2730A1822F4AA0054849B /* CCBSequenceProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CCBSequenceProperty.h; path = "cocos2d-ui/CCBReader/CCBSequenceProperty.h"; sourceTree = "<group>"; };
@@ -2231,8 +2231,8 @@
 				B7D273031822F4AA0054849B /* CCBKeyframe.m */,
 				B7D273041822F4AA0054849B /* CCBLocalizationManager.h */,
 				B7D273051822F4AA0054849B /* CCBLocalizationManager.m */,
-				B7D273061822F4AA0054849B /* CCBReader.h */,
-				B7D273071822F4AA0054849B /* CCBReader.m */,
+				B7D273061822F4AA0054849B /* CCSBReader.h */,
+				B7D273071822F4AA0054849B /* CCSBReader.m */,
 				B7D273081822F4AA0054849B /* CCBSequence.h */,
 				B7D273091822F4AA0054849B /* CCBsequence.m */,
 				B7D2730A1822F4AA0054849B /* CCBSequenceProperty.h */,
@@ -2607,7 +2607,7 @@
 				D2C788261A5D32C10070EA5D /* CCView.h in Headers */,
 				D34CAD6C19C3AA10009BED7A /* CCRendererBasicTypes_Private.h in Headers */,
 				D268FE13198078FF00ECBCD0 /* CCEffectReflection.h in Headers */,
-				B7D273131822F4AA0054849B /* CCBReader.h in Headers */,
+				B7D273131822F4AA0054849B /* CCSBReader.h in Headers */,
 				9DF37621191C594A00C6D27A /* CCEffectPixellate.h in Headers */,
 				509D0818101E4FCE007E1749 /* CCTiledMap.h in Headers */,
 				D31C795219994197007921E1 /* CCMetalSupport_Private.h in Headers */,
@@ -2903,7 +2903,7 @@
 				7A59476B19E3731800F65F90 /* CCBAnimationManager.h in Headers */,
 				7A59476D19E3731800F65F90 /* CCBKeyframe.h in Headers */,
 				7A59476F19E3731900F65F90 /* CCBLocalizationManager.h in Headers */,
-				7A59477119E3731A00F65F90 /* CCBReader.h in Headers */,
+				7A59477119E3731A00F65F90 /* CCSBReader.h in Headers */,
 				7A59477319E3731B00F65F90 /* CCBSequence.h in Headers */,
 				7A59477519E3731C00F65F90 /* CCBSequenceProperty.h in Headers */,
 				D2C788281A5D32C10070EA5D /* CCView.h in Headers */,
@@ -3004,7 +3004,7 @@
 				BC9F4EA019DB649E00B25F01 /* CCPackageHelper.h in Headers */,
 				D2FEB648194F6C9E00FC0574 /* CCEffectStack.h in Headers */,
 				D2FEB64A194F6C9E00FC0574 /* CCTextField.h in Headers */,
-				D2FEB64B194F6C9E00FC0574 /* CCBReader.h in Headers */,
+				D2FEB64B194F6C9E00FC0574 /* CCSBReader.h in Headers */,
 				D2FEB64C194F6C9E00FC0574 /* CCEffectPixellate.h in Headers */,
 				14B84C931A700B55002C4D20 /* CCSetup.h in Headers */,
 				D2FEB64E194F6C9E00FC0574 /* CCTiledMap.h in Headers */,
@@ -3427,7 +3427,7 @@
 				9D96F9791AA9411700937308 /* CCEffectUniform.m in Sources */,
 				9DBCA31519B68BE400EFE96D /* CCEffectColorChannelOffset.m in Sources */,
 				D3903B15199528B6003AA81A /* CCMetalView.m in Sources */,
-				B7D273141822F4AA0054849B /* CCBReader.m in Sources */,
+				B7D273141822F4AA0054849B /* CCSBReader.m in Sources */,
 				571CD02B19649E03003D460C /* CCPlatformTextFieldIOS.m in Sources */,
 				83E1A86519C8ACA0000A3BCA /* CCPackageConstants.m in Sources */,
 				D272032E18FC89A000B100FF /* CCEffectStack.m in Sources */,
@@ -3647,7 +3647,7 @@
 				7A5948B719E375BA00F65F90 /* CCBAnimationManager.m in Sources */,
 				7A5948B919E375BA00F65F90 /* CCBKeyframe.m in Sources */,
 				7A5948BB19E375BA00F65F90 /* CCBLocalizationManager.m in Sources */,
-				7A5948BD19E375BB00F65F90 /* CCBReader.m in Sources */,
+				7A5948BD19E375BB00F65F90 /* CCSBReader.m in Sources */,
 				7A5948BF19E375BB00F65F90 /* CCBsequence.m in Sources */,
 				D39D34A41A4243EE00B5A115 /* CCViewportNode.m in Sources */,
 				9D03A5F81A02F8C600C651C8 /* CCEffectLighting.m in Sources */,
@@ -3729,7 +3729,7 @@
 				D2FEB6DE194F6C9E00FC0574 /* CGPointExtension.m in Sources */,
 				D2FEB6DF194F6C9E00FC0574 /* CCParticleSystem.m in Sources */,
 				D27451BD19AEC84C006DA0A1 /* CCEffectDistanceField.m in Sources */,
-				D2FEB6E3194F6C9E00FC0574 /* CCBReader.m in Sources */,
+				D2FEB6E3194F6C9E00FC0574 /* CCSBReader.m in Sources */,
 				D304BC281A1DA3CA005A0260 /* CCRenderableNode.m in Sources */,
 				BC9F4E9219DB633B00B25F01 /* CCPackageDownloadManager.m in Sources */,
 				D3903B17199528DF003AA81A /* CCRenderDispatch.m in Sources */,

--- a/cocos2d.xcodeproj/project.pbxproj
+++ b/cocos2d.xcodeproj/project.pbxproj
@@ -2198,7 +2198,7 @@
 			isa = PBXGroup;
 			children = (
 				571CD01A19649E03003D460C /* Platform */,
-				B7D272FA1822F4920054849B /* CCBReader */,
+				B7D272FA1822F4920054849B /* CCSBReader */,
 				B7C6237917EA7D8600928F91 /* cocos2d-ui.h */,
 				B78AE45C17E7AF1C0028BE0B /* CCControl.h */,
 				B750162218124B6000708A2F /* CCControlSubclass.h */,
@@ -2217,7 +2217,7 @@
 			name = "cocos2d-ui";
 			sourceTree = "<group>";
 		};
-		B7D272FA1822F4920054849B /* CCBReader */ = {
+		B7D272FA1822F4920054849B /* CCSBReader */ = {
 			isa = PBXGroup;
 			children = (
 				D24160F61958F6EE003673BD /* CCAnimationManager_Private.h */,
@@ -2240,7 +2240,7 @@
 				B7D2730C1822F4AA0054849B /* CCBuilderReader.h */,
 				B77060CE18341AD50043CC67 /* CCBReader_Private.h */,
 			);
-			name = CCBReader;
+			name = CCSBReader;
 			sourceTree = "<group>";
 		};
 		B7E7DE351A76DB7D004234B7 /* cocos2dMacFramework */ = {

--- a/cocos2d/Platforms/Android/CCActivity.m
+++ b/cocos2d/Platforms/Android/CCActivity.m
@@ -15,7 +15,7 @@
 #import <AndroidKit/AndroidAbsoluteLayout.h>
 
 #import "cocos2d.h"
-#import "CCBReader.h"
+#import "CCSBReader.h"
 #import "CCGLView.h"
 #import "CCScene.h"
 

--- a/cocos2d/Platforms/CCSetup.m
+++ b/cocos2d/Platforms/CCSetup.m
@@ -29,7 +29,7 @@
 #import "CCDirector_Private.h"
 
 #import "CCScene.h"
-#import "CCBReader.h"
+#import "CCSBReader.h"
 #import "CCDeviceInfo.h"
 #import "OALSimpleAudio.h"
 #import "CCPackageManager.h"
@@ -154,7 +154,7 @@ static CGFloat FindPOTScale(CGFloat size, CGFloat fixedSize)
 
 - (CCScene *)createFirstScene
 {
-    return [CCBReader loadAsScene:@"MainScene"];
+    return [CCSBReader loadAsScene:@"MainScene"];
 }
 
 - (CCScene *)startScene


### PR DESCRIPTION
This renames the CCBReader class to CCSBReader. 

The internal CCB\* classes are left untouched by this pull request, as there are many string/class comparisons throughout the app that depend on the type name. This will likely require a new ccbreader / writer version.
