### PR TITLE
Simplifying color setup

### DIFF
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -880,15 +880,9 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
     }
     
     // Handle font color
-    
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
-    const CGFloat components[] = {_fontColor.red, _fontColor.green, _fontColor.blue, _fontColor.alpha};
-    CGColorRef color = CGColorCreate(colorspace, components);
-    CGColorSpaceRelease(colorspace);
-
+    CGColorRef color = _fontColor.CGColor;
     CGContextSetFillColorWithColor(context, color);
     CGContextSetStrokeColorWithColor(context, color);
-    CGColorRelease(color);
 
     [self drawString:string withFont:font inContext:context inRect:drawArea];
 


### PR DESCRIPTION
Use the _fontColor object's CGColor property to setup the context rather than making a new CGColor object and then deleting it. NSMutableAttributedStringFixPlatformSpecificAttributes will also use the _fontColor CGColor so this change doesn't create an object that wasn't going to be created anyway, and we get some reuse.
