### PR TITLE
Fixing the color space lookup for initWithUIColor

### DIFF
--- a/cocos2d/Support/CCColor.m
+++ b/cocos2d/Support/CCColor.m
@@ -153,13 +153,13 @@
     self = [super init];
     if (!self) return self;
     
-    CGColorRef colorRef = self.CGColor;
+    CGColorRef colorRef = color.CGColor;
     CGColorSpaceModel csModel = CGColorSpaceGetModel(CGColorGetColorSpace(colorRef));
     if (csModel == kCGColorSpaceModelRGB)
     {
-		    CGFloat r, g, b, a;
+	CGFloat r, g, b, a;
         [color getRed:&r green:&g blue:&b alpha:&a];
-				_r = r, _g = g, _b = b, _a = a;
+	_r = r, _g = g, _b = b, _a = a;
     }
     else if (csModel == kCGColorSpaceModelMonochrome)
     {


### PR DESCRIPTION
CCColor initWithUIColor was using self.GCColor to work out the color space to use rather than the passed in color. Self at this point is un-initialised so wouldn't be giving good information and since change addb32507676c47cfc1624d66ec44893c9d16cbd it breaks the further use of CGColor on the object as that will have been lazy allocated, probably to pure transparent black - 0/0/0/0.

Previous to that commit this method would have caused a leak of a CGColor object.
