### PR TITLE
Assert recognizers not already added

### DIFF
--- a/cocos2d-ui/CCScrollView.m
+++ b/cocos2d-ui/CCScrollView.m
@@ -763,6 +763,8 @@
 
 - (void) onEnterTransitionDidFinish
 {
+    NSAssert(_panRecognizer.view == nil && _tapRecognizer.view == nil, @"CCScrollView: Probable double call into onEnterTransitionDidFinish - gesture recognizers are already added");
+
     // Add recognizers to view
     UIView* view = [CCDirector sharedDirector].view;
     


### PR DESCRIPTION
From iOS9 adding a gesture recognizer that is already associated with a view is an error and no longer associates it with the second view - it leaves it on the first.

See http://forum.cocos2d-objc.org/t/onenter-call-order-issue/17718/1 for circumstances in which this can (relatively easily) happen due to user code.

Assert prevents the problem and indicates a possible path to look at to fix it.
