### PR TITLE
Fix loading files from full paths

### DIFF
--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -471,7 +471,7 @@ static CCFileUtils *fileUtils = nil;
 
 -(NSString*) fullPathForFilename:(NSString*)filename
 {
-	return [self fullPathForFilename:filename contentScale:NULL];
+	return [self fullPathForFilenameIgnoringResolutions:filename];
 }
 
 -(NSString*) fullPathForFilename:(NSString*)filename contentScale:(CGFloat *)contentScale

--- a/cocos2d/Support/CCFileUtils.m
+++ b/cocos2d/Support/CCFileUtils.m
@@ -480,12 +480,10 @@ static CCFileUtils *fileUtils = nil;
 	if(!contentScale) contentScale = &_contentScale;
 	
 	// fullpath? return it
-//	if ([filename isAbsolutePath]) {
-//		CCLOGWARN(@"cocos2d: WARNING fullPathForFilename:resolutionType: should not be called with absolute path. Instead call fullPathForFilenameIgnoringResolutions:");
-//		*contentScale = 1.0;
-//		NSLog(@"filename:%@, fullPath:%@, contentScale:%f", filename, filename, *contentScale);
-//		return filename;
-//	}
+	if ([filename isAbsolutePath]) {
+		CCLOGWARN(@"cocos2d: WARNING fullPathForFilename:resolutionType: should not be called with absolute path. Instead call fullPathForFilenameIgnoringResolutions:");
+        return filename;
+	}
 
 	// Already Cached ?
 	CCCacheValue *value = [_fullPathCache objectForKey:filename];


### PR DESCRIPTION
Support for loading files from full paths was partially broken due to some commented-out code. This introduces a fix and calls the proper method suggested by some comments in said code.
