### PR TITLE
Added new property colorRGBAAsGLkVector4 to CCNode

### DIFF
--- a/cocos2d/CCDirector.m
+++ b/cocos2d/CCDirector.m
@@ -251,7 +251,7 @@ static CCDirector *_sharedDirector = nil;
 		[renderer prepareWithProjection:&projection framebuffer:_framebuffer];
 		[CCRenderer bindRenderer:renderer];
 		
-		[renderer enqueueClear:(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT) color:_runningScene.colorRGBA.glkVector4 depth:1.0f stencil:0 globalSortOrder:NSIntegerMin];
+		[renderer enqueueClear:(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT) color:_runningScene.colorRGBAAsGLkVector4 depth:1.0f stencil:0 globalSortOrder:NSIntegerMin];
 		
 		// Render
 		[_runningScene visit:renderer parentTransform:&projection];

--- a/cocos2d/CCNode.h
+++ b/cocos2d/CCNode.h
@@ -974,6 +974,13 @@
 */
 @property (nonatomic,strong) CCColor* colorRGBA;
 
+/** Returns a GLKVector4 structure built using the nodes colorRGBA property.  This can be used to circumvent the creation of throwaway CCColor objects.
+ 
+ @see colorRGBA
+ @see CCColor
+*/
+@property (nonatomic,readonly) GLKVector4 colorRGBAAsGLkVector4;
+
 /** Returns the actual color used by the node. This may be different from the color and colorRGBA properties if the parent
  node has cascadeColorEnabled.
 

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -1697,6 +1697,10 @@ CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
 	[self cascadeOpacityIfNeeded];
 }
 
+-(GLKVector4) colorRGBAAsGLkVector4
+{
+    return GLKVector4Make(_color.r, _color.g, _color.b, _color.a);
+}
 
 - (void) cascadeColorIfNeeded
 {

--- a/cocos2d/CCTransition.m
+++ b/cocos2d/CCTransition.m
@@ -273,7 +273,7 @@ typedef NS_ENUM(NSInteger, CCTransitionFixedFunction)
 
 - (void)renderOutgoing:(float)progress
 {
-    GLKVector4 c = _outgoingScene.colorRGBA.glkVector4;
+    GLKVector4 c = _outgoingScene.colorRGBAAsGLkVector4;
     [_outgoingTexture beginWithClear:c.r g:c.g b:c.b a:c.a depth:1.0 stencil:0];
     [_outgoingScene visit];
     [_outgoingTexture end];
@@ -281,7 +281,7 @@ typedef NS_ENUM(NSInteger, CCTransitionFixedFunction)
 
 - (void)renderIncoming:(float)progress
 {
-    GLKVector4 c = _outgoingScene.colorRGBA.glkVector4;
+    GLKVector4 c = _outgoingScene.colorRGBAAsGLkVector4;
     [_incomingTexture beginWithClear:c.r g:c.g b:c.b a:c.a depth:1.0 stencil:0];
 	    [_incomingScene visit];
     [_incomingTexture end];

--- a/cocos2d/Support/CCColor.h
+++ b/cocos2d/Support/CCColor.h
@@ -285,7 +285,10 @@
 /// @name Converting Colors
 /// -----------------------------------------------------------------------
 
-/** The Quartz color reference that corresponds to the CCColor color. */
+/** The Quartz color reference that corresponds to the CCColor color.
+ @note Calling this method causes the creation of a CGColor that will not be released until the
+ parent CCColor object is released.
+ */
 @property(nonatomic, readonly) CGColorRef CGColor;
 
 #if __CC_PLATFORM_IOS

--- a/cocos2d/Support/CCColor.m
+++ b/cocos2d/Support/CCColor.m
@@ -15,7 +15,8 @@
 
 - (void)dealloc
 {
-    CGColorRelease(_color);
+    // Ensure that the cached CGColor object (if any) is released.
+    [self releaseCGColor];
 }
 
 + (CCColor*) colorWithWhite:(float)white alpha:(float)alpha
@@ -59,6 +60,9 @@
     _g = white;
     _b = white;
     _a = alpha;
+    
+    // Ensure that the cached CGColor object (if any) is released.
+    [self releaseCGColor];
     
     return self;
 }
@@ -116,6 +120,9 @@
     _b = blue;
     _a = alpha;
     
+    // Ensure that the cached CGColor object (if any) is released.
+    [self releaseCGColor];
+    
     return self;
 }
 
@@ -128,6 +135,9 @@
     _g = green;
     _b = blue;
     _a = 1;
+    
+    // Ensure that the cached CGColor object (if any) is released.
+    [self releaseCGColor];
     
     return self;
 }
@@ -143,6 +153,9 @@
     _g = (float) components[1];
     _b = (float) components[2];
     _a = (float) components[3];
+    
+    // Ensure that the cached CGColor object (if any) is released.
+    [self releaseCGColor];
     
     return self;
 }
@@ -171,13 +184,31 @@
     {
         NSAssert(NO, @"UIColor has unsupported color space model");
     }
+
+    // Ensure that the cached CGColor object (if any) is released.
+    [self releaseCGColor];
     
     return self;
 }
 #endif
 
+/**
+ Releases the CGColor field, if it exists.  This method exists so that there is a controlled,
+ specific method for releasing the object.  It should be called on dealloc(), and whenever any of the
+ components of the color are changed.
+ */
+- (void) releaseCGColor {
+    if (_color != NULL) {
+        CGColorRelease(_color);
+        _color = NULL;
+    }
+}
+
 - (CGColorRef) CGColor
 {
+    // Only create the result if it doesn't already exist.  It should not be possible for the components of
+    // the color represented by self to change without affecting CGColor.
+    //
     if (_color == NULL)
     {
         CGFloat components[4] = {(CGFloat)_r, (CGFloat)_g, (CGFloat)_b, (CGFloat)_a};


### PR DESCRIPTION
Whilst chasing a memory leak in CCColor, I found that there is a ridiculous number of CCColor objects being created that simply aren't needed.  They are only created to serve the purpose of creating a GLKVector4 structure.

By adding the code in this commit, all of those allocations and garbage collections are no longer needed.
