### PR TITLE
Fixes issue where CCTextField.hidden doesn't hide NSTextField on OSX

### DIFF
--- a/cocos2d-ui/Platform/Mac/CCPlatformTextFieldMac.m
+++ b/cocos2d-ui/Platform/Mac/CCPlatformTextFieldMac.m
@@ -101,6 +101,14 @@
 {
     return _textField.stringValue;
 }
+
+- (BOOL)hidden {
+    return _textField.hidden;
+}
+
+- (void) setHidden:(BOOL)hidden {
+    _textField.hidden = hidden;
+}
 @end
 
 #endif


### PR DESCRIPTION
This addresses the issue where if you hide a CCTextField the corresponding NSTextField will remain on screen until the CCTextField is deallocated.