### PR TITLE
Fixed CCTextField textField property always being nil on mac.

### DIFF
--- a/cocos2d-ui/Platform/Mac/CCPlatformTextFieldMac.m
+++ b/cocos2d-ui/Platform/Mac/CCPlatformTextFieldMac.m
@@ -58,6 +58,11 @@
     return YES;
 }
 
+- (id)nativeTextField
+{
+    return _textField;
+}
+
 - (void)setFontSize:(float)fontSize {
     NSFont* font = _textField.font;
     _textField.font = [NSFont fontWithName:font.fontName size:fontSize];


### PR DESCRIPTION
Fixes issue #1122 when building for OSX.
