### PR TITLE
Some tweaks to the cocos2d code:

### DIFF
--- a/cocos2d/CCActionEase.m
+++ b/cocos2d/CCActionEase.m
@@ -176,7 +176,7 @@
 @implementation CCActionEaseOut
 -(void) update: (CCTime) t
 {
-	[_inner update: powf(t,1/_rate)];
+    [_inner update: 1.0f - powf(1.0f - t, _rate)];
 }
 @end
 

--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -336,7 +336,8 @@
 	{
 		while (dt > _nextDt && _total < _times)
 		{
-			[_innerAction update:1.0];
+
+			[_innerAction update:1.0f];
 			_total++;
 
 			[_innerAction stop];
@@ -345,7 +346,7 @@
 		}
 		
 		// fix for issue #1288, incorrect end value of repeat
-		if(dt >= 1.0 && _total < _times) 
+		if(dt >= 1.0f && _total < _times) 
 		{
 			_total++;
 		}
@@ -367,7 +368,7 @@
 	}
 	else
 	{
-		[_innerAction update:fmod(dt * _times, 1.0)];
+		[_innerAction update:fmodf(dt * _times,1.0f)];
 	}
 }
 

--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -156,7 +156,8 @@ static __strong NSMutableDictionary* ccLabelTTF_registeredFonts;
 {
     NSAssert(attributedString, @"Invalid attributedString");
     
-    if ( _attributedString.hash != attributedString.hash)
+    if ( ![_attributedString isEqualToAttributedString: attributedString])
+//    if ( _attributedString.hash != attributedString.hash)
     {
         _attributedString = [attributedString copy];
         

--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -397,11 +397,20 @@ TransformPointAsVector(CGPoint p, CGAffineTransform t)
     // Update the children (if needed)
     for (CCNode* child in _children)
     {
-        if (!CCPositionTypeIsBasicPoints(child->_positionType))
+        [child parentsContentSizeChanged];
+    }
+    
+}
+
+- (void) parentsContentSizeChanged
         {
-            // This is a position type affected by content size
-            child->_isTransformDirty = _isInverseDirty = YES;
+    if (!CCSizeTypeIsBasicPoints(_contentSizeType))
+    {
+        [self contentSizeChanged];
         }
+    else if (!CCPositionTypeIsBasicPoints(_positionType))
+    {
+        _isTransformDirty = _isInverseDirty = YES;
     }
 }
 

--- a/cocos2d/CCNode_Private.h
+++ b/cocos2d/CCNode_Private.h
@@ -108,5 +108,6 @@ CGAffineTransform CGAffineTransformMakeRigid(CGPoint translate, CGFloat radians)
 -(void) detachChild:(CCNode *)child cleanup:(BOOL)doCleanup;
 
 - (void) contentSizeChanged;
+- (void) parentsContentSizeChanged;
 
 @end

--- a/cocos2d/CCRendererBasicTypes.h
+++ b/cocos2d/CCRendererBasicTypes.h
@@ -129,6 +129,14 @@ extern NSString * const CCBlendEquationAlpha;
 +(CCBlendMode *)addMode;
 /// Multiply blending mode. (Similar to PhotoShop's burn mode)
 +(CCBlendMode *)multiplyMode;
+/// A (better) multiply blending mode.
++(CCBlendMode *)multiplicativeMode;
+/// A (better) add mode.
++(CCBlendMode *)addWithAlphaMode;
+/// Similar to PhotoShop's screen mode.
++(CCBlendMode *)screenMode;
+/// Similar to PhotoShop's dodge mode.
++(CCBlendMode *)dodgeMode;
 
 @end
 

--- a/cocos2d/CCRendererBasicTypes.m
+++ b/cocos2d/CCRendererBasicTypes.m
@@ -128,6 +128,11 @@ static CCBlendMode *CCBLEND_PREMULTIPLIED_ALPHA = nil;
 static CCBlendMode *CCBLEND_ADD = nil;
 static CCBlendMode *CCBLEND_MULTIPLY = nil;
 
+static CCBlendMode *CCBLEND_ADD_WITH_ALPHA = nil;
+static CCBlendMode *CCBLEND_SCREEN = nil;
+static CCBlendMode *CCBLEND_MULTIPLICATIVE = nil;
+static CCBlendMode *CCBLEND_DODGE = nil;
+
 NSDictionary *CCBLEND_DISABLED_OPTIONS = nil;
 
 +(void)initialize
@@ -160,6 +165,26 @@ NSDictionary *CCBLEND_DISABLED_OPTIONS = nil;
 		CCBlendFuncSrcColor: @(GL_DST_COLOR),
 		CCBlendFuncDstColor: @(GL_ZERO),
 	}];
+    
+    CCBLEND_ADD_WITH_ALPHA = [self blendModeWithOptions:@{
+        CCBlendFuncSrcColor: @(GL_SRC_ALPHA),
+        CCBlendFuncDstColor: @(GL_ZERO),
+    }];
+    
+    CCBLEND_SCREEN = [self blendModeWithOptions:@{
+        CCBlendFuncSrcColor: @(GL_ONE_MINUS_DST_COLOR),
+        CCBlendFuncDstColor: @(GL_ONE),
+    }];
+    
+    CCBLEND_MULTIPLICATIVE = [self blendModeWithOptions:@{
+        CCBlendFuncSrcColor: @(GL_DST_COLOR),
+        CCBlendFuncDstColor: @(GL_ONE_MINUS_SRC_ALPHA),
+    }];
+    
+    CCBLEND_DODGE = [self blendModeWithOptions:@{
+        CCBlendFuncSrcColor: @(GL_ONE_MINUS_SRC_ALPHA),
+        CCBlendFuncDstColor: @(GL_ONE),
+    }];
 }
 
 +(void)flushCache
@@ -195,6 +220,26 @@ NSDictionary *CCBLEND_DISABLED_OPTIONS = nil;
 +(CCBlendMode *)multiplyMode
 {
 	return CCBLEND_MULTIPLY;
+}
+
++(CCBlendMode *)multiplicativeMode
+{
+    return CCBLEND_MULTIPLICATIVE;
+}
+
++(CCBlendMode *)addWithAlphaMode
+{
+    return CCBLEND_ADD_WITH_ALPHA;
+}
+
++(CCBlendMode *)screenMode
+{
+    return CCBLEND_SCREEN;
+}
+
++(CCBlendMode *)dodgeMode
+{
+    return CCBLEND_DODGE;
 }
 
 @end

--- a/cocos2d/Support/NSAttributedString+CCAdditions.m
+++ b/cocos2d/Support/NSAttributedString+CCAdditions.m
@@ -261,12 +261,12 @@ BOOL NSMutableAttributedStringFixPlatformSpecificAttributes(NSMutableAttributedS
         [string addAttribute:(id)kCTForegroundColorFromContextAttributeName value:(__bridge id)color range:fullRange];
         CGColorRelease(color);
     }
-    if (NSAttributedStringHasAttribute(string, NSFontAttributeName)) {
-        id font = [string attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
-        CTFontRef ctFont = CTFontCreateWithPlatformSpecificFont(font);
-        [string addAttribute:(id)kCTFontAttributeName value:(__bridge id)ctFont range:fullRange];
-        CFRelease(ctFont);
-    }
+//    if (NSAttributedStringHasAttribute(string, NSFontAttributeName)) {
+//        id font = [string attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
+//        CTFontRef ctFont = CTFontCreateWithPlatformSpecificFont(font);
+//        [string addAttribute:(id)kCTFontAttributeName value:(__bridge id)ctFont range:fullRange];
+//        CFRelease(ctFont);
+//    }
     
     // Shadow
     if (NSAttributedStringHasAttribute(string, NSShadowAttributeName))
@@ -330,7 +330,7 @@ BOOL NSMutableAttributedStringFixPlatformSpecificAttributes(NSMutableAttributedS
     // Font
     CTFontRef font = CTFontCreateWithName((__bridge CFStringRef)defaultFontName, defaultFontSize, NULL);
     if (font == NULL) font = CTFontCreateWithName(CFSTR("Helvetica"), defaultFontSize, NULL);
-    [string addAttribute:(NSString *)kCTFontAttributeName value:(__bridge id)font range:fullRange];
+//    [string addAttribute:(NSString *)kCTFontAttributeName value:(__bridge id)font range:fullRange];
     NSMutableAttributedStringSetDefaultAttribute(string, (NSString *)kCTFontAttributeName, (__bridge id)font);
     CFRelease(font);
     return useFullColor;


### PR DESCRIPTION
These are some changes in my project clone of cocos2d 3.4.9.  It's my first step towards formalising my tvOS branch of 3.x.  I want to sync the official 3.4.9 into my app project but I wanted to preserve these changes first.  Once this is in, and I've got my app in sync with 3.4.9 I'll start adding support for tvOS like I've done for v2.2 - classic
1. CCActionEaseOut wasn't easing very well.
2. Fixed a few basic compiler warnings.
3. Use [NSAttributedString isEqualToAttributedString:] for comparison.
4. Added enhancement to CCNode so that when a nodes content size is changed, it's children are updated as well which is essential when using normalised coordinates/sizes in children.
5. Added some more photoshop blend modes.
6. Patched NSAttributedString+CCAdditions.m to prevent font overrides when we don't want them.
