### PR TITLE
Fix xcode 7 crash fix when using CCDrawNode

### DIFF
--- a/cocos2d/CCDrawNode.m
+++ b/cocos2d/CCDrawNode.m
@@ -53,10 +53,6 @@ static NSString *CCDrawNodeFragmentShaderSource =
     @"}\n";
 #else
 static NSString *CCDrawNodeFragmentShaderSource =
-	@"#ifdef GL_ES\n"
-	@"#extension GL_OES_standard_derivatives : enable\n"
-	@"#endif\n"
-	@"\n"
 	@"void main(){\n"
 	@"	gl_FragColor = cc_FragColor*smoothstep(0.0, length(fwidth(cc_FragTexCoord1)), 1.0 - length(cc_FragTexCoord1));\n"
 	@"}\n";

--- a/cocos2d/CCShader.m
+++ b/cocos2d/CCShader.m
@@ -62,6 +62,11 @@ NSString * const CCShaderUniformAlphaTestValue = @"cc_AlphaTestValue";
 // These are the lines loaded for both vertex and fragment shaders
 
 static NSString *CCShaderHeader =
+    @"#ifdef GL_ES\n"
+    @"#ifdef GL_OES_standard_derivatives\n"
+    @"#extension GL_OES_standard_derivatives : enable\n"
+    @"#endif\n"
+    @"#endif\n"
 	@"#ifndef GL_ES\n"
 	@"#define lowp\n"
 	@"#define mediump\n"


### PR DESCRIPTION
To reproduce the crash in Xcode 7 create an empty project with SpriteBuilder and add a CCDrawNode
