### PR TITLE
Reducing Logging verbosity

### DIFF
--- a/cocos2d/Support/NSThread+performBlock.m
+++ b/cocos2d/Support/NSThread+performBlock.m
@@ -25,7 +25,7 @@ typedef void (^BlockWithParam)(id param);
 @implementation CCObjectWith2Params
 @synthesize block, param;
 - (void)dealloc {
-	CCLOG(@"cocos2d: deallocing %@", self);
+	CCLOGINFO(@"cocos2d: deallocing %@", self);
 
 }
 @end


### PR DESCRIPTION
Dropping the dealloc LOG line down to the same verbosity level as others in the library.
