### PR TITLE
Metal Prep Step 9 - Immutable render passes

### DIFF
--- a/cocos2d/CCEffect.m
+++ b/cocos2d/CCEffect.m
@@ -62,11 +62,11 @@ const CCEffectPrepareResult CCEffectPrepareNoop     = { CCEffectPrepareSuccess, 
             
             // If a uniform translation table is not set already, set it to the default.
             NSMutableArray *beginBlocks = [NSMutableArray array];
-            for (CCEffectRenderPassBeginBlockContext *blockContext in passDescriptor.beginBlocks)
+            for (CCEffectBeginBlockContext *blockContext in passDescriptor.beginBlocks)
             {
                 if (!blockContext.uniformTranslationTable)
                 {
-                    [beginBlocks addObject:[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:blockContext.block uniformTranslationTable:allUTTs[passDescriptor.shaderIndex]]];
+                    [beginBlocks addObject:[[CCEffectBeginBlockContext alloc] initWithBlock:blockContext.block uniformTranslationTable:allUTTs[passDescriptor.shaderIndex]]];
                 }
                 else
                 {

--- a/cocos2d/CCEffect.m
+++ b/cocos2d/CCEffect.m
@@ -27,17 +27,16 @@ const CCEffectPrepareResult CCEffectPrepareNoop     = { CCEffectPrepareSuccess, 
 
 @implementation CCEffectImpl
 
--(id)initWithRenderPasses:(NSArray *)renderPasses shaders:(NSArray *)shaders
+-(id)initWithRenderPassDescriptors:(NSArray *)renderPassDescriptors shaders:(NSArray *)shaders
 {
     if((self = [super init]))
     {
         _stitchFlags = CCEffectFunctionStitchBoth;
         _firstInStack = YES;
         
-        // Copy these arrays so the caller can't mutate them
-        // behind our backs later (they could be NSMutableArray
+        // Copy the shader array so the caller can't mutate it
+        // behind our backs later (it could be NSMutableArray
         // after all).
-        _renderPasses = [renderPasses copy];
         _shaders = [shaders copy];
         
         _shaderUniforms = [[NSMutableDictionary alloc] init];
@@ -54,22 +53,41 @@ const CCEffectPrepareResult CCEffectPrepareNoop     = { CCEffectPrepareSuccess, 
         
         // Setup the pass shaders based on the pass shader indices and
         // supplied shaders.
-        for (CCEffectRenderPass *pass in _renderPasses)
+        NSUInteger passIndex = 0;
+        NSMutableArray *renderPasses = [NSMutableArray array];
+        for (CCEffectRenderPassDescriptor *passDescriptor in renderPassDescriptors)
         {
-            NSAssert([pass isKindOfClass:[CCEffectRenderPass class]], @"Expected a CCEffectRenderPass but received something else.");
-            NSAssert(pass.shaderIndex < _shaders.count, @"Supplied shader index out of range.");
-            
-            pass.effectShader = _shaders[pass.shaderIndex];
+            NSAssert([passDescriptor isKindOfClass:[CCEffectRenderPassDescriptor class]], @"Expected a CCEffectRenderPassDescriptor but received something else.");
+            NSAssert(passDescriptor.shaderIndex < _shaders.count, @"Supplied shader index out of range.");
             
             // If a uniform translation table is not set already, set it to the default.
-            for (CCEffectRenderPassBeginBlockContext *blockContext in pass.beginBlocks)
+            NSMutableArray *beginBlocks = [NSMutableArray array];
+            for (CCEffectRenderPassBeginBlockContext *blockContext in passDescriptor.beginBlocks)
             {
                 if (!blockContext.uniformTranslationTable)
                 {
-                    blockContext.uniformTranslationTable = allUTTs[pass.shaderIndex];
+                    [beginBlocks addObject:[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:blockContext.block uniformTranslationTable:allUTTs[passDescriptor.shaderIndex]]];
+                }
+                else
+                {
+                    [beginBlocks addObject:blockContext];
                 }
             }
+
+            CCEffectRenderPass *pass = [[CCEffectRenderPass alloc] initWithIndex:passIndex
+                                                                texCoordsMapping:passDescriptor.texCoordsMapping
+                                                                       blendMode:passDescriptor.blendMode
+                                                                     shaderIndex:passDescriptor.shaderIndex
+                                                                    effectShader:_shaders[passDescriptor.shaderIndex]
+                                                                     beginBlocks:beginBlocks
+                                                                    updateBlocks:passDescriptor.updateBlocks
+                                                                      debugLabel:passDescriptor.debugLabel];
+            
+            [renderPasses addObject:pass];
+            
+            passIndex++;
         }
+        _renderPasses = [renderPasses copy];
     }
     return self;
 }

--- a/cocos2d/CCEffectBloom.m
+++ b/cocos2d/CCEffectBloom.m
@@ -110,7 +110,7 @@
     NSArray *renderPasses = [CCEffectBloomImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders =  @[[[CCEffectShader alloc] initWithVertexShaderBuilder:vertShaderBuilder fragmentShaderBuilder:fragShaderBuilder]];
 
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectBloomImplGL";
@@ -318,7 +318,7 @@
     // self is not necesssarily valid.
     __weak CCEffectBloom *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] initWithIndex:0];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectBloom pass 0";
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
@@ -337,7 +337,7 @@
     }]];
     
     
-    CCEffectRenderPass *pass1 = [[CCEffectRenderPass alloc] initWithIndex:1];
+    CCEffectRenderPassDescriptor *pass1 = [CCEffectRenderPassDescriptor descriptor];
     pass1.debugLabel = @"CCEffectBloom pass 1";
     pass1.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
@@ -355,10 +355,10 @@
     }]];
 
     
-    CCEffectRenderPass *pass2 = [[CCEffectRenderPass alloc] initWithIndex:2];
+    CCEffectRenderPassDescriptor *pass2 = [CCEffectRenderPassDescriptor descriptor];
     pass2.debugLabel = @"CCEffectBloom pass 2";
-    pass2.texCoord1Mapping = CCEffectTexCoordMapPreviousPassTex;
-    pass2.texCoord2Mapping = CCEffectTexCoordMapMainTex;
+    CCEffectTexCoordsMapping texCoordsMapping = { CCEffectTexCoordMapPreviousPassTex, CCEffectTexCoordMapMainTex };
+    pass2.texCoordsMapping = texCoordsMapping;
     pass2.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectBloom.m
+++ b/cocos2d/CCEffectBloom.m
@@ -320,7 +320,7 @@
 
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectBloom pass 0";
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
@@ -339,7 +339,7 @@
     
     CCEffectRenderPassDescriptor *pass1 = [CCEffectRenderPassDescriptor descriptor];
     pass1.debugLabel = @"CCEffectBloom pass 1";
-    pass1.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass1.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformTexCoord1Center] = [NSValue valueWithGLKVector2:GLKVector2Make(0.5f, 0.5f)];
@@ -359,7 +359,7 @@
     pass2.debugLabel = @"CCEffectBloom pass 2";
     CCEffectTexCoordsMapping texCoordsMapping = { CCEffectTexCoordMapPreviousPassTex, CCEffectTexCoordMapMainTex };
     pass2.texCoordsMapping = texCoordsMapping;
-    pass2.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass2.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformTexCoord1Center] = [NSValue valueWithGLKVector2:GLKVector2Make(0.5f, 0.5f)];

--- a/cocos2d/CCEffectBlur.m
+++ b/cocos2d/CCEffectBlur.m
@@ -98,7 +98,7 @@
     NSArray *renderPasses = [CCEffectBlurImplGL buildRenderPasses];
     NSArray *shaders =  @[[[CCEffectShader alloc] initWithVertexShaderBuilder:vertShaderBuilder fragmentShaderBuilder:fragShaderBuilder]];
 
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectBlurImplGL";
@@ -271,7 +271,7 @@
     // pass 0: blurs (horizontal) texture[0] and outputs blurmap to texture[1]
     // pass 1: blurs (vertical) texture[1] and outputs to texture[2]
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] initWithIndex:0];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectBlur pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
@@ -288,7 +288,7 @@
     }]];
 
     
-    CCEffectRenderPass *pass1 = [[CCEffectRenderPass alloc] initWithIndex:1];
+    CCEffectRenderPassDescriptor *pass1 = [CCEffectRenderPassDescriptor descriptor];
     pass1.debugLabel = @"CCEffectBlur pass 1";
     pass1.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass1.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectBlur.m
+++ b/cocos2d/CCEffectBlur.m
@@ -274,7 +274,7 @@
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectBlur pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
@@ -291,7 +291,7 @@
     CCEffectRenderPassDescriptor *pass1 = [CCEffectRenderPassDescriptor descriptor];
     pass1.debugLabel = @"CCEffectBlur pass 1";
     pass1.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass1.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass1.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
         

--- a/cocos2d/CCEffectBrightness.m
+++ b/cocos2d/CCEffectBrightness.m
@@ -83,7 +83,7 @@ static float conditionBrightness(float brightness);
 
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectBrightness pass 0";
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectBrightness.m
+++ b/cocos2d/CCEffectBrightness.m
@@ -31,7 +31,7 @@ static float conditionBrightness(float brightness);
     NSArray *renderPasses = [CCEffectBrightnessImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectBrightnessImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectBrightnessImplGL";
@@ -81,7 +81,7 @@ static float conditionBrightness(float brightness);
 {
     __weak CCEffectBrightness *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectBrightness pass 0";
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         

--- a/cocos2d/CCEffectColorChannelOffset.m
+++ b/cocos2d/CCEffectColorChannelOffset.m
@@ -30,7 +30,7 @@
     NSArray *renderPasses = [CCEffectColorChannelOffsetImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectColorChannelOffsetImplGL buildShaders];
 
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectColorChannelOffsetImplGL";
@@ -100,7 +100,7 @@
 {
     __weak CCEffectColorChannelOffset *weakInterface = interface;
     
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectColorChannelOffset pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectColorChannelOffset.m
+++ b/cocos2d/CCEffectColorChannelOffset.m
@@ -103,7 +103,7 @@
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectColorChannelOffset pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectContrast.m
+++ b/cocos2d/CCEffectContrast.m
@@ -32,7 +32,7 @@ static float conditionContrast(float contrast);
     NSArray *renderPasses = [CCEffectContrastImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectContrastImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectContrastImplGL";
@@ -83,7 +83,7 @@ static float conditionContrast(float contrast);
 {
     __weak CCEffectContrast *weakInterface = interface;
     
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectContrast pass 0";
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         

--- a/cocos2d/CCEffectContrast.m
+++ b/cocos2d/CCEffectContrast.m
@@ -85,7 +85,7 @@ static float conditionContrast(float contrast);
     
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectContrast pass 0";
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectDFInnerGlow.m
+++ b/cocos2d/CCEffectDFInnerGlow.m
@@ -160,7 +160,7 @@
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectDFInnerGlow pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformNormalMapTexture] = weakInterface.distanceField;
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectDFInnerGlow.m
+++ b/cocos2d/CCEffectDFInnerGlow.m
@@ -39,7 +39,7 @@
     NSArray *renderPasses = [CCEffectDFInnerGlowImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectDFInnerGlowImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectDFInnerGlowImplGL";
@@ -157,7 +157,7 @@
 {
     __weak CCEffectDFInnerGlow *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectDFInnerGlow pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectDFOutline.m
+++ b/cocos2d/CCEffectDFOutline.m
@@ -37,7 +37,7 @@
     NSArray *renderPasses = [CCEffectDFOutlineImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectDFOutlineImplGL buildShaders];
 
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectDFOutlineImplGL";
@@ -128,7 +128,7 @@
 {
     __weak CCEffectDFOutline *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectDFOutline pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectDFOutline.m
+++ b/cocos2d/CCEffectDFOutline.m
@@ -131,7 +131,7 @@
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectDFOutline pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformNormalMapTexture] = weakInterface.distanceField;
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectDistanceField.m
+++ b/cocos2d/CCEffectDistanceField.m
@@ -32,7 +32,7 @@
     NSArray *renderPasses = [CCEffectDistanceFieldImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectDistanceFieldImplGL buildShaders];
 
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectDistanceFieldImplGL";
@@ -145,7 +145,7 @@
 {
     __weak CCEffectDistanceField *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectDistanceField pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectDistanceField.m
+++ b/cocos2d/CCEffectDistanceField.m
@@ -148,7 +148,7 @@
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectDistanceField pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectDropShadow.m
+++ b/cocos2d/CCEffectDropShadow.m
@@ -282,7 +282,7 @@
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectDropShadow pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
@@ -297,7 +297,7 @@
     CCEffectRenderPassDescriptor *pass1 = [CCEffectRenderPassDescriptor descriptor];
     pass1.debugLabel = @"CCEffectDropShadow pass 1";
     pass1.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass1.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass1.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
         GLKVector2 dur = GLKVector2Make(0.0, 1.0 / (passInputs.previousPassTexture.sizeInPixels.height / passInputs.previousPassTexture.contentScale));
@@ -309,7 +309,7 @@
     CCEffectRenderPassDescriptor *pass3 = [CCEffectRenderPassDescriptor descriptor];
     pass3.debugLabel = @"CCEffectDropShadow pass 3";
     pass3.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass3.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass3.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
         GLKVector2 dur = GLKVector2Make(0.0, 1.0 / (passInputs.previousPassTexture.sizeInPixels.height / passInputs.previousPassTexture.contentScale));

--- a/cocos2d/CCEffectDropShadow.m
+++ b/cocos2d/CCEffectDropShadow.m
@@ -115,7 +115,7 @@
     NSArray *renderPasses = [CCEffectDropShadowImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders =  @[[[CCEffectShader alloc] initWithVertexShaderBuilder:vertShaderBuilder fragmentShaderBuilder:fragShaderBuilder]];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectDropShadowImplGL";        
@@ -279,7 +279,7 @@
     
     __weak CCEffectDropShadow *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectDropShadow pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
@@ -294,7 +294,7 @@
     }]];
 
     
-    CCEffectRenderPass *pass1 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass1 = [CCEffectRenderPassDescriptor descriptor];
     pass1.debugLabel = @"CCEffectDropShadow pass 1";
     pass1.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass1.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
@@ -306,7 +306,7 @@
         
     }]];
     
-    CCEffectRenderPass *pass3 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass3 = [CCEffectRenderPassDescriptor descriptor];
     pass3.debugLabel = @"CCEffectDropShadow pass 3";
     pass3.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass3.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectGlass.m
+++ b/cocos2d/CCEffectGlass.m
@@ -43,7 +43,7 @@ static const float CCEffectGlassDefaultFresnelPower = 2.0f;
     NSArray *renderPasses = [CCEffectGlassImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectGlassImplGL buildShaders];
 
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectGlass";
@@ -217,7 +217,7 @@ static const float CCEffectGlassDefaultFresnelPower = 2.0f;
 {
     __weak CCEffectGlass *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectGlass pass 0";
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         

--- a/cocos2d/CCEffectGlass.m
+++ b/cocos2d/CCEffectGlass.m
@@ -219,7 +219,7 @@ static const float CCEffectGlassDefaultFresnelPower = 2.0f;
 
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectGlass pass 0";
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectHue.m
+++ b/cocos2d/CCEffectHue.m
@@ -33,7 +33,7 @@ static GLKMatrix4 matrixWithHue(float hue);
     NSArray *renderPasses = [CCEffectHueImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectHueImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectHueImplGL";
@@ -84,7 +84,7 @@ static GLKMatrix4 matrixWithHue(float hue);
 {
     __weak CCEffectHue *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectHue pass 0";
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 

--- a/cocos2d/CCEffectHue.m
+++ b/cocos2d/CCEffectHue.m
@@ -86,7 +86,7 @@ static GLKMatrix4 matrixWithHue(float hue);
 
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectHue pass 0";
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectInvert.m
+++ b/cocos2d/CCEffectInvert.m
@@ -26,7 +26,7 @@
     NSArray *renderPasses = [CCEffectInvertImplGL buildRenderPasses];
     NSArray *shaders = [CCEffectInvertImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.debugName = @"CCEffectInvertImplGL";
     }
@@ -75,7 +75,7 @@
 
 + (NSArray *)buildRenderPasses
 {
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectInvert pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectInvert.m
+++ b/cocos2d/CCEffectInvert.m
@@ -78,7 +78,7 @@
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectInvert pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -126,7 +126,7 @@ static float conditionShininess(float shininess);
     NSArray *shaders = @[[[CCEffectShader alloc] initWithVertexShaderBuilder:vertShaderBuilder fragmentShaderBuilder:fragShaderBuilder]];
     NSArray *renderPasses = [CCEffectLightingImplGL buildRenderPassesWithInterface:interface];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectLightingImplGL";
@@ -258,7 +258,7 @@ static float conditionShininess(float shininess);
 {
     __weak CCEffectLighting *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectLighting pass 0";
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         

--- a/cocos2d/CCEffectLighting.m
+++ b/cocos2d/CCEffectLighting.m
@@ -260,7 +260,7 @@ static float conditionShininess(float shininess);
 
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectLighting pass 0";
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectOutline.m
+++ b/cocos2d/CCEffectOutline.m
@@ -32,7 +32,7 @@
     NSArray *renderPasses = [CCEffectOutlineImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectOutlineImplGL buildShaders];
 
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         _interface = interface;
         self.debugName = @"CCEffectOutline";
@@ -116,7 +116,7 @@
 {
     __weak CCEffectOutline *weakInterface = interface;
     
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectOutline pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
@@ -141,7 +141,7 @@
     
     // Pass 1 is a WIP (trying to scale the outline before applying it. (a bad idea so far..)
 #if 1
-    CCEffectRenderPass *pass1 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass1 = [CCEffectRenderPassDescriptor descriptor];
     pass1.debugLabel = @"CCEffectOutline pass 1";
     pass1.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass1.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectOutline.m
+++ b/cocos2d/CCEffectOutline.m
@@ -119,7 +119,7 @@
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectOutline pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
@@ -144,7 +144,7 @@
     CCEffectRenderPassDescriptor *pass1 = [CCEffectRenderPassDescriptor descriptor];
     pass1.debugLabel = @"CCEffectOutline pass 1";
     pass1.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass1.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass1.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformTexCoord1Center] = [NSValue valueWithGLKVector2:passInputs.texCoord1Center];

--- a/cocos2d/CCEffectPixellate.m
+++ b/cocos2d/CCEffectPixellate.m
@@ -66,7 +66,7 @@ static float conditionBlockSize(float blockSize);
     NSArray *renderPasses = [CCEffectPixellateImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectPixellateImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectPixellateImplGL";
@@ -121,7 +121,7 @@ static float conditionBlockSize(float blockSize);
 {
     __weak CCEffectPixellate *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectPixellate pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectPixellate.m
+++ b/cocos2d/CCEffectPixellate.m
@@ -124,7 +124,7 @@ static float conditionBlockSize(float blockSize);
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectPixellate pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
 
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -39,7 +39,7 @@
     NSArray *renderPasses = [CCEffectReflectionImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectReflectionImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectReflectionImplGL";
@@ -172,7 +172,7 @@
 {
     __weak CCEffectReflection *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectReflection pass 0";
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         

--- a/cocos2d/CCEffectReflection.m
+++ b/cocos2d/CCEffectReflection.m
@@ -174,7 +174,7 @@
 
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectReflection pass 0";
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -155,7 +155,7 @@
 
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectRefraction pass 0";
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectRefraction.m
+++ b/cocos2d/CCEffectRefraction.m
@@ -37,7 +37,7 @@
     NSArray *renderPasses = [CCEffectRefractionImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectRefractionImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectRefractionImplGL";
@@ -153,7 +153,7 @@
 {
     __weak CCEffectRefraction *weakInterface = interface;
 
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectRefraction pass 0";
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         

--- a/cocos2d/CCEffectRenderPass.h
+++ b/cocos2d/CCEffectRenderPass.h
@@ -53,17 +53,17 @@ static const CCEffectTexCoordsMapping CCEffectTexCoordsMappingDefault = { CCEffe
 
 @class CCEffectRenderPass;
 
-typedef void (^CCEffectRenderPassBeginBlock)(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs);
-typedef void (^CCEffectRenderPassUpdateBlock)(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs);
+typedef void (^CCEffectBeginBlock)(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs);
+typedef void (^CCEffectUpdateBlock)(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs);
 
 
-@interface CCEffectRenderPassBeginBlockContext : NSObject <NSCopying>
+@interface CCEffectBeginBlockContext : NSObject <NSCopying>
 
-@property (nonatomic, readonly) CCEffectRenderPassBeginBlock block;
+@property (nonatomic, readonly) CCEffectBeginBlock block;
 @property (nonatomic, readonly) NSDictionary *uniformTranslationTable;
 
--(id)initWithBlock:(CCEffectRenderPassBeginBlock)block uniformTranslationTable:(NSDictionary *)utt;
--(id)initWithBlock:(CCEffectRenderPassBeginBlock)block;
+-(id)initWithBlock:(CCEffectBeginBlock)block uniformTranslationTable:(NSDictionary *)utt;
+-(id)initWithBlock:(CCEffectBeginBlock)block;
 
 @end
 

--- a/cocos2d/CCEffectRenderPass.h
+++ b/cocos2d/CCEffectRenderPass.h
@@ -20,6 +20,16 @@ typedef NS_ENUM(NSUInteger, CCEffectTexCoordMapping)
     CCEffectTexCoordMapCustomTexNoTransform = 3
 };
 
+typedef struct CCEffectTexCoordsMapping
+{
+    CCEffectTexCoordMapping tc1;
+    CCEffectTexCoordMapping tc2;
+    
+} CCEffectTexCoordsMapping;
+
+static const CCEffectTexCoordsMapping CCEffectTexCoordsMappingDefault = { CCEffectTexCoordMapPreviousPassTex, CCEffectTexCoordMapCustomTex };
+
+
 
 @interface CCEffectRenderPassInputs : NSObject
 
@@ -47,12 +57,28 @@ typedef void (^CCEffectRenderPassBeginBlock)(CCEffectRenderPass *pass, CCEffectR
 typedef void (^CCEffectRenderPassUpdateBlock)(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs);
 
 
-@interface CCEffectRenderPassBeginBlockContext : NSObject
+@interface CCEffectRenderPassBeginBlockContext : NSObject <NSCopying>
 
-@property (nonatomic, copy) CCEffectRenderPassBeginBlock block;
-@property (nonatomic, strong) NSDictionary *uniformTranslationTable;
+@property (nonatomic, readonly) CCEffectRenderPassBeginBlock block;
+@property (nonatomic, readonly) NSDictionary *uniformTranslationTable;
 
+-(id)initWithBlock:(CCEffectRenderPassBeginBlock)block uniformTranslationTable:(NSDictionary *)utt;
 -(id)initWithBlock:(CCEffectRenderPassBeginBlock)block;
+
+@end
+
+
+@interface CCEffectRenderPassDescriptor : NSObject <NSCopying>
+
+@property (nonatomic, assign) NSUInteger shaderIndex;
+@property (nonatomic, assign) CCEffectTexCoordsMapping texCoordsMapping;
+@property (nonatomic, strong) CCBlendMode* blendMode;
+@property (nonatomic, copy) NSArray* beginBlocks;
+@property (nonatomic, copy) NSArray* updateBlocks;
+@property (nonatomic, copy) NSString *debugLabel;
+
+-(id)init;
++(instancetype)descriptor;
 
 @end
 
@@ -60,16 +86,22 @@ typedef void (^CCEffectRenderPassUpdateBlock)(CCEffectRenderPass *pass, CCEffect
 @interface CCEffectRenderPass : NSObject <NSCopying>
 
 @property (nonatomic, readonly) NSUInteger indexInEffect;
-@property (nonatomic, assign) NSUInteger shaderIndex;
-@property (nonatomic, assign) CCEffectTexCoordMapping texCoord1Mapping;
-@property (nonatomic, assign) CCEffectTexCoordMapping texCoord2Mapping;
-@property (nonatomic, strong) CCBlendMode* blendMode;
-@property (nonatomic, strong) CCEffectShader* effectShader;
-@property (nonatomic, copy) NSArray* beginBlocks;
-@property (nonatomic, copy) NSArray* updateBlocks;
-@property (nonatomic, copy) NSString *debugLabel;
+@property (nonatomic, readonly) CCEffectTexCoordsMapping texCoordsMapping;
+@property (nonatomic, readonly) CCBlendMode *blendMode;
+@property (nonatomic, readonly) NSUInteger shaderIndex;
+@property (nonatomic, readonly) CCEffectShader *effectShader;
+@property (nonatomic, readonly) NSArray *beginBlocks;
+@property (nonatomic, readonly) NSArray *updateBlocks;
+@property (nonatomic, readonly) NSString *debugLabel;
 
--(id)initWithIndex:(NSUInteger)indexInEffect;
+-(id)initWithIndex:(NSUInteger)indexInEffect
+  texCoordsMapping:(CCEffectTexCoordsMapping)texCoordsMapping
+         blendMode:(CCBlendMode *)blendMode
+       shaderIndex:(NSUInteger)shaderIndex
+      effectShader:(CCEffectShader *)effectShader
+       beginBlocks:(NSArray *)beginBlocks
+      updateBlocks:(NSArray *)updateBlocks
+        debugLabel:(NSString *)debugLabel;
 
 -(void)begin:(CCEffectRenderPassInputs *)passInputs;
 -(void)update:(CCEffectRenderPassInputs *)passInputs;

--- a/cocos2d/CCEffectRenderPass.m
+++ b/cocos2d/CCEffectRenderPass.m
@@ -26,20 +26,63 @@
 
 @implementation CCEffectRenderPassBeginBlockContext
 
--(id)initWithBlock:(CCEffectRenderPassBeginBlock)block;
+-(id)initWithBlock:(CCEffectRenderPassBeginBlock)block uniformTranslationTable:(NSDictionary *)utt
 {
     if (self = [super init])
     {
         _block = [block copy];
+        _uniformTranslationTable = [utt copy];
     }
     return self;
 }
 
+-(id)initWithBlock:(CCEffectRenderPassBeginBlock)block
+{
+    return [self initWithBlock:block uniformTranslationTable:nil];
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+    // CCEffectRenderPassBeginBlockContext is immutable so no need to really copy.
+    return self;
+}
+
+@end
+
+
+#pragma mark CCEffectRenderPassDescriptor
+
+@implementation CCEffectRenderPassDescriptor
+
+-(id)init
+{
+    if((self = [super init]))
+    {
+        _shaderIndex = 0;
+        _texCoordsMapping = CCEffectTexCoordsMappingDefault;
+        _blendMode = [CCBlendMode premultipliedAlphaMode];
+        _beginBlocks = nil;
+        _updateBlocks = nil;
+        _debugLabel = nil;
+    }
+    return self;
+}
+
++(instancetype)descriptor
+{
+    return [[self alloc] init];
+}
+
 -(instancetype)copyWithZone:(NSZone *)zone
 {
-    CCEffectRenderPassBeginBlockContext *newContext = [[CCEffectRenderPassBeginBlockContext allocWithZone:zone] initWithBlock:_block];
-    newContext.uniformTranslationTable = _uniformTranslationTable;
-    return newContext;
+    CCEffectRenderPassDescriptor *newDescriptor = [[CCEffectRenderPassDescriptor alloc] init];
+    newDescriptor.shaderIndex = _shaderIndex;
+    newDescriptor.texCoordsMapping = _texCoordsMapping;
+    newDescriptor.blendMode = _blendMode;
+    newDescriptor.beginBlocks = _beginBlocks;
+    newDescriptor.updateBlocks = _updateBlocks;
+    newDescriptor.debugLabel = _debugLabel;
+    return newDescriptor;
 }
 
 @end
@@ -49,32 +92,41 @@
 
 @implementation CCEffectRenderPass
 
--(id)init
-{
-    return [self initWithIndex:0];
-}
-
 -(id)initWithIndex:(NSUInteger)indexInEffect
+  texCoordsMapping:(CCEffectTexCoordsMapping)texCoordsMapping
+         blendMode:(CCBlendMode *)blendMode
+       shaderIndex:(NSUInteger)shaderIndex
+      effectShader:(CCEffectShader *)effectShader
+       beginBlocks:(NSArray *)beginBlocks
+      updateBlocks:(NSArray *)updateBlocks
+        debugLabel:(NSString *)debugLabel
 {
     if((self = [super init]))
     {
         _indexInEffect = indexInEffect;
-        _shaderIndex = 0;
+        _texCoordsMapping = texCoordsMapping;
+        _blendMode = blendMode;
+        _shaderIndex = shaderIndex;
+        _effectShader = effectShader;
+        _beginBlocks = [beginBlocks copy];
         
-        _texCoord1Mapping = CCEffectTexCoordMapPreviousPassTex;
-        _texCoord2Mapping = CCEffectTexCoordMapCustomTex;
+        if (updateBlocks)
+        {
+            _updateBlocks = [updateBlocks copy];
+        }
+        else
+        {
+            CCEffectRenderPassUpdateBlock updateBlock = ^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+                if (passInputs.needsClear)
+                {
+                    [passInputs.renderer enqueueClear:GL_COLOR_BUFFER_BIT color:[CCColor clearColor].glkVector4 depth:0.0f stencil:0 globalSortOrder:NSIntegerMin];
+                }
+                [pass enqueueTriangles:passInputs];
+            };
+            _updateBlocks = @[[updateBlock copy]];
+        }
         
-        _beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){}]];
-        
-        CCEffectRenderPassUpdateBlock updateBlock = ^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
-            if (passInputs.needsClear)
-            {
-                [passInputs.renderer enqueueClear:GL_COLOR_BUFFER_BIT color:[CCColor clearColor].glkVector4 depth:0.0f stencil:0 globalSortOrder:NSIntegerMin];
-            }
-            [pass enqueueTriangles:passInputs];
-        };
-        _updateBlocks = @[[updateBlock copy]];
-        _blendMode = [CCBlendMode premultipliedAlphaMode];
+        _debugLabel = [debugLabel copy];
         
         return self;
     }
@@ -82,18 +134,10 @@
     return self;
 }
 
--(instancetype)copyWithZone:(NSZone *)zone
+- (instancetype)copyWithZone:(NSZone *)zone
 {
-    CCEffectRenderPass *newPass = [[CCEffectRenderPass allocWithZone:zone] initWithIndex:_indexInEffect];
-    newPass.shaderIndex = _shaderIndex;
-    newPass.texCoord1Mapping = _texCoord1Mapping;
-    newPass.texCoord2Mapping = _texCoord2Mapping;
-    newPass.blendMode = _blendMode;
-    newPass.effectShader = _effectShader;
-    newPass.beginBlocks = [_beginBlocks copy];
-    newPass.updateBlocks = [_updateBlocks copy];
-    newPass.debugLabel = _debugLabel;
-    return newPass;
+    // CCEffectRenderPass is immutable so no need to really copy.
+    return self;
 }
 
 -(void)begin:(CCEffectRenderPassInputs *)passInputs

--- a/cocos2d/CCEffectRenderPass.m
+++ b/cocos2d/CCEffectRenderPass.m
@@ -22,11 +22,11 @@
 @end
 
 
-#pragma mark CCEffectRenderPassBeginBlockContext
+#pragma mark CCEffectBeginBlockContext
 
-@implementation CCEffectRenderPassBeginBlockContext
+@implementation CCEffectBeginBlockContext
 
--(id)initWithBlock:(CCEffectRenderPassBeginBlock)block uniformTranslationTable:(NSDictionary *)utt
+-(id)initWithBlock:(CCEffectBeginBlock)block uniformTranslationTable:(NSDictionary *)utt
 {
     if (self = [super init])
     {
@@ -36,14 +36,14 @@
     return self;
 }
 
--(id)initWithBlock:(CCEffectRenderPassBeginBlock)block
+-(id)initWithBlock:(CCEffectBeginBlock)block
 {
     return [self initWithBlock:block uniformTranslationTable:nil];
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone
 {
-    // CCEffectRenderPassBeginBlockContext is immutable so no need to really copy.
+    // CCEffectBeginBlockContext is immutable so no need to really copy.
     return self;
 }
 
@@ -116,7 +116,7 @@
         }
         else
         {
-            CCEffectRenderPassUpdateBlock updateBlock = ^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+            CCEffectUpdateBlock updateBlock = ^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
                 if (passInputs.needsClear)
                 {
                     [passInputs.renderer enqueueClear:GL_COLOR_BUFFER_BIT color:[CCColor clearColor].glkVector4 depth:0.0f stencil:0 globalSortOrder:NSIntegerMin];
@@ -142,7 +142,7 @@
 
 -(void)begin:(CCEffectRenderPassInputs *)passInputs
 {
-    for (CCEffectRenderPassBeginBlockContext *blockContext in _beginBlocks)
+    for (CCEffectBeginBlockContext *blockContext in _beginBlocks)
     {
         passInputs.uniformTranslationTable = blockContext.uniformTranslationTable;
         blockContext.block(self, passInputs);
@@ -151,7 +151,7 @@
 
 -(void)update:(CCEffectRenderPassInputs *)passInputs
 {
-    for (CCEffectRenderPassUpdateBlock block in _updateBlocks)
+    for (CCEffectUpdateBlock block in _updateBlocks)
     {
         block(self, passInputs);
     }

--- a/cocos2d/CCEffectRenderer.m
+++ b/cocos2d/CCEffectRenderer.m
@@ -264,14 +264,20 @@ static GLKVector2 selectTexCoordPadding(CCEffectTexCoordSource tcSource, GLKVect
         }
         else
         {
-            renderPass = [[CCEffectRenderPass alloc] init];
-            renderPass.debugLabel = @"CCEffectRenderer composite pass";
-            renderPass.effectShader = [CCEffectRenderer sharedCopyShader];
-            renderPass.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+            NSArray *beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
                 
                 passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
                 passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
             }]];
+            
+            renderPass = [[CCEffectRenderPass alloc] initWithIndex:0
+                                                  texCoordsMapping:CCEffectTexCoordsMappingDefault
+                                                         blendMode:[CCBlendMode premultipliedAlphaMode]
+                                                       shaderIndex:0
+                                                      effectShader:[CCEffectRenderer sharedCopyShader]
+                                                       beginBlocks:beginBlocks
+                                                      updateBlocks:nil
+                                                        debugLabel:@"CCEffectRenderer composite pass"];
         }
         
         if (fromIntermediate && (renderPass.indexInEffect == 0))
@@ -292,8 +298,8 @@ static GLKVector2 selectTexCoordPadding(CCEffectTexCoordSource tcSource, GLKVect
         // - Later pass into intermediate RT : Pad vertices, overwrite texture coordiates so they are lower-left (0,0) upper right (1, 1), add padding to RT, adjust ortho matrix
         //
         
-        CCEffectTexCoordFunc tc1 = selectTexCoordFunc(renderPass.texCoord1Mapping, CCEffectTexCoordSource1, fromIntermediate, padMainTexCoords);
-        CCEffectTexCoordFunc tc2 = selectTexCoordFunc(renderPass.texCoord2Mapping, CCEffectTexCoordSource2, fromIntermediate, padMainTexCoords);
+        CCEffectTexCoordFunc tc1 = selectTexCoordFunc(renderPass.texCoordsMapping.tc1, CCEffectTexCoordSource1, fromIntermediate, padMainTexCoords);
+        CCEffectTexCoordFunc tc2 = selectTexCoordFunc(renderPass.texCoordsMapping.tc2, CCEffectTexCoordSource2, fromIntermediate, padMainTexCoords);
         
         renderPassInputs.verts = padVertices(sprite.vertexes, effect.padding, tc1, tc2);
         

--- a/cocos2d/CCEffectRenderer.m
+++ b/cocos2d/CCEffectRenderer.m
@@ -264,7 +264,7 @@ static GLKVector2 selectTexCoordPadding(CCEffectTexCoordSource tcSource, GLKVect
         }
         else
         {
-            NSArray *beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+            NSArray *beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
                 
                 passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
                 passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectSaturation.m
+++ b/cocos2d/CCEffectSaturation.m
@@ -68,7 +68,7 @@ static float conditionSaturation(float saturation);
     NSArray *renderPasses = [CCEffectSaturationImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectSaturationImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectSaturationImplGL";
@@ -124,7 +124,7 @@ static float conditionSaturation(float saturation);
 {
     __weak CCEffectSaturation *weakInterface = interface;
     
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectSaturation pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectSaturation.m
+++ b/cocos2d/CCEffectSaturation.m
@@ -127,7 +127,7 @@ static float conditionSaturation(float saturation);
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectSaturation pass 0";
     pass0.blendMode = [CCBlendMode premultipliedAlphaMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformTexCoord1Center] = [NSValue valueWithGLKVector2:passInputs.texCoord1Center];

--- a/cocos2d/CCEffectStack.m
+++ b/cocos2d/CCEffectStack.m
@@ -200,7 +200,7 @@
     }
     
     // Stitch the stitch lists and collect the resulting render passes and shaders.
-    NSMutableArray *outputPasses = [[NSMutableArray alloc] init];
+    NSMutableArray *outputPassDescriptors = [[NSMutableArray alloc] init];
     NSMutableArray *outputShaders = [[NSMutableArray alloc] init];
     for (int stitchListIndex = 0; stitchListIndex < stitchLists.count; stitchListIndex++)
     {
@@ -209,12 +209,12 @@
         NSString *prefix = [NSString stringWithFormat:@"SL%d_", stitchListIndex];
         CCEffectStitcher *stitcher = [CCEffectStitcher stitcherWithEffects:stitchList manglePrefix:prefix stitchListIndex:stitchListIndex shaderStartIndex:outputShaders.count];
         
-        [outputPasses addObjectsFromArray:stitcher.renderPasses];
+        [outputPassDescriptors addObjectsFromArray:stitcher.renderPassDescriptors];
         [outputShaders addObjectsFromArray:stitcher.shaders];
     }
     
     // Create a new effect implementation from all the collected passes and shaders.
-    return [[CCEffectImpl alloc] initWithRenderPasses:outputPasses shaders:outputShaders];
+    return [[CCEffectImpl alloc] initWithRenderPassDescriptors:outputPassDescriptors shaders:outputShaders];
 }
 
 @end

--- a/cocos2d/CCEffectStereo.m
+++ b/cocos2d/CCEffectStereo.m
@@ -104,7 +104,7 @@
     CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectPixellate pass 0";
     pass0.blendMode = [CCBlendMode disabledMode];
-    pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
+    pass0.beginBlocks = @[[[CCEffectBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){
         
         passInputs.shaderUniforms[CCShaderUniformMainTexture] = passInputs.previousPassTexture;
         passInputs.shaderUniforms[CCShaderUniformPreviousPassTexture] = passInputs.previousPassTexture;

--- a/cocos2d/CCEffectStereo.m
+++ b/cocos2d/CCEffectStereo.m
@@ -32,7 +32,7 @@
     NSArray *renderPasses = [CCEffectStereoImplGL buildRenderPassesWithInterface:interface];
     NSArray *shaders = [CCEffectStereoImplGL buildShaders];
     
-    if((self = [super initWithRenderPasses:renderPasses shaders:shaders]))
+    if((self = [super initWithRenderPassDescriptors:renderPasses shaders:shaders]))
     {
         self.interface = interface;
         self.debugName = @"CCEffectStereoImpl";
@@ -101,7 +101,7 @@
 {
     __weak CCEffectStereo *weakInterface = interface;
     
-    CCEffectRenderPass *pass0 = [[CCEffectRenderPass alloc] init];
+    CCEffectRenderPassDescriptor *pass0 = [CCEffectRenderPassDescriptor descriptor];
     pass0.debugLabel = @"CCEffectPixellate pass 0";
     pass0.blendMode = [CCBlendMode disabledMode];
     pass0.beginBlocks = @[[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:^(CCEffectRenderPass *pass, CCEffectRenderPassInputs *passInputs){

--- a/cocos2d/CCEffectStitcher.h
+++ b/cocos2d/CCEffectStitcher.h
@@ -10,7 +10,7 @@
 
 @interface CCEffectStitcher : NSObject
 
-@property (nonatomic, readonly) NSArray *renderPasses;
+@property (nonatomic, readonly) NSArray *renderPassDescriptors;
 @property (nonatomic, readonly) NSArray *shaders;
 
 - (id)init;

--- a/cocos2d/CCEffectStitcher.m
+++ b/cocos2d/CCEffectStitcher.m
@@ -23,7 +23,7 @@
 }
 
 
-- (NSArray *)renderPasses
+- (NSArray *)renderPassDescriptors
 {
     NSAssert(0, @"Subclasses must override this.");
     return nil;

--- a/cocos2d/CCEffectStitcherGL.m
+++ b/cocos2d/CCEffectStitcherGL.m
@@ -179,9 +179,9 @@ static NSString * const CCEffectStitcherVaryings = @"CCEffectStitcherVaryings";
 
             // Update the uniform translation table in the new pass's begin blocks
             NSMutableArray *beginBlocks = [[NSMutableArray alloc] init];
-            for (CCEffectRenderPassBeginBlockContext *blockContext in pass.beginBlocks)
+            for (CCEffectBeginBlockContext *blockContext in pass.beginBlocks)
             {
-                [beginBlocks addObject:[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:blockContext.block uniformTranslationTable:allUTTs[pass.effectShader]]];
+                [beginBlocks addObject:[[CCEffectBeginBlockContext alloc] initWithBlock:blockContext.block uniformTranslationTable:allUTTs[pass.effectShader]]];
             }
             newDescriptor.beginBlocks = beginBlocks;
             newDescriptor.updateBlocks = pass.updateBlocks;
@@ -207,9 +207,9 @@ static NSString * const CCEffectStitcherVaryings = @"CCEffectStitcherVaryings";
         {
             for (CCEffectRenderPass *pass in effect.renderPasses)
             {
-                for (CCEffectRenderPassBeginBlockContext *blockContext in pass.beginBlocks)
+                for (CCEffectBeginBlockContext *blockContext in pass.beginBlocks)
                 {
-                    [beginBlocks addObject:[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:blockContext.block uniformTranslationTable:allUTTs[pass.effectShader]]];
+                    [beginBlocks addObject:[[CCEffectBeginBlockContext alloc] initWithBlock:blockContext.block uniformTranslationTable:allUTTs[pass.effectShader]]];
                 }
                 
                 // Copy the update blocks. They don't need any adjustment so they can just

--- a/cocos2d/CCEffectStitcherGL.m
+++ b/cocos2d/CCEffectStitcherGL.m
@@ -32,7 +32,7 @@ static NSString * const CCEffectStitcherVaryings = @"CCEffectStitcherVaryings";
 @property (nonatomic, assign) NSUInteger shaderStartIndex;
 
 // Outputs
-@property (nonatomic, strong) NSArray *cachedRenderPasses;
+@property (nonatomic, strong) NSArray *cachedRenderPassDescriptors;
 @property (nonatomic, strong) NSArray *cachedShaders;
 
 @end
@@ -53,27 +53,27 @@ static NSString * const CCEffectStitcherVaryings = @"CCEffectStitcherVaryings";
         _stitchListIndex = stitchListIndex;
         _shaderStartIndex = shaderStartIndex;
         
-        _cachedRenderPasses = nil;
+        _cachedRenderPassDescriptors = nil;
         _cachedShaders = nil;
     }
     return self;
 }
 
-- (NSArray *)renderPasses
+- (NSArray *)renderPassDescriptors
 {
     // The output render pass and shader arrays are computed lazily when requested.
     // One method computes both of them so we need to make sure everything stays
     // in sync (ie if we don't have one we don't have the other and if one gets
     // created so does the other).
-    if (!_cachedRenderPasses)
+    if (!_cachedRenderPassDescriptors)
     {
         NSAssert(!_cachedShaders, @"The output render pass array is nil but the output shader array is not.");
         [self stitchEffects:self.effects manglePrefix:self.manglePrefix stitchListIndex:self.stitchListIndex shaderStartIndex:self.shaderStartIndex];
 
-        NSAssert(_cachedRenderPasses, @"Failed to create an output render pass array.");
+        NSAssert(_cachedRenderPassDescriptors, @"Failed to create an output render pass array.");
         NSAssert(_cachedShaders, @"Failed to create an output shader array.");
     }
-    return _cachedRenderPasses;
+    return _cachedRenderPassDescriptors;
 }
 
 - (NSArray *)shaders
@@ -84,10 +84,10 @@ static NSString * const CCEffectStitcherVaryings = @"CCEffectStitcherVaryings";
     // created so does the other).
     if (!_cachedShaders)
     {
-        NSAssert(!_cachedRenderPasses, @"The output shader array is nil but the output render pass array is not.");
+        NSAssert(!_cachedRenderPassDescriptors, @"The output shader array is nil but the output render pass array is not.");
         [self stitchEffects:self.effects manglePrefix:self.manglePrefix stitchListIndex:self.stitchListIndex shaderStartIndex:self.shaderStartIndex];
 
-        NSAssert(_cachedRenderPasses, @"Failed to create an output render pass array.");
+        NSAssert(_cachedRenderPassDescriptors, @"Failed to create an output render pass array.");
         NSAssert(_cachedShaders, @"Failed to create an output shader array.");
     }
     return _cachedShaders;
@@ -169,29 +169,35 @@ static NSString * const CCEffectStitcherVaryings = @"CCEffectStitcherVaryings";
         // the uniform translation table.
         
         CCEffectImpl *effect = [effects firstObject];
-        NSMutableArray *renderPasses = [[NSMutableArray alloc] init];
+        NSMutableArray *renderPassDescriptors = [[NSMutableArray alloc] init];
         for (CCEffectRenderPass *pass in effect.renderPasses)
         {
-            CCEffectRenderPass *newPass = [pass copy];
-            newPass.shaderIndex += shaderStartIndex;
-            
+            CCEffectRenderPassDescriptor *newDescriptor = [CCEffectRenderPassDescriptor descriptor];
+            newDescriptor.shaderIndex = pass.shaderIndex + shaderStartIndex;
+            newDescriptor.texCoordsMapping = pass.texCoordsMapping;
+            newDescriptor.blendMode = pass.blendMode;
+
             // Update the uniform translation table in the new pass's begin blocks
-            for (CCEffectRenderPassBeginBlockContext *blockContext in newPass.beginBlocks)
+            NSMutableArray *beginBlocks = [[NSMutableArray alloc] init];
+            for (CCEffectRenderPassBeginBlockContext *blockContext in pass.beginBlocks)
             {
-                blockContext.uniformTranslationTable = allUTTs[pass.effectShader];
+                [beginBlocks addObject:[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:blockContext.block uniformTranslationTable:allUTTs[pass.effectShader]]];
             }
+            newDescriptor.beginBlocks = beginBlocks;
+            newDescriptor.updateBlocks = pass.updateBlocks;
+            newDescriptor.debugLabel = pass.debugLabel;
             
-            [renderPasses addObject:newPass];
+            [renderPassDescriptors addObject:newDescriptor];
         }
         
-        _cachedRenderPasses = [renderPasses copy];
+        _cachedRenderPassDescriptors = [renderPassDescriptors copy];
     }
     else
-    {
-        // Create a new render pass and point it at the stitched shader.
-        CCEffectRenderPass *renderPass = [[CCEffectRenderPass alloc] init];
-        renderPass.debugLabel = [NSString stringWithFormat:@"CCEffectStack_Stitched_%@", prefix];;
-        renderPass.shaderIndex = shaderStartIndex;
+    {        
+        CCEffectRenderPassDescriptor *newDescriptor = [CCEffectRenderPassDescriptor descriptor];
+        newDescriptor.shaderIndex = shaderStartIndex;
+        newDescriptor.texCoordsMapping = CCEffectTexCoordsMappingDefault;
+        newDescriptor.blendMode = [CCBlendMode premultipliedAlphaMode];
         
         NSMutableArray *beginBlocks = [[NSMutableArray alloc] init];
         NSMutableArray *updateBlocks = [[NSMutableArray alloc] init];
@@ -203,24 +209,20 @@ static NSString * const CCEffectStitcherVaryings = @"CCEffectStitcherVaryings";
             {
                 for (CCEffectRenderPassBeginBlockContext *blockContext in pass.beginBlocks)
                 {
-                    // Copy the context and set the UTT to the new UTT for the corresponding
-                    // shader for this pass.
-                    CCEffectRenderPassBeginBlockContext *newContext = [blockContext copy];
-                    newContext.uniformTranslationTable = allUTTs[pass.effectShader];
-                    
-                    [beginBlocks addObject:newContext];
+                    [beginBlocks addObject:[[CCEffectRenderPassBeginBlockContext alloc] initWithBlock:blockContext.block uniformTranslationTable:allUTTs[pass.effectShader]]];
                 }
                 
                 // Copy the update blocks. They don't need any adjustment so they can just
                 // be copied outright.
-                [updateBlocks addObjectsFromArray:[pass.updateBlocks copy]];
+                [updateBlocks addObjectsFromArray:pass.updateBlocks];
             }
         }
+
+        newDescriptor.beginBlocks = beginBlocks;
+        newDescriptor.updateBlocks = updateBlocks;
+        newDescriptor.debugLabel = [NSString stringWithFormat:@"CCEffectStack_Stitched_%@", prefix];;
         
-        renderPass.beginBlocks = beginBlocks;
-        renderPass.updateBlocks = updateBlocks;
-        
-        _cachedRenderPasses = @[renderPass];
+        _cachedRenderPassDescriptors = @[newDescriptor];
     }
 }
 

--- a/cocos2d/CCEffect_Private.h
+++ b/cocos2d/CCEffect_Private.h
@@ -83,7 +83,7 @@ typedef NS_ENUM(NSUInteger, CCEffectFunctionStitchFlags)
 @property (nonatomic, readonly) BOOL firstInStack;
 
 
--(id)initWithRenderPasses:(NSArray *)renderPasses shaders:(NSArray *)shaders;
+-(id)initWithRenderPassDescriptors:(NSArray *)renderPasses shaders:(NSArray *)shaders;
 
 -(CCEffectPrepareResult)prepareForRenderingWithSprite:(CCSprite *)sprite;
 -(CCEffectRenderPass *)renderPassAtIndex:(NSUInteger)passIndex;


### PR DESCRIPTION
This isn't strictly necessary for Metal support but it's the last bit of cleanup that I wanted to work in with all of the refactoring that _is_ necessary for Metal support. All classes that define an effect implementation are now immutable and, with this change, a whole host of potential "What would happen if X changed unexpectedly behind my back?" type situations are removed as are the bugs that go with them.

Here's a bit more detail:
- CCEffectRenderPass is immutable and effect implementations no longer directly create render pass objects.
- CCEffectRenderPassDescriptor is introduced. This is what effects now create and hand off to CCEffectImpl at initialization time. CCEffectImpl uses the descriptors to create render pass objects internally.
- CCEffectRenderPassBeginBlockContext becomes CCEffectBeginBlockContext because CCERPBBC was too long. It's immutable now too.
- CCEffectRenderPassBeginBlock and UpdateBlock become CCEffectBeginBlock and CCEffectUpdateBlock (for consistency with the previous item).
- All effects are updated to adapt to these changes.
