### PR TITLE
Fix incorrect scaling of content

### DIFF
--- a/cocos2d/Platforms/Mac/CCViewMacGL.m
+++ b/cocos2d/Platforms/Mac/CCViewMacGL.m
@@ -58,7 +58,7 @@
     // Only draw if there is something to draw, otherwise it actually creates a flicker of the current glClearColor
     if(_director.runningScene){
         CGSize sizeInPixels = [self convertSizeFromBacking:self.bounds.size];
-        _director.runningScene.contentSizeInPoints = CC_SIZE_SCALE(sizeInPixels, 1.0/[CCSetup sharedSetup].contentScale);
+        _director.runningScene.contentSizeInPoints = CC_SIZE_SCALE(sizeInPixels, [CCSetup sharedSetup].contentScale);
         
         [_director mainLoopBody];
     }


### PR DESCRIPTION
In regards to: spritebuilder/SpriteBuilder#1572

The latest build of Spritebuilder from the develop branch contained an issue where the content in the opengl view was being scaled incorrectly on a retina screen only.
